### PR TITLE
Revert Withdrawn user QBD view change

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -247,6 +247,9 @@ class QB_Status(object):
         :return: QBD for best match, on None
 
         """
+        if self.withdrawn_by(self.as_of_date):
+            # User effectively withdrawn, no current
+            return None
         if classification == 'indefinite':
             return self._current_indef
         if self._current:


### PR DESCRIPTION
Reverts Withdrawn users need access to "current" QBD for correct history display. (#3156)

This reverts commit 6eab46a8063424f7fa68909d31ddb748e8c2dff8

See comments on TN-1947