### PR TITLE
TN-1965 set completion date to consent date/time if occurs on current

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1689,7 +1689,7 @@ export default (function() {
             },
             setInitManualEntryCompletionDate: function() {
                 this.manualEntry.todayObj = this.modules.tnthDates.getTodayDateObj();
-                //set initial completiont date as GMT date/time for today based on user timezone
+                //set initial completion date as GMT date/time for today based on user timezone
                 this.manualEntry.completionDate = this.manualEntry.todayObj.gmtDate;
                 //comparing consent date to completion date without the time element
                 if (this.modules.tnthDates.formatDateString(this.manualEntry.consentDate, "iso-short") === 
@@ -1742,6 +1742,7 @@ export default (function() {
                                 self.manualEntry.consentDate = self.modules.tnthDates.formatDateString(consentItems[0].acceptance_date, "system");
                             }
                         }
+                        //set completion date once consent date/time has been set
                         self.setInitManualEntryCompletionDate();
                     });
                     setTimeout(function() { self.manualEntry.initloading = false;}, 10);

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1687,10 +1687,14 @@ export default (function() {
                     if (callback) { callback(); }
                 }, 1000, self.manualEntryModalVis);
             },
-            setInitManualEntryCompletionDate: function() {
+            setManualEntryDateToToday: function() {
                 this.manualEntry.todayObj = this.modules.tnthDates.getTodayDateObj();
                 //set initial completion date as GMT date/time for today based on user timezone
                 this.manualEntry.completionDate = this.manualEntry.todayObj.gmtDate;
+            },
+            setInitManualEntryCompletionDate: function() {
+                //set initial completion date as GMT date/time for today based on user timezone
+                this.setManualEntryDateToToday();
                 //comparing consent date to completion date without the time element
                 if (this.modules.tnthDates.formatDateString(this.manualEntry.consentDate, "iso-short") === 
                     this.modules.tnthDates.formatDateString(this.manualEntry.completionDate, "iso-short")) {
@@ -1752,9 +1756,12 @@ export default (function() {
                     self.manualEntry.errorMessage = "";
                     self.manualEntry.method = $(this).val();
                     if ($(this).val() === "interview_assisted") {
-                        //if method is interview assisted, reset completion date to GMT date/time for today (or consent date/time if same as today)
-                        self.setInitManualEntryCompletionDate();
+                        //if method is interview assisted, reset completion date to GMT date/time for today
+                        self.setManualEntryDateToToday();
+                        return;
                     }
+                    //paper entry
+                    self.setInitManualEntryCompletionDate();
                 });
 
                 self.__convertToNumericField($("#qCompletionDay, #qCompletionYear"));


### PR DESCRIPTION
Address issue found for https://jira.movember.com/browse/TN-1965
Issue arose for a newly created patient account whose consent date falls on current date/time (today's datetime of patient timezone)
Instead of defaulting to current date/time, completion date should be set to using consent date/time **IF** they are the same.