### PR TITLE
Simplify docker-compose syntax

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -38,7 +38,7 @@ get_docker_tags() {
     GIT_BRANCH="$(echo $GIT_BRANCH | tr / _)"
     GIT_TAG="${GIT_TAG:-$(git describe --tags --exact-match 2>/dev/null || true)}"
     GIT_HASH="${GIT_HASH:-$(git rev-parse HEAD)}"
-    GIT_SHORT_HASH="$(echo $GIT_HASH | cut --characters 1-7)"
+    GIT_SHORT_HASH="${GIT_SHORT_HASH:-$(git rev-parse --short HEAD)}"
 
     DOCKER_TAGS=$(cat << BLOCK
 $GIT_BRANCH

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -13,7 +13,7 @@ RUN \
         devscripts \
         equivs \
         git | grep "Setting up" | awk '{print $3 $4}' ORS=' '
-        # only print package names, versions
+        # only print package names and versions
 
 WORKDIR /root/portal
 

--- a/docker/docker-compose.build.yaml
+++ b/docker/docker-compose.build.yaml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: docker/Dockerfile.build
     environment:
-      - GIT_REPO=${GIT_REPO:-/mnt/git_repo}
+      GIT_REPO: /mnt/git_repo
     volumes:
       - source: ../debian/artifacts
         target: /tmp/artifacts

--- a/docker/docker-compose.flower.yaml
+++ b/docker/docker-compose.flower.yaml
@@ -4,7 +4,7 @@ version: "3.4"
 services:
   celeryflower:
     environment:
-      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      REDIS_URL: redis://redis:6379/0
     build:
       context: https://github.com/mher/flower.git#v0.9.2
     entrypoint: /bin/sh

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,11 +10,11 @@ x-service-base: &service_base
     - ${PORTAL_ENV_FILE:-portal.env}
   environment:
     # cross-service defaults
-    PGDATABASE: ${PGDATABASE:-portaldb}
-    PGHOST: ${PGHOST:-db}
-    PGPASSWORD: ${PGPASSWORD:-""}
-    PGUSER: ${PGUSER:-postgres}
-    REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+    PGDATABASE: portaldb
+    PGHOST: db
+    PGPASSWORD: ""
+    PGUSER: postgres
+    REDIS_URL: redis://redis:6379/0
 
 services:
   web:


### PR DESCRIPTION
* Remove shell-style defaults (see below) from docker-compose files
  * Shell-style defaults allow overrides via `.env` and `portal.env` (env files)
  * Now only overrideable via `portal.env`
* Still necessary for some settings that cannot be set from `portal.env`
  * eg `volumes`, `ports`

Shell-style defaults:
```
${FOO:-default value of FOO if not set}
```