### PR TITLE
Update source code repository URL to current value.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Clone the Project
 
 .. code:: bash
 
-    $ git clone https://github.com/uwcirg/true_nth_usa_portal.git $PROJECT_HOME
+    $ git clone https://github.com/uwcirg/truenth-portal.git $PROJECT_HOME
 
 Create a Virtual Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -352,7 +352,7 @@ This project includes integration with the `TravisCI continuous
 integration
 platform <https://docs.travis-ci.com/user/languages/python/>`__. The
 full test suite (every Tox virtual environment) is `automatically
-run <https://travis-ci.org/uwcirg/true_nth_usa_portal>`__ for the last
+run <https://travis-ci.org/uwcirg/truenth-portal>`__ for the last
 commit pushed to any branch, and for all pull requests. Results are
 reported as passing with a ✔ and failing with a ✖.
 

--- a/app.json
+++ b/app.json
@@ -2,9 +2,9 @@
   "name": "TrueNTH USA Portal",
   "description": "Movember TrueNTH USA Shared Services",
   "keywords": ["CIRG","fhir"],
-  "website": "https://github.com/uwcirg/true_nth_usa_portal",
-  "repository": "https://github.com/uwcirg/true_nth_usa_portal",
-  "logo": "https://github.com/uwcirg/true_nth_usa_portal/raw/develop/portal/static/img/logo.png",
+  "website": "https://github.com/uwcirg/truenth-portal",
+  "repository": "https://github.com/uwcirg/truenth-portal",
+  "logo": "https://github.com/uwcirg/truenth-portal/raw/develop/portal/static/img/logo.png",
   "success_url": "/about",
   "env": {
     "SERVER_NAME": {

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -3,7 +3,7 @@ FROM debian:stretch
 ENV \
     ARTIFACT_DIR=/tmp/artifacts \
     DEBIAN_FRONTEND=noninteractive \
-    GIT_REPO=https://github.com/uwcirg/true_nth_usa_portal
+    GIT_REPO=https://github.com/uwcirg/truenth-portal
 
 RUN \
     apt-get update --quiet && \

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -19,7 +19,7 @@ To initialize on a debian system, install the git-flow package::
 
 Return to the root of your TrueNTH Shared Services checkout and initialize::
 
-    cd ~/true_nth_usa_portal
+    cd ~/truenth-portal
     git-flow init
 
 You should be able to accept all the defaults (caveat: in some cases "Branch name for production releases: []" won't have a default; in that case, use "master").  The results are written to the nested `.git/config` file, such as::
@@ -54,7 +54,7 @@ Pull Request
 ============
 
 To bring the feature into the main develop branch, head over to
-`github <https://github.com/uwcirg/true_nth_usa_portal>`_ and trigger
+`github <https://github.com/uwcirg/truenth-portal>`_ and trigger
 a **pull request**.
 
 Rebase

--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -61,7 +61,7 @@ To build a Debian package from the current branch of your local repo::
 If you would like to create a package from a remote repository you can override the local repo as follows below::
 
     # Override default with environment variable
-    export GIT_REPO='https://github.com/USERNAME/true_nth_usa_portal'
+    export GIT_REPO='https://github.com/USERNAME/truenth-portal'
 
     # Build the package from the above repo
     docker-compose -f docker-compose.build.yaml run builder

--- a/portal/eproms/templates/eproms/about.html
+++ b/portal/eproms/templates/eproms/about.html
@@ -9,7 +9,7 @@
   {% if config.metadata.version %}
   <br />
     {% if config.metadata.git_hash %}
-    <div class="pull-right text-muted smaller-text">TrueNTH Version: <a target="_blank" href="https://github.com/uwcirg/true_nth_usa_portal/commit/{{ config.metadata.git_hash }}" >{{ config.metadata.version }}</a></div>
+    <div class="pull-right text-muted smaller-text">TrueNTH Version: <a target="_blank" href="https://github.com/uwcirg/truenth-portal/commit/{{ config.metadata.git_hash }}" >{{ config.metadata.version }}</a></div>
     {% else %}
     <div class="pull-right text-muted smaller-text">TrueNTH Version: {{ config.metadata.version }}</div>
     {% endif %}

--- a/portal/gil/templates/gil/base.html
+++ b/portal/gil/templates/gil/base.html
@@ -154,7 +154,7 @@
   {% block version %}
     {% if config.metadata.version %}
       {% if config.metadata.git_hash %}
-        <div id="repoVersion" class="pull-right text-muted">{{_("TrueNTH Version")}}: <a target="_blank" href="https://github.com/uwcirg/true_nth_usa_portal/commit/{{ config.metadata.git_hash }}" >{{ config.metadata.version }}</a></div>
+        <div id="repoVersion" class="pull-right text-muted">{{_("TrueNTH Version")}}: <a target="_blank" href="https://github.com/uwcirg/truenth-portal/commit/{{ config.metadata.git_hash }}" >{{ config.metadata.version }}</a></div>
       {% else %}
         <div id="repoVersion" class="pull-right text-muted">{{_("TrueNTH Version")}}: {{ config.metadata.version }}</div>
       {% endif %}

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@
 name = portal
 description = TrueNTH Shared Services
 long_description = TrueNTH Shared Services RESTful API, to be used by TrueNTH intervention applications. This API attempts to conform with the HL7 FHIR specification as much as is reasonable.
-url = https://github.com/uwcirg/true_nth_usa_portal
+url = https://github.com/uwcirg/truenth-portal
 author = CIRG, University of Washington
 author_email = truenth-dev@uw.edu
 maintainer = CIRG, University of Washington


### PR DESCRIPTION
@ivan-c this should be all obsolete references *except* those I see in `portal/translations`.  I didn't update those, assuming that's a symptom - how is the repo string landing within?