### PR TITLE
Feature/dockerize site persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ pip-selfcheck.json
 log
 portal/test_uploads
 docker/portal.env
-docker/docker-compose.pb.yaml
+docker/docker-compose.dev.*.yaml
 
 geckodriver.log
 coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ pip-selfcheck.json
 log
 portal/test_uploads
 docker/portal.env
+docker/docker-compose.pb.yaml
 
 geckodriver.log
 coverage.xml

--- a/portal/config/config_persistence.py
+++ b/portal/config/config_persistence.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from flask import current_app
@@ -26,6 +27,10 @@ class ConfigPersistence(ModelPersistence):
             raise ValueError(
                 "didn't find expected 'resourceType': {}".format(
                     SITE_CFG))
+        if not os.access(cfg_file, os.W_OK):
+            logging.warning("Can't write config to {}, skipping".format(
+                cfg_file))
+            return
         with open(cfg_file, 'w') as fp:
             for line in cfg_data['results']:
                 fp.write(line)


### PR DESCRIPTION
site persistence can't write to read only filesystem (such as when running in docker container).  simply log warning if `site.cfg` is not writable.