### PR TITLE
Withdrawn users need access to "current" QBD for correct history 

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -247,9 +247,6 @@ class QB_Status(object):
         :return: QBD for best match, on None
 
         """
-        if self.withdrawn_by(self.as_of_date):
-            # User effectively withdrawn, no current
-            return None
         if classification == 'indefinite':
             return self._current_indef
         if self._current:


### PR DESCRIPTION
Remove obsolete check for withdrawn users in `current_qbd`, as it's needed for display of history.