### PR TITLE
fix error generated when filtering org(s) on admin list

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -586,7 +586,6 @@ def admin():
 
         # for selected filtered orgs, we also need to get the children
         # of each, if any
-        pref_org_list = set(pref_org_list.split(","))
         for orgId in pref_org_list:
             check_int(orgId)
             if orgId == 0:  # None of the above doesn't count


### PR DESCRIPTION
Fix 500 error generated (i.e. 'list' object has no attribute 'split') when filtering organization(s) on admin list.
Fix is to remove code that attempt to perform string split on orgs list preference object variable
note: orgs list filtering preference is now saved as a list instead of a comma-delimited string (see PR: https://github.com/uwcirg/truenth-portal/pull/3041)
