### PR TITLE
Feature/manual entry consent completion dates

### DIFF
--- a/portal/static/js/src/modules/Consent.js
+++ b/portal/static/js/src/modules/Consent.js
@@ -322,6 +322,16 @@ export default { /*global i18next datepicker $*/
         }
         setTimeout(function() { tnthAjax.deleteConsent(userId, {"org": orgId});}, 350);
     },
+    /*
+        parameter: consent data item, as returned from consent API
+        boolean: return whether the item has all the relevant consent flags
+    */
+    hasConsentedFlags: function(item) {
+        if (!item) {
+            return false;
+        }
+        return item.send_reminders && item.staff_editable && item.include_in_reports;
+    },
     setConsentBySelectedOrg: function(userId, obj, isConsentWithTopLevelOrg, callback) {
         callback = callback || function() {};
         var self = this;

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -2,6 +2,7 @@ import Utility from "./Utility.js";
 import tnthDates from "./TnthDate.js";
 import SYSTEM_IDENTIFIER_ENUM from "./SYSTEM_IDENTIFIER_ENUM.js";
 import CLINICAL_CODE_ENUM from "./CLINICAL_CODE_ENUM.js";
+import Consent from "./Consent.js";
 export default { /*global $ */
     "beforeSend": function() {
         $.ajaxSetup({
@@ -416,7 +417,7 @@ export default { /*global $ */
             }
             consentedOrgIds = $.grep(data.consent_agreements, function(item) {
                 var expired = item.expires ? tnthDates.getDateDiff(String(item.expires)) : 0; /*global tnthDates */
-                return (String(orgId) === String(item.organization_id)) && !item.deleted && !(expired > 0) && item.staff_editable && item.send_reminders && item.include_in_reports;
+                return (String(orgId) === String(item.organization_id)) && !item.deleted && !(expired > 0) && Consent.hasConsentedFlags(item);
             });
         });
         return consentedOrgIds.length;

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -193,6 +193,9 @@ var tnthDates =  { /*global i18next */
             case "dd/mm/yyyy":
                 nd = day + "/" + month + "/" + year;
                 break;
+            case "mm/dd/yyyy hh:mm:ss":
+                nd = month + "/" + day + "/" + year + " " + hours + ":" + minutes + ":" + seconds;
+                break;
             case "dd/mm/yyyy hh:mm:ss":
                 nd = day + "/" + month + "/" + year + " " + hours + ":" + minutes + ":" + seconds;
                 break;
@@ -246,13 +249,14 @@ var tnthDates =  { /*global i18next */
         }
         return convertedDate;
     },
-    getDateWithTimeZone: function(dObj) {
+    getDateWithTimeZone: function(dObj, format) {
         /*
          * param is a date object - calculating UTC date using Date object's timezoneOffset method
          * the method return offset in minutes, so need to convert it to miliseconds - adding the resulting offset will be the UTC date/time
          */
+        format = format || "system";
         var utcDate = new Date(dObj.getTime() + (dObj.getTimezoneOffset()) * 60 * 1000);
-        return this.formatDateString(utcDate, "yyyy-mm-dd hh:mm:ss");  //I believe this is a valid python date format, will save it as GMT date/time NOTE, conversion already occurred, so there will be no need for backend to convert it again
+        return this.formatDateString(utcDate, format);  //I believe this is a valid python date format, will save it as GMT date/time NOTE, conversion already occurred, so there will be no need for backend to convert it again
     },
     getTodayDateObj: function() { //return object containing today's date/time information
         var today = new Date();

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -6,7 +6,6 @@ import ProcApp from "./modules/Procedures.js";
 import Utility from "./modules/Utility.js";
 import ClinicalQuestions from "./modules/ClinicalQuestions.js";
 import Consent from "./modules/Consent.js";
-import CONSENT_ENUM from "./modules/CONSENT_ENUM.js";
 
 /*
  * helper Object for initializing profile sections  TODO streamline this more
@@ -1780,7 +1779,7 @@ export default (function() {
                         if (!self.manualEntry.consentDate) {
                             return false;
                         }
-                        
+
                         //check completion date against consent date
                         //all date/time should be in GMT date/time
                         var completionDate = new Date(self.manualEntry.completionDate);

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1727,7 +1727,6 @@ export default (function() {
                             //filtered out non-deleted items from all consents
                             return !item.deleted && String(item.status) === "suspended";
                         });
-                        console.log("widthdrawn? ", withdrawnItem);
                         if (withdrawnItem.length) {
                             //use PREVIOUSLY valid consent date
                             var consentItems = $.grep(dataArray, function(item) {
@@ -1781,7 +1780,7 @@ export default (function() {
                         if (!self.manualEntry.consentDate) {
                             return false;
                         }
-
+                        
                         //check completion date against consent date
                         //all date/time should be in GMT date/time
                         var completionDate = new Date(self.manualEntry.completionDate);
@@ -1794,8 +1793,7 @@ export default (function() {
                         var oConsentDate = new Date(cConsentDate.getTime());
                         var nCompletionDate = completionDate.setHours(0, 0, 0, 0);
                         var nConsentDate = cConsentDate.setHours(0, 0, 0, 0);
-                
-                        console.log("original complete date: " , completionDate, " consent ", oConsentDate, " competion date? ", nCompletionDate, " consent date? ", nConsentDate);
+            
                         /*
                          * set completion date/time to consent date/time IF the two dates are the same 
                          */

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -1169,15 +1169,6 @@ select:not([multiple]) {
     border-top: 1px solid #ddd;
     justify-content: space-around;
   }
-  #enterManualInfoContainer {
-    margin-bottom: 1em;
-    .flex {
-      flex-wrap: wrap
-    }
-  }
-  #manualEntryCompletionDateContainer {
-    margin-top: 1em
-  }
   #phone, #email, #altPhone  {
     width: 300px;
     max-width: 100%;
@@ -2929,6 +2920,9 @@ body.portal .copyright-container  {
   margin-bottom: 2em;
   letter-spacing: 1px;
 }
+.detail-title {
+  margin-bottom: 0;
+}
 #mainDiv.profile .profile-item-container .profile-item-title {
   max-width: 150px;
 }
@@ -3621,8 +3615,7 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
 }
 .custom-container {
   display: block;
-  margin-bottom: 2em;
-  border-bottom: 1px solid #E0E6E3;
+  margin-bottom: 1em;
   padding: 0.1em 0 1.5em 0;
   .profile-item-container {
     padding: 1.5em 2em 2em 2em;
@@ -3779,6 +3772,9 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
 }
 .modal-footer {
   min-height: 4em;
+}
+.modal-header,
+.modal-footer {
   padding: 0.7em;
 }
 .modal-header button,
@@ -3865,6 +3861,20 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
   }
   .loading-message-indicator {
     display: block;
+  }
+}
+#enterManualInfoContainer {
+  margin-bottom: 1em;
+  .flex {
+    flex-wrap: wrap
+  }
+}
+#manualEntryCompletionDateContainer {
+  margin-top: 1em;
+  label {
+    position: relative;
+    top: 0.35em;
+    margin-bottom: 4px;
   }
 }
 #emailBodyModal .body-content {
@@ -4105,15 +4115,30 @@ div.biopsy-option:last-of-type{
   display: none;
 }
 #identityVerificationContainer {
-  padding: 2em 1.5em;
+  padding: 1em 0.5em;
   margin: 1em auto;
+  .title,
+  .hr {
+    font-weight: 500;
+    width: 350px;
+    max-width: 100%;
+  }
+  .hr {
+    margin: -8px 0 16px;
+  }
   input,
   select {
-    width: 100%;
+    width: 350px;
     max-width: 100%;
   }
   .form-group {
-    margin-bottom: 1em;
+    margin-bottom: 0.5em;
+  }
+  .name-container {
+    margin-bottom: 1.25em;
+  }
+  .form___submit_container {
+    margin-top: 1.5em;
   }
 }
 .box-shadow-container {
@@ -4200,6 +4225,16 @@ div.timezone-warning.text-warning {
     font-size: @mobileSmallSize;
     width: 100%;
     max-width: 100%;
+}
+#profileAuditLogTable {
+  td {
+    word-break: break-all;
+    .second {
+      display: block;
+      width: 500px;
+      max-width: 100%;
+    }
+  }
 }
 /** Responsive sizes **/
 @media (min-width: 423px) {

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1083,7 +1083,7 @@
                                         <i class="fa fa-spinner fa-spin fa-2x loading-message"></i>
                                     </div>
                                     <div id="manualEntryMain" v-show="!manualEntry.initloading">
-                                        <p class="text-left text-muted">{{ _("Select the method in which the questionnaire will be completed:") }}</p>
+                                        <p class="text-left">{{ _("Select the method in which the questionnaire will be completed:") }}</p>
                                         <input type="hidden" id="manualEntryConsentDate" v-model="manualEntry.consentDate" />
                                         <input type="hidden" id="qCompletionDate" v-model="manualEntry.completionDate" />
                                         <input type="hidden" id="qToday" v-model="manualEntry.todayObj.gmtDate" />
@@ -1128,7 +1128,6 @@
                                                 </div>
                                             </div>
                                         </div>
-                                        <!--<div id="errorCompletionDate" class="error-message"></div>-->
                                         {% raw %}
                                             <div id="manualEntryMessageContainer" class="error-message">{{manualEntry.errorMessage}}</div>
                                         {% endraw %}

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1606,9 +1606,8 @@ def present_needed():
         return redirect('/')
 
     url = url_for('.present_assessment', **args)
-    auditable_event("present assessment url {}".format(url),
-                    user_id=current_user().id, subject_id=subject_id,
-                    context='assessment')
+    current_app.logger.debug('present assessment url: %s', url)
+    
     return redirect(url, code=302)
 
 

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1606,6 +1606,9 @@ def present_needed():
         return redirect('/')
 
     url = url_for('.present_assessment', **args)
+    auditable_event("present assessment url {}".format(url),
+                    user_id=current_user().id, subject_id=subject_id,
+                    context='assessment')
     return redirect(url, code=302)
 
 

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1606,8 +1606,7 @@ def present_needed():
         return redirect('/')
 
     url = url_for('.present_assessment', **args)
-    current_app.logger.debug('present assessment url: %s', url)
-    
+    current_app.logger.debug('present assessment url, redirecting to: %s', url)
     return redirect(url, code=302)
 
 


### PR DESCRIPTION
subtask for this story:
https://jira.movember.com/browse/TN-1965
For manual entry of papel questionnaire:
Dealing with the scenario where completion date is the same as the consent date.
Changes include:
- Use consent date/time if completion date is **the same** as consent date
- Use previous consent date/time for comparison if subject has withdrawn
- styling fixes of manual entry modal
- add audit entry for present assessment url (url redirect to assessment engine) so to see what parameters were actually passed