### PR TITLE
Add docker-compose development overrides

### DIFF
--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -1,12 +1,19 @@
 # docker-compose development overrides
+# mount code checkout into container and use development server for auto-reloading
 ---
 version: "3.4"
 services:
   web:
     environment:
       FLASK_DEBUG: 1
+      FLASK_APP: /mnt/code/manage.py
     command: sh -c '
      flask run
         --port ${PORT}
         --host 0.0.0.0
      '
+    volumes:
+      - source: ../
+        target: /mnt/code
+        type: bind
+        read_only: true

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -1,0 +1,12 @@
+# docker-compose development overrides
+---
+version: "3.4"
+services:
+  web:
+    environment:
+      FLASK_DEBUG: 1
+    command: sh -c '
+     flask run
+        --port ${PORT}
+        --host 0.0.0.0
+     '

--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -124,6 +124,20 @@ To bootstrap an admin account after a fresh install, run the below ``flask`` CLI
 Advanced Configuration
 ======================
 
+Development
+-----------
+If you would like to use docker to work on the portal, you can configure ``docker-compose`` to use the development overrides as follows::
+
+    # Set COMPOSE_FILE in the current shell
+    export COMPOSE_FILE=docker-compose.yaml:docker-compose.dev.yaml
+    # or add to .env to preserve the change between shell sessions
+
+    docker-compose up web
+
+This will mount your checkout into a docker container and use the flask development server instead of the production default (gunicorn).
+
+Environment Variables
+---------------------
 Environment variables defined in the ``portal.env`` environment file are only passed to the underlying containers. However, some environment variables are used for configuration specific to docker-compose.
 
 An


### PR DESCRIPTION
* Add `docker-compose.dev.yaml` (Add to `COMPOSE_FILE` (in `.env` ) to enable)
  * Use flask dev server, enable debugging
  * Mount git checkout into container as volume to allow auto-reloading development
* Add docs
