### PR TITLE
Fix off-by-one error in scheduled job test

### DIFF
--- a/tests/test_scheduled_job.py
+++ b/tests/test_scheduled_job.py
@@ -37,7 +37,7 @@ class TestScheduledJob(TestCase):
             name="rando", task="test", schedule=schedule, active=True)
         sjc = sj.crontab_schedule()
         assert len(sjc.minute) == 1
-        assert sjc.minute.pop() in range(0, 59)
+        assert sjc.minute.pop() in range(0, 60)
         assert len(sjc.hour) == 24
 
     def test_job_upsert(self):


### PR DESCRIPTION
See test fail log:
```
=================================== FAILURES ===================================
____________________ TestScheduledJob.test_random_schedule _____________________
self = <tests.test_scheduled_job.TestScheduledJob testMethod=test_random_schedule>
    def test_random_schedule(self):
        schedule = "r * * * *"
        sj = ScheduledJob(
            name="rando", task="test", schedule=schedule, active=True)
        sjc = sj.crontab_schedule()
        assert len(sjc.minute) == 1
>       assert sjc.minute.pop() in range(0, 59)
E       AssertionError: assert 59 in range(0, 59)
E        +  where 59 = <built-in method pop of set object at 0x7f35dacbd3c8>()
E        +    where <built-in method pop of set object at 0x7f35dacbd3c8> = set().pop
E        +      where set() = <crontab: 59 * * * * (m/h/d/dM/MY)>.minute
E        +  and   range(0, 59) = range(0, 59)
tests/test_scheduled_job.py:40: AssertionError
```