### PR TITLE
Revert billiard update to version actually installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ alembic==1.0.8            # via flask-migrate
 amqp==2.4.2               # via kombu
 babel==2.6.0              # via flask-babel, sphinx
 bcrypt==3.1.6             # via flask-user
-billiard==3.6.0.0         # via celery
+billiard==3.5.0.5         # via celery
 blinker==1.4              # via flask-mail, flask-webtest
 celery==4.2.1
 certifi==2018.11.29        # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ alembic==1.0.8            # via flask-migrate
 amqp==2.4.2               # via kombu
 babel==2.6.0              # via flask-babel, sphinx
 bcrypt==3.1.6             # via flask-user
-billiard==3.5.0.5         # via celery
+billiard==3.5.0.5         # pyup: < 3.6.0  # pin until celery upgraded # via celery
 blinker==1.4              # via flask-mail, flask-webtest
 celery==4.2.1
 certifi==2018.11.29        # via requests


### PR DESCRIPTION
* Revert billiard version to match one installed by celery

Currently `billiard` version `3.6.0` is listed in [`requirements.txt`](https://github.com/uwcirg/truenth-portal/blob/v19.2.25/requirements.txt#L14), but `celery` (installed from [`setup.cfg` abstract requirements](https://github.com/uwcirg/truenth-portal/blob/develop/setup.cfg#L42)) requires `billiard` be at least `3.5.0.5` ([see build log](https://travis-ci.org/uwcirg/truenth-portal/jobs/500511926#L1557))