### PR TITLE
TN-1975 always preserve order of QBT.at values inserting QB_Timeline

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -86,12 +86,12 @@ class AtOrderedList(list):
 
         """
         if not self.__len__():
-            return super().append(value)
+            return super(AtOrderedList, self).append(value)
 
         # Expecting to build in order; common case new value
         # lands at end.
         if self[-1].at <= value.at:
-            return super().append(value)
+            return super(AtOrderedList, self).append(value)
 
         # Otherwise, walk backwards till new value < existing
         for i, e in reversed(list(enumerate(self))):

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -63,15 +63,17 @@ class QBT(db.Model):
 
 
 class AtOrderedList(list):
-    """Specialize ``list`` to maintain insertion order and ``at`` values
+    """Specialize ``list`` to maintain insertion order and ``at`` attribute
 
     When building up QBTs for a user, we need to maintain both order and
-    sort by ``QBT.at`` values.  As there are rows with identical ``at``
-    values, it can't simply be sorted by a field.
+    sort by the ``QBT.at`` attribute.  As there are rows with identical ``at``
+    values, it can't simply be sorted by a field, as insertion order matters
+    in the case of a tie (as say the ``due`` status needs to precede a
+    ``completed``, which does happen with paper entry).
 
     As the build order matters, continue to add QBTs to the end of the list,
     taking special care to insert those with earlier ``at`` values in
-    the correct place.  Two or more identicle ``at`` values should result
+    the correct place.  Two or more identical ``at`` values should result
     in the latest addition following preexisting.
 
     """

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -62,6 +62,50 @@ class QBT(db.Model):
             recur_id=self.qb_recur_id, qb_id=self.qb_id)
 
 
+class AtOrderedList(list):
+    """Specialize ``list`` to maintain insertion order and ``at`` values
+
+    When building up QBTs for a user, we need to maintain both order and
+    sort by ``QBT.at`` values.  As there are rows with identical ``at``
+    values, it can't simply be sorted by a field.
+
+    As the build order matters, continue to add QBTs to the end of the list,
+    taking special care to insert those with earlier ``at`` values in
+    the correct place.  Two or more identicle ``at`` values should result
+    in the latest addition following preexisting.
+
+    """
+
+    def append(self, value):
+        """Maintain order by appending or inserting as needed
+
+        If the given value.at is > current_end.at, append to end.
+        Otherwise, walk backwards till the new can be inserted
+        so the list remains ordered by the 'at' attribute, with
+        new matching values following existing
+
+        """
+        if not self.__len__():
+            return super().append(value)
+
+        # Expecting to build in order; common case new value
+        # lands at end.
+        if self[-1].at <= value.at:
+            return super().append(value)
+
+        # Otherwise, walk backwards till new value < existing
+        for i, e in reversed(list(enumerate(self))):
+            if i > 0:
+                # If not at start and previous is also greater
+                # than new, continue to walk backwards
+                if self[i-1].at > value.at:
+                    continue
+            if e.at > value.at:
+                return self.insert(i, value)
+
+        raise ValueError("still here?")
+
+
 def ordered_rp_qbs(rp_id, trigger_date):
     """Generator to yield ordered qbs by research protocol alone"""
     baselines = qbs_by_rp(rp_id, 'baseline')
@@ -370,7 +414,7 @@ def update_users_QBT(user_id, invalidate_existing=False):
 
         # As we move forward, capture state at each time point
 
-        pending_qbts = []
+        pending_qbts = AtOrderedList()
         kwargs = {"user_id": user_id}
         for qbd in qb_generator:
             qb_recur_id = qbd.recur.id if qbd.recur else None
@@ -416,12 +460,15 @@ def update_users_QBT(user_id, invalidate_existing=False):
                     pending_qbts.append(QBT(
                         at=complete_date, status='completed',
                         **kwargs))
-                    if complete_date < expired_date:
+                    if complete_date <= expired_date:
                         include_overdue = False
                         include_expired = False
                         expired_as_partial = False
 
             if include_overdue and overdue_date:
+                # Take care to add overdue in the right order wrt
+                # partial and complete rows.
+
                 pending_qbts.append(QBT(
                     at=overdue_date, status='overdue', **kwargs))
 

--- a/tests/test_qb_timeline.py
+++ b/tests/test_qb_timeline.py
@@ -7,6 +7,7 @@ from portal.database import db
 from portal.models.audit import Audit
 from portal.models.clinical_constants import CC
 from portal.models.qb_timeline import (
+    AtOrderedList,
     QB_StatusCacheKey,
     QBT,
     ordered_qbs,
@@ -420,3 +421,89 @@ class Test_QB_StatusCacheKey(TestCase):
         cache_key = QB_StatusCacheKey()
         cache_key.update(hourback)
         assert cache_key.minutes_old() == 60
+
+
+class HasAt(object):
+    """Mock the sorted portion of QBT for testing AtOrderedList"""
+    def __init__(self, at, label):
+        self.at = at
+        self.label = label
+
+
+n = HasAt(datetime.utcnow(), 'now')
+y = HasAt(n.at - relativedelta(days=1), 'yesterday')
+y2 = HasAt(y.at, 'yesterday again')
+wa = HasAt(n.at - relativedelta(weeks=1), 'week ago')
+
+
+def test_at_ordered_empty():
+    ao = AtOrderedList()
+    assert len(ao) == 0
+    ao.append(n)
+    assert len(ao) == 1
+    assert ao.pop() == n
+
+
+def test_at_ordered_end():
+    ao = AtOrderedList()
+    ao.append(wa)
+
+    # now append one (y)esterday, then a second
+    # expecting order based on 'at' and insertion
+    # which should map to append order in this case
+
+    ao.append(y)
+    ao.append(y2)
+
+    assert len(ao) == 3
+    assert ao.pop().label == y2.label
+    assert ao.pop() == y
+    assert ao.pop() == wa
+
+
+def test_at_ordered_insertion():
+    ao = AtOrderedList()
+    ao.append(wa)
+    ao.append(n)
+
+    # now insert one (y)esterday, then a second
+    # expecting order based on 'at' and insertion
+    # as (n)ow is already inserted and has a greater
+    # 'at' value, it should remain at the end.
+    ao.append(y)
+    ao.append(y2)
+
+    assert len(ao) == 4
+    assert ao.pop() == n
+    assert ao.pop().label == y2.label
+    assert ao.pop() == y
+    assert ao.pop() == wa
+
+
+def test_at_ordered_first():
+    ao = AtOrderedList()
+    ao.append(y)
+    ao.append(n)
+
+    # now insert element (wa - week ago) that should land at front of list
+    ao.append(wa)
+
+    assert len(ao) == 3
+    assert ao.pop() == n
+    assert ao.pop() == y
+    assert ao.pop() == wa
+
+
+def test_at_ordered_first_match():
+    ao = AtOrderedList()
+    ao.append(y)
+    ao.append(n)
+
+    # now insert element with same 'at' as first, expecting the original
+    # first will remain first, and new, second
+    ao.append(y2)
+
+    assert len(ao) == 3
+    assert ao.pop() == n
+    assert ao.pop() == y2
+    assert ao.pop() == y

--- a/tests/test_qb_timeline.py
+++ b/tests/test_qb_timeline.py
@@ -430,80 +430,80 @@ class HasAt(object):
         self.label = label
 
 
-n = HasAt(datetime.utcnow(), 'now')
-y = HasAt(n.at - relativedelta(days=1), 'yesterday')
-y2 = HasAt(y.at, 'yesterday again')
-wa = HasAt(n.at - relativedelta(weeks=1), 'week ago')
+origin = HasAt(datetime.strptime("2112-01-31", '%Y-%m-%d'), 'origin')
+day_before = HasAt(origin.at - relativedelta(days=1), 'day before')
+day_before2 = HasAt(day_before.at, 'day before again')
+week_before = HasAt(origin.at - relativedelta(weeks=1), 'week before')
 
 
 def test_at_ordered_empty():
     ao = AtOrderedList()
     assert len(ao) == 0
-    ao.append(n)
+    ao.append(origin)
     assert len(ao) == 1
-    assert ao.pop() == n
+    assert ao.pop() == origin
 
 
 def test_at_ordered_end():
     ao = AtOrderedList()
-    ao.append(wa)
+    ao.append(week_before)
 
-    # now append one (y)esterday, then a second
+    # now append one day before, then a second
     # expecting order based on 'at' and insertion
     # which should map to append order in this case
 
-    ao.append(y)
-    ao.append(y2)
+    ao.append(day_before)
+    ao.append(day_before2)
 
     assert len(ao) == 3
-    assert ao.pop().label == y2.label
-    assert ao.pop() == y
-    assert ao.pop() == wa
+    assert ao.pop().label == day_before2.label
+    assert ao.pop() == day_before
+    assert ao.pop() == week_before
 
 
 def test_at_ordered_insertion():
     ao = AtOrderedList()
-    ao.append(wa)
-    ao.append(n)
+    ao.append(week_before)
+    ao.append(origin)
 
-    # now insert one (y)esterday, then a second
+    # now insert one from day before, then a second
     # expecting order based on 'at' and insertion
-    # as (n)ow is already inserted and has a greater
+    # as origin is already inserted and has a greater
     # 'at' value, it should remain at the end.
-    ao.append(y)
-    ao.append(y2)
+    ao.append(day_before)
+    ao.append(day_before2)
 
     assert len(ao) == 4
-    assert ao.pop() == n
-    assert ao.pop().label == y2.label
-    assert ao.pop() == y
-    assert ao.pop() == wa
+    assert ao.pop() == origin
+    assert ao.pop().label == day_before2.label
+    assert ao.pop() == day_before
+    assert ao.pop() == week_before
 
 
 def test_at_ordered_first():
     ao = AtOrderedList()
-    ao.append(y)
-    ao.append(n)
+    ao.append(day_before)
+    ao.append(origin)
 
-    # now insert element (wa - week ago) that should land at front of list
-    ao.append(wa)
+    # now insert element that should land at front of list
+    ao.append(week_before)
 
     assert len(ao) == 3
-    assert ao.pop() == n
-    assert ao.pop() == y
-    assert ao.pop() == wa
+    assert ao.pop() == origin
+    assert ao.pop() == day_before
+    assert ao.pop() == week_before
 
 
 def test_at_ordered_first_match():
     ao = AtOrderedList()
-    ao.append(y)
-    ao.append(n)
+    ao.append(day_before)
+    ao.append(origin)
 
     # now insert element with same 'at' as first, expecting the original
     # first will remain first, and new, second
-    ao.append(y2)
+    ao.append(day_before2)
 
     assert len(ao) == 3
-    assert ao.pop() == n
-    assert ao.pop() == y2
-    assert ao.pop() == y
+    assert ao.pop() == origin
+    assert ao.pop() == day_before2
+    assert ao.pop() == day_before


### PR DESCRIPTION
New data structure added to maintain order of list by attribute `at` field, named `AtOrderedList`.
The `append` method on `AtOrderedList` enforces order on insertion.
Use when building user's qb_timeline rows to prevent order errors, such as those demonstrated in TN-1975.

NB - no migration yet to seek out any qb_timeline rows needing to be reprocessed.  Waiting to see if another issue's migration during same sprint will cover.