### PR TITLE
Hotfix original CSV generator function

### DIFF
--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -305,7 +305,8 @@ def questionnaire_status():
             yield ','.join(desired_order) + '\n'  # header row
             for i in items:
                 yield ','.join(
-                    [str(i.get(k, "")) for k in desired_order]) + '\n'
+                    ['"{}"'.format(i.get(k, "")) for k in desired_order]
+                ) + '\n'
 
         # default file base title
         base_name = 'Questionnaire-Timeline-Data'

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -300,22 +300,12 @@ def questionnaire_status():
 
     if request.args.get('format', 'json').lower() == 'csv':
         def gen(items):
-            line = StringIO()
-            writer = csv.writer(line)
-            desired_order = (
-                'user_id', 'study_id', 'status', 'visit',
-                'entry_method', 'site', 'consent')
-            writer.writerow(desired_order)
-            line.seek(0)
-            yield line.read()  # header row
-            line.truncate(0)
-            line.seek(0)
+            desired_order = [
+                'user_id', 'study_id', 'status', 'visit', 'site', 'consent']
+            yield ','.join(desired_order) + '\n'  # header row
             for i in items:
-                writer.writerow([str(i.get(k, "")) for k in desired_order])
-                line.seek(0)
-                yield line.read()
-                line.truncate(0)
-                line.seek(0)
+                yield ','.join(
+                    [str(i.get(k, "")) for k in desired_order]) + '\n'
 
         # default file base title
         base_name = 'Questionnaire-Timeline-Data'


### PR DESCRIPTION
Temp fix for below exception:
```
 Traceback (most recent call last):
   File "/srv/www/eproms.cirg.washington.edu/portal/env/local/lib/python2.7/site-packages/werkzeug/wsgi.py", line 870, in __next__
     return self._next()
   File "/srv/www/eproms.cirg.washington.edu/portal/env/local/lib/python2.7/site-packages/werkzeug/wrappers.py", line 82, in _iter_encoded
     for item in iterable:
   File "/srv/www/eproms.cirg.washington.edu/portal/portal/views/reporting.py", line 308, in gen
     writer.writerow(desired_order)
 TypeError: unicode argument expected, got 'str'
```