### PR TITLE
TN-1945 Psa Tracker Graph bug fixes

### DIFF
--- a/portal/static/js/src/components/PsaTracker.vue
+++ b/portal/static/js/src/components/PsaTracker.vue
@@ -455,7 +455,7 @@
                 this.postData();
             },
             checkTreatmentCoreData: function() {
-                tnthAjax.getConfigurationByKey("REQUIRED_CORE_DATA",false, function(data) {
+                tnthAjax.getConfigurationByKey("REQUIRED_CORE_DATA", false, function(data) {
                     if (!data || !data.REQUIRED_CORE_DATA) {
                         return;
                     }

--- a/portal/static/less/psaTracker.less
+++ b/portal/static/less/psaTracker.less
@@ -193,7 +193,7 @@ option.select-option {
             background-color:@contentColor;
             cursor: pointer;
         }
-        width: 70px;
+        width: 120px;
         padding: 4px;
         position: absolute;
         right: 1%;


### PR DESCRIPTION
https://jira.movember.com/browse/TN-1945
address the issue where data points were drawn beyond visual area.
changes include: 
- since the graph is drawn in log scale, need to account for value(s), e.g. < 0.1 that caused invalid log value  - in which case use the minimum allowable log value (0.1)
- grid line needs to be capped at maximum allowable range for PSA tracker values (10000) (otherwise seeing extra line drawn)
- allow edit of treatment date only if it is possible (the section is only shown in profile, where treatment is edited, in Truenth USA)
