### PR TITLE
TN-408 followfix - child org rendering

### DIFF
--- a/portal/static/css/orgTreeView.css
+++ b/portal/static/css/orgTreeView.css
@@ -25,6 +25,14 @@ input.clinic {
 #fillOrgs * {
 	font-size: 12px;
 }
+#fillOrgs .parent-org-container,
+#fillOrgs .sub-org-container {
+	padding: 0.5em;
+}
+#fillOrgs .sub-org-container {
+	border: 2px solid #ececec;
+	margin-bottom: 0.25em;
+}
 #fillOrgs .sub-text,
 #fillOrgs .json-link {
 	font-size: 10px;
@@ -33,8 +41,11 @@ input.clinic {
 #fillOrgs .singleton {
 	color: #68727e;
     display: inline-block;
-    border: 1px solid #ececec !important;
+    border: 1px solid #ececec;
     padding: 0.5em !important;
+}
+#fillOrgs .sub-org-container .singleton {
+	border: 0;
 }
 #fillOrgs .text-muted:after {
 	content: "\2193";
@@ -50,10 +61,14 @@ input.clinic {
 	max-width: 100%;
 }
 #fillOrgs .text-muter {
-	color: #71464f;
+	color: #68727e;
+	opacity: 0.8;
 	display: inline-block;
 	padding: 0.5em;
 	border: 1px solid #ececec !important;
+}
+#fillOrgs .child-item {
+	border: 1px solid #ececec;
 }
 #fillOrgs .text-muter:after {
 	content: "\2193";
@@ -65,7 +80,7 @@ input.clinic {
 	content: "";
 }
 #fillOrgs legend,
-#fillOrgs .parent-singleton {
+#fillOrgs .parent-singleton legend {
     background: #7C959E;
     color: #FFF;
     margin: 4px 0;
@@ -87,9 +102,11 @@ input.clinic {
 }
 #fillOrgs .parent-singleton label.org-label { /* single parent org label */
 	display: block;
-	background: #FFF;
 	width: 100%;
+	left: 0;
+	background: #FFF;
 	color: #68727e;
+	border: 2px solid #ececec;
 }
 #fillOrgs .parent-singleton label.org-label .sub-text {
 	display: none;
@@ -97,11 +114,15 @@ input.clinic {
 #fillOrgs .parent-singleton label.org-label .json-link {
 	display: none;
 }
+#fillOrgs .parent-singleton label.org-label input {
+	display: none !important;
+}
+
 #fillOrgs .parent-singleton label.org-label:after {
 	content: "( single parent org )";
 	display: block;
-	color: #68727e;
 	width: 100%;
+	color: #68727e;
 	font-weight: 200;
 }
 #fillOrgs .parent-singleton .sub-text,
@@ -113,11 +134,12 @@ input.clinic {
 	top: 2px;
 	padding: 4px;
 }
+#fillOrgs .parent-org-container legend:after,
 #fillOrgs legend.singleton:after {
 	content: "\2193";
 	display: block;
 	width: 20px;
-	margin: auto;
+	margin-left: 2em;
 }
 #fillOrgs div.org-container label.org-label {
 	margin: 0.5em 0;

--- a/portal/static/js/src/modules/OrgTool.js
+++ b/portal/static/js/src/modules/OrgTool.js
@@ -321,11 +321,11 @@ export default (function() { /*global i18next $ */
                     }
                     var attrObj = {dataAttributes:(' data-parent-id="' + topLevelOrgId + '"  data-parent-name="' + orgsList[topLevelOrgId].name + '" '), containerClass: "", textClass: ""};
                     if (_isTopLevel) {
+                        attrObj.containerClass = "sub-org-container";
                         attrObj.dataAttributes = (' data-parent-id="' + _parentOrgId + '"  data-parent-name="' + _parentOrg.name + '" ');
                     }
                     if (orgsList[item.id].children.length > 0) {
                         if (_isTopLevel) {
-                            attrObj.containerClass = "sub-org-container";
                             attrObj.textClass = "text-muted";
                         } else {
                             attrObj.textClass = "text-muter";
@@ -333,6 +333,8 @@ export default (function() { /*global i18next $ */
                     } else {
                         if (_isTopLevel) {
                             attrObj.textClass = "text-muted singleton";
+                        } else {
+                            attrObj.textClass = "child-item";
                         }
                     }
                     childClinic = `<div id="${item.id}_container" ${attrObj.dataAttributes} class="indent org-container ${attrObj.containerClass}">
@@ -340,6 +342,7 @@ export default (function() { /*global i18next $ */
                         <input class="clinic" type="checkbox" name="organization" id="${item.id}_org" data-org-name="${item.name}" data-short-name="${item.shortname || item.name}" state="${state ? state : ''}" value="${item.id}" ${attrObj.dataAttributes} />
                         <span>${item.name}</span></label></div>`;
                     var parentOrgContainer = $("#" + _parentOrgId + "_container");
+        
                     if (parentOrgContainer.length > 0) {
                         parentOrgContainer.append(childClinic);
                     } else {


### PR DESCRIPTION
Followup fix to this story:
https://jira.movember.com/browse/TN-408

still seeing issues with the way org tree is being rendered (see /api/organization?tree_view=True):

adding helper css class to distinguish child organizations
styling fixes for sub group of organizations (including single item organization)
