### PR TITLE
TN-703 replace content UUID for day of reminder on 3 month QB.

### DIFF
--- a/portal/config/eproms/CommunicationRequest.json
+++ b/portal/config/eproms/CommunicationRequest.json
@@ -614,7 +614,7 @@
           "value": "IRONMAN Recurring | 6 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 0,
       "questionnaire_bank": {
@@ -631,7 +631,7 @@
           "value": "IRONMAN v3 Recurring | 6 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 0,
       "questionnaire_bank": {
@@ -784,7 +784,7 @@
           "value": "IRONMAN Recurring | 9 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 1,
       "questionnaire_bank": {
@@ -801,7 +801,7 @@
           "value": "IRONMAN v3 Recurring | 9 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 1,
       "questionnaire_bank": {
@@ -954,7 +954,7 @@
           "value": "IRONMAN Recurring | 12 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 0,
       "questionnaire_bank": {
@@ -971,7 +971,7 @@
           "value": "IRONMAN v3 Recurring | 12 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 0,
       "questionnaire_bank": {
@@ -1124,7 +1124,7 @@
           "value": "IRONMAN Recurring | 15 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 2,
       "questionnaire_bank": {
@@ -1141,7 +1141,7 @@
           "value": "IRONMAN v3 Recurring | 15 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 2,
       "questionnaire_bank": {
@@ -1294,7 +1294,7 @@
           "value": "IRONMAN Recurring | 18 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 1,
       "questionnaire_bank": {
@@ -1311,7 +1311,7 @@
           "value": "IRONMAN v3 Recurring | 18 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 1,
       "questionnaire_bank": {
@@ -1464,7 +1464,7 @@
           "value": "IRONMAN Recurring | 21 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 3,
       "questionnaire_bank": {
@@ -1481,7 +1481,7 @@
           "value": "IRONMAN v3 Recurring | 21 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 3,
       "questionnaire_bank": {
@@ -1634,7 +1634,7 @@
           "value": "IRONMAN Recurring | 24 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 1,
       "questionnaire_bank": {
@@ -1651,7 +1651,7 @@
           "value": "IRONMAN v3 Recurring | 24 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 1,
       "questionnaire_bank": {
@@ -1804,7 +1804,7 @@
           "value": "IRONMAN Recurring | 30 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 2,
       "questionnaire_bank": {
@@ -1821,7 +1821,7 @@
           "value": "IRONMAN v3 Recurring | 30 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 2,
       "questionnaire_bank": {
@@ -1974,7 +1974,7 @@
           "value": "IRONMAN Recurring | 36 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 2,
       "questionnaire_bank": {
@@ -1991,7 +1991,7 @@
           "value": "IRONMAN v3 Recurring | 36 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 2,
       "questionnaire_bank": {

--- a/portal/config/eproms/CommunicationRequest.json
+++ b/portal/config/eproms/CommunicationRequest.json
@@ -444,7 +444,7 @@
           "value": "IRONMAN Recurring | 3 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 0,
       "questionnaire_bank": {
@@ -461,7 +461,7 @@
           "value": "IRONMAN v3 Recurring | 3 Month Reminder (3)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 2}",
       "qb_iteration": 0,
       "questionnaire_bank": {


### PR DESCRIPTION
This replaces just the 3 month 3rd reminder (day of) for rp2 and rp3.  Open questions in https://jira.movember.com/browse/TN-703 should this be expanded to other cycles.