### PR TITLE
TN-1995 correct consent lookup bug generated in fixing TN-1947

### DIFF
--- a/portal/migrations/versions/ede15dcea777_.py
+++ b/portal/migrations/versions/ede15dcea777_.py
@@ -1,0 +1,28 @@
+"""invalidate cache for any users with multiple consent rows
+
+Revision ID: ede15dcea777
+Revises: 687dd856dc5e
+Create Date: 2019-04-10 14:47:34.398914
+
+"""
+from alembic import op
+from sqlalchemy.orm import sessionmaker
+
+# revision identifiers, used by Alembic.
+revision = 'ede15dcea777'
+down_revision = '687dd856dc5e'
+Session = sessionmaker()
+
+
+def upgrade():
+    session = Session(bind=op.get_bind())
+    query = (
+        "delete from qb_timeline where user_id in ("
+        "select distinct(user_id) from user_consents group by user_id "
+        "having count(*) > 1)")
+    session.execute(query)
+
+
+def downgrade():
+    # nothing needed
+    pass

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -204,6 +204,11 @@ def calc_and_adjust_start(user, qbd, initial_trigger):
 
     """
     users_trigger = trigger_date(user, qbd.questionnaire_bank)
+    if not users_trigger:
+        trace(
+            "no valid trigger, default to initial value: {}".format(
+                initial_trigger))
+        users_trigger = initial_trigger
     if initial_trigger > users_trigger:
         trace(
             "user {} has unexpected trigger date before consent date".format(
@@ -230,6 +235,11 @@ def calc_and_adjust_expired(user, qbd, initial_trigger):
 
     """
     users_trigger = trigger_date(user, qbd.questionnaire_bank)
+    if not users_trigger:
+        trace(
+            "no valid trigger, default to initial value: {}".format(
+                initial_trigger))
+        users_trigger = initial_trigger
     if initial_trigger > users_trigger:
         trace(
             "user {} has unexpected trigger date before consent date".format(
@@ -272,10 +282,14 @@ def ordered_qbs(user, classification=None):
     # bootstrap problem - don't know initial `as_of_date` w/o a QB
     # call `trigger_date` w/o QB for best guess.
     td = trigger_date(user=user)
-    _, withdrawal_date = consent_withdrawal_dates(user)
+    old_td, withdrawal_date = consent_withdrawal_dates(user)
     if not td:
-        trace("no trigger date therefore nothing from ordered_qbds()")
-        return
+        if old_td:
+            trace("withdrawn user, use previous trigger {}".format(old_td))
+            td = old_td
+        else:
+            trace("no trigger date therefore nothing from ordered_qbds()")
+            return
 
     # Zero to one RP makes things significantly easier - otherwise
     # swap in a strategy that can work with the change.


### PR DESCRIPTION
Confronts a bug introduced in PR #3053.  Reworked ``latest_consent`` to only return valid, current consent, and extended ``consent_withdrawal_dates`` to correctly handle the withdrawn scenario, and use to work with building history of withdrawn cases.

@ivan-c this PR may need a migration to purge potentially incorrect qb_timeline rows as well.  Pushing now for test run.