### PR TITLE
TN-1931 Exclude test users from /reports

### DIFF
--- a/portal/migrations/versions/55469bdd181f_.py
+++ b/portal/migrations/versions/55469bdd181f_.py
@@ -14,7 +14,7 @@ from portal.models.questionnaire_bank import QuestionnaireBank, visit_name
 from portal.models.questionnaire_response import QuestionnaireResponse
 from portal.models.research_protocol import ResearchProtocol
 from portal.models.role import ROLE, Role
-from portal.models.user import User, UserRoles, active_patients
+from portal.models.user import User, UserRoles
 from portal.models.overall_status import OverallStatus
 
 # revision identifiers, used by Alembic.
@@ -61,6 +61,8 @@ def upgrade():
         return  # nothing to do on systems w/o RP changes
     fix_map = dict()
 
+    raise RuntimeError(
+        "Unsupported migration; code has changed - not maintained")
     for patient in active_patients(include_test_role=True).order_by(User.id):
         qnrs = QuestionnaireResponse.query.filter(
             QuestionnaireResponse.subject_id == patient.id).order_by(

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -945,7 +945,7 @@ def org_restriction_by_role(user, requested_orgs):
 
     :param requested_orgs: List of organization IDs the user has selected
         for inclusion in filtering, may be None.  If defined, the return
-        list will be the intersection of the pref_org_list and the list of
+        list will be the intersection of the requested_orgs and the list of
         organizations the user's role gives them the right to view.
 
     :returns: None if no org restrictions apply, or a list of org_ids

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -15,6 +15,7 @@ from ..system_uri import TRUENTH_EXTERNAL_STUDY_SYSTEM
 from .fhir import bundle_results
 from .organization import OrgTree
 from .reference import Reference
+from .user import active_patients
 
 
 class QuestionnaireResponse(db.Model):
@@ -215,7 +216,9 @@ def aggregate_responses(instrument_ids, current_user, patch_dstu2=False):
     from .qb_timeline import qb_status_visit_name  # avoid cycle
 
     # Gather up the patient IDs for whom current user has 'view' permission
-    user_ids = OrgTree().visible_patients(current_user)
+    visible_orgs = OrgTree().visible_orgs(current_user)
+    user_ids = active_patients(
+        require_orgs=visible_orgs, include_test_role=False)
 
     annotated_questionnaire_responses = []
     questionnaire_responses = QuestionnaireResponse.query.filter(

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -13,9 +13,8 @@ from ..database import db
 from ..date_tools import FHIR_datetime
 from ..system_uri import TRUENTH_EXTERNAL_STUDY_SYSTEM
 from .fhir import bundle_results
-from .organization import OrgTree
 from .reference import Reference
-from .user import active_patients
+from .user import User, patients_query
 
 
 class QuestionnaireResponse(db.Model):
@@ -216,9 +215,8 @@ def aggregate_responses(instrument_ids, current_user, patch_dstu2=False):
     from .qb_timeline import qb_status_visit_name  # avoid cycle
 
     # Gather up the patient IDs for whom current user has 'view' permission
-    visible_orgs = OrgTree().visible_orgs(current_user)
-    user_ids = active_patients(
-        require_orgs=visible_orgs, include_test_role=False)
+    user_ids = patients_query(
+        current_user, include_test_role=False).with_entities(User.id)
 
     annotated_questionnaire_responses = []
     questionnaire_responses = QuestionnaireResponse.query.filter(

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -41,7 +41,7 @@ from .encounter import Encounter
 from .extension import CCExtension, TimezoneExtension
 from .fhir import bundle_results, v_or_first, v_or_n
 from .identifier import Identifier, UserIdentifier
-from .intervention import intervention_restrictions, UserIntervention
+from .intervention import UserIntervention, intervention_restrictions
 from .observation import Observation, UserObservation
 from .organization import (
     Organization,
@@ -1908,7 +1908,8 @@ def patients_query(
         consent_query = UserConsent.query.filter(and_(
             UserConsent.deleted_id.is_(None),
             UserConsent.expires > datetime.utcnow()))
-        consented_users = [u.user_id for u in consent_query if u.staff_editable]
+        consented_users = [
+            u.user_id for u in consent_query if u.staff_editable]
 
     if require_interventions:
         query = query.join(UserIntervention).filter(

--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -295,7 +295,7 @@ import CurrentUser from "./mixins/CurrentUser.js";
             initRoleBasedEvent: function() {
                 if (this.isAdminUser()) { /* turn on test account toggle checkbox if admin user */
                     $("#frmTestUsersContainer").removeClass("tnth-hide");
-                    $("#include_test_roles").on("click", function() {
+                    $("#include_test_role").on("click", function() {
                         $("#frmTestUsers").submit();
                     });
                 }

--- a/portal/templates/admin/admin_base.html
+++ b/portal/templates/admin/admin_base.html
@@ -44,7 +44,7 @@
 	<caption id="frmTestUsersContainer" class="tnth-hide">
 		<form id="frmTestUsers" method="GET" action="{{postUrl}}">
 			<label class="text-normal text-warning">
-				<input type="checkbox" name="include_test_roles" id="include_test_roles" value="True" {%if include_test_roles %}checked{% endif %}/>
+				<input type="checkbox" name="include_test_role" id="include_test_role" value="True" {%if include_test_role %}checked{% endif %}/>
 				{{_("include test accounts")}}
 			</label>
 		</form>

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -11,23 +11,19 @@ from flask import (
 )
 from flask_babel import gettext as _
 from flask_user import roles_required
-from sqlalchemy import and_
 
 from ..extensions import oauth
 from ..models.coding import Coding
-from ..models.intervention import Intervention, UserIntervention
-from ..models.organization import Organization, OrgTree
+from ..models.intervention import Intervention
+from ..models.organization import Organization
 from ..models.qb_timeline import qb_status_visit_name, QB_StatusCacheKey
 from ..models.role import ROLE
 from ..models.table_preference import TablePreference
 from ..models.user import (
-    User,
-    active_patients,
     current_user,
     get_user_or_abort,
+    patients_query,
 )
-from ..models.user_consent import UserConsent
-from ..type_tools import check_int
 
 patients = Blueprint('patients', __name__, url_prefix='/patients')
 
@@ -51,112 +47,31 @@ def patients_root():
     expected and will raise a 400: Bad Request
 
     """
-    broken_role_situation = (
-        "Patients list for staff and intervention-staff are mutually"
-        " exclusive - user shouldn't have both roles")
 
-    def org_restriction(user):
-        """Determine if user (prefs) restrict list of patients by org
+    def org_preference_filter(user):
+        """Obtain user's preference for filtering organizations
 
-        :returns: None if no org restrictions apply, or a list of org_ids
+        :returns: list of org IDs to use as filter, or None
 
         """
-        pref_org_list = None
         # check user table preference for organization filters
         pref = TablePreference.query.filter_by(
             table_name='patientList', user_id=user.id).first()
         if pref and pref.filters:
-            pref_org_list = pref.filters.get('orgs_filter_control')
+            return pref.filters.get('orgs_filter_control')
+        return None
 
-        if (user.has_role(ROLE.ADMIN.value) or
-                user.has_role(ROLE.INTERVENTION_STAFF.value)):
-            # admins and intervention_staff aren't generally restricted by
-            # organization - only apply a restriction if they've set a filter
-            return pref_org_list
-
-        org_list = set()
-        if user.has_role(ROLE.STAFF.value):
-            if user.has_role(ROLE.INTERVENTION_STAFF.value):
-                abort(400, broken_role_situation)
-
-            # Build list of all organization ids, and their descendants, the
-            # user belongs to
-            ot = OrgTree()
-
-            if pref_org_list:
-                # for preferred filtered orgs
-                pref_org_list = set(pref_org_list)
-                for orgId in pref_org_list:
-                    if orgId == 0:  # None of the above doesn't count
-                        continue
-                    for org in user.organizations:
-                        if orgId in ot.here_and_below_id(org.id):
-                            org_list.add(orgId)
-                            break
-            else:
-                for org in user.organizations:
-                    if org.id == 0:  # None of the above doesn't count
-                        continue
-                    org_list.update(ot.here_and_below_id(org.id))
-            return list(org_list)
-
-    def intervention_restrictions(user):
-        """returns tuple of lists for interventions: (disallow, require)
-
-        Users may not have access to some interventions (such as randomized
-        control trials).  In such a case, the first of the tuple items
-        will name intervention ids which should not be included.
-
-        Other users get access to all patients with one or more
-        interventions.  In this case, a list of interventions for which
-        the user should be granted access is in the second position.
-
-        """
-        if user.has_role(ROLE.ADMIN.value):
-            return None, None  # no restrictions
-
-        disallowed, required = None, None
-        if user.has_role(ROLE.STAFF.value):
-            if user.has_role(ROLE.INTERVENTION_STAFF.value):
-                abort(400, broken_role_situation)
-            # staff users aren't to see patients from RCT interventions
-            disallowed = Intervention.rct_ids()
-        if user.has_role(ROLE.INTERVENTION_STAFF.value):
-            # Look up associated interventions
-            uis = UserIntervention.query.filter(
-                UserIntervention.user_id == user.id)
-            # check if the user is associated with any intervention at all
-            if uis.count() == 0:
-                abort(400, "User is not associated with any intervention.")
-            required = [ui.intervention_id for ui in uis]
-        return disallowed, required
+    include_test_role = request.args.get('include_test_role')
 
     if request.form.get('reset_cache'):
         QB_StatusCacheKey().update(datetime.utcnow())
 
     user = current_user()
-    # Not including test accounts by default, unless requested
-    include_test_role = request.args.get('include_test_role')
-
-    # If there are org restrictions, we also require consent
-    require_orgs = org_restriction(user)
-    consented_users = None
-    if require_orgs:
-        consent_query = UserConsent.query.filter(and_(
-            UserConsent.deleted_id.is_(None),
-            UserConsent.expires > datetime.utcnow()))
-        consented_users = [u.user_id for u in consent_query if u.staff_editable]
-
-    # Restrict by intervention or remove RCT user ids as applicable
-    disallowed_iv_ids, required_iv_ids = intervention_restrictions(user)
-
-    patients = active_patients(
-        require_orgs=require_orgs,
+    query = patients_query(
+        acting_user=user,
         include_test_role=include_test_role,
         include_deleted=True,
-        require_interventions=required_iv_ids,
-        disallow_interventions=disallowed_iv_ids,
-        filter_by_ids=consented_users)
+        requested_orgs=org_preference_filter(user))
 
     # get assessment status only if it is needed as specified by config
     qb_status_cache_age = 0
@@ -164,19 +79,20 @@ def patients_root():
         status_cache_key = QB_StatusCacheKey()
         cached_as_of_key = status_cache_key.current()
         qb_status_cache_age = status_cache_key.minutes_old()
-        patient_list = []
-        for patient in patients:
+        patients_list = []
+        for patient in query:
             if patient.deleted:
-                patient_list.append(patient)
+                patients_list.append(patient)
                 continue
             a_s, visit = qb_status_visit_name(patient.id, cached_as_of_key)
             patient.assessment_status = _(a_s)
             patient.current_qb = visit
-            patient_list.append(patient)
-        patients = patient_list
+            patients_list.append(patient)
+    else:
+        patients_list = query
 
     return render_template(
-        'admin/patients_by_org.html', patients_list=patients, user=user,
+        'admin/patients_by_org.html', patients_list=patients_list, user=user,
         qb_status_cache_age=qb_status_cache_age, wide_container="true",
         include_test_role=include_test_role)
 

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -152,7 +152,7 @@ def patients_root():
 
     patients = active_patients(
         require_orgs=require_orgs,
-        include_test_role=include_test_roles,
+        include_test_role=include_test_role,
         include_deleted=True,
         require_interventions=required_iv_ids,
         disallow_interventions=disallowed_iv_ids,

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -178,7 +178,7 @@ def patients_root():
     return render_template(
         'admin/patients_by_org.html', patients_list=patients, user=user,
         qb_status_cache_age=qb_status_cache_age, wide_container="true",
-        include_test_roles=include_test_roles)
+        include_test_role=include_test_role)
 
 
 @patients.route('/patient-profile-create')

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -136,7 +136,7 @@ def patients_root():
 
     user = current_user()
     # Not including test accounts by default, unless requested
-    include_test_roles = request.args.get('include_test_roles')
+    include_test_role = request.args.get('include_test_role')
 
     # If there are org restrictions, we also require consent
     require_orgs = org_restriction(user)

--- a/portal/views/staff.py
+++ b/portal/views/staff.py
@@ -153,9 +153,9 @@ def staff_index():
         and_(UserOrganization.user_id == User.id,
              UserOrganization.organization_id.in_(org_list)))
 
-    include_test_roles = request.args.get('include_test_roles')
+    include_test_role = request.args.get('include_test_role')
     # not including test accounts by default, unless requested
-    if not include_test_roles:
+    if not include_test_role:
         org_staff = org_staff.filter(
             ~User.roles.any(Role.name == ROLE.TEST.value))
 
@@ -163,4 +163,4 @@ def staff_index():
     return render_template(
         'admin/staff_by_org.html', staff_list=staff_list,
         user=user, wide_container="true",
-        include_test_roles=include_test_roles)
+        include_test_role=include_test_role)

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -23,6 +23,7 @@ from portal.models.organization import (
     OrganizationResearchProtocol,
     OrgTree,
     ResearchProtocolExtension,
+    org_restriction_by_role,
 )
 from portal.models.reference import Reference
 from portal.models.research_protocol import ResearchProtocol
@@ -621,7 +622,7 @@ class TestOrganization(TestCase):
         self.promote_user(role_name=ROLE.STAFF.value)
         self.test_user = db.session.merge(self.test_user)
 
-        org_list = OrgTree().visible_orgs(self.test_user)
+        org_list = org_restriction_by_role(self.test_user, None)
         assert len(org_list) == 0
 
     def test_user_org_get(self):

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -615,14 +615,14 @@ class TestOrganization(TestCase):
         for i in (102, 1002, 10031, 10032):
             assert i in nodes
 
-    def test_visible_patients_on_none(self):
+    def test_visible_orgs_on_none(self):
         # Add none of the above to users orgs
         self.test_user.organizations.append(Organization.query.get(0))
         self.promote_user(role_name=ROLE.STAFF.value)
         self.test_user = db.session.merge(self.test_user)
 
-        patients_list = OrgTree().visible_patients(self.test_user)
-        assert len(patients_list) == 0
+        org_list = OrgTree().visible_orgs(self.test_user)
+        assert len(org_list) == 0
 
     def test_user_org_get(self):
         self.bless_with_basics()


### PR DESCRIPTION
Another, and better, refactor of patient queries.  Should now in a more uniform manner, across clients including /patients /reports and /api/patients/assessment , stick to common rules for behavior by ROLE and apply the RCT constraints as defined in TN-1835.

Resulted in moving detailed query code from views into respective models and elimination of several duplicate functions.