### PR TITLE
pull base requirements.txt file as dev dependency.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ correct libraries are installed:
 
     pip install --requirement requirements.txt
 
-To install additional dependencies necessary for development, also run ``pip`` as below:
+To install additional dependencies necessary for development, replace the named requirements file:
 
 .. code:: bash
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
--r requirements.txt
+--requirement requirements.txt
 
 alabaster==0.7.12         # via sphinx
 beautifulsoup4==4.7.1     # via webtest

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+
 alabaster==0.7.12         # via sphinx
 beautifulsoup4==4.7.1     # via webtest
 docutils==0.14            # via sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ skip_missing_interpreters = True
 [testenv]
 description = Default testing environment, run unit test suite
 deps =
-    --requirement=requirements.txt
     --requirement=requirements.dev.txt
     pytest-cov
 passenv =


### PR DESCRIPTION
Noticed this trick in another example.  Should mean any devs keeping their local builds up via `pip` are down to a single step: `pip install -r requirements.dev.txt` 