### PR TITLE
TN-2021 current_qbd gains `even_if_withdrawn` parameter

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -233,7 +233,7 @@ class QB_Status(object):
         org = self.user.first_top_organization()
         return getattr(org, 'name', '')
 
-    def current_qbd(self, classification=None):
+    def current_qbd(self, classification=None, even_if_withdrawn=False):
         """ Looks for current QBD for given parameters
 
         If the user has a valid questionnaire bank for the given as_of_date
@@ -241,14 +241,15 @@ class QB_Status(object):
         (QBD), which fully defines the questionnaire bank, iteration, recur
         and start date.
 
-        :param as_of_date: point in time for reference, frequently utcnow
         :param classification: None defaults to all, special case for
           ``indefinite``
-        :return: QBD for best match, on None
+        :param even_if_withdrawn: Set true to get the current, even if the
+          patient may be in a withdrawn state.  By default, post the withdrawal
+          date, a patient doesn't have a current QBD.
+        :return: QBD for best match, or None
 
         """
-        if self.withdrawn_by(self.as_of_date):
-            # User effectively withdrawn, no current
+        if not even_if_withdrawn and self.withdrawn_by(self.as_of_date):
             return None
         if classification == 'indefinite':
             return self._current_indef

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -269,7 +269,8 @@ def questionnaire_status():
             row['study_id'] = study_id
 
         # if no current, try previous (as current may be expired)
-        last_viable = qb_stats.current_qbd() or qb_stats.prev_qbd
+        last_viable = qb_stats.current_qbd(
+            even_if_withdrawn=True) or qb_stats.prev_qbd
         if last_viable:
             row['qb'] = last_viable.questionnaire_bank.name
             row['visit'] = visit_name(last_viable)


### PR DESCRIPTION
Fixes report when patient's withdrawal date coincided with "current" QB cycle.

Corrects first attempt that inadvertently opened the door for assessments beyond a patient's withdrawal date.
