### PR TITLE
TN-1932 add missing America/Sao_Paulo time zone

### DIFF
--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -929,7 +929,7 @@
             <option value="America/Los_Angeles">{{_("America/Los Angeles")}}</option>
             <option value="America/Indianapolis">{{_("America/Indianapolis")}}</option>
             <option value="America/New_York">{{_("America/New York")}}</option>
-            <option value="America/Sao_Paulo">{{_("America/Sao_Paulo")}}</option>
+            <option value="America/Sao_Paulo">{{_("America/Sao Paulo")}}</option>
             <option value="Australia/Adelaide">{{_("Australia/Adelaide")}}</option>
             <option value="Australia/Brisbane">{{_("Australia/Brisbane")}}</option>
             <option value="Australia/Broken_Hill">{{_("Australia/Broken_Hill")}}</option>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -929,6 +929,7 @@
             <option value="America/Los_Angeles">{{_("America/Los Angeles")}}</option>
             <option value="America/Indianapolis">{{_("America/Indianapolis")}}</option>
             <option value="America/New_York">{{_("America/New York")}}</option>
+            <option value="America/Sao_Paulo">{{_("America/Sao_Paulo")}}</option>
             <option value="Australia/Adelaide">{{_("Australia/Adelaide")}}</option>
             <option value="Australia/Brisbane">{{_("Australia/Brisbane")}}</option>
             <option value="Australia/Broken_Hill">{{_("Australia/Broken_Hill")}}</option>


### PR DESCRIPTION
add missing sao paulo timezone to dropdown list.  note: the list is currently hard-coded.  A story has been created to dynamically generate this list:  https://jira.movember.com/browse/TN-2024