### PR TITLE
Fix python build-dependency conflict

### DIFF
--- a/bin/nodejs-wrapper.sh
+++ b/bin/nodejs-wrapper.sh
@@ -31,7 +31,7 @@ setup_python_venv() {
     fi
 
     echo "Creating new Python virtual environment: ${python_venv_path}"
-    virtualenv "${python_venv_path}"
+    python -m virtualenv "${python_venv_path}"
 }
 
 
@@ -51,7 +51,7 @@ setup_node_venv() {
     . "${python_venv_path}/bin/activate"
 
     echo "Installing node_env"
-    pip install nodeenv
+    python -m pip install nodeenv
 
     echo "Creating new virtual environment for NodeJS: ${node_venv_path}"
     nodeenv "${node_venv_path}"

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,8 @@ Maintainer: CIRG, University of Washington <truenth-dev@uw.edu>
 # docs suggest building psycopg2 from source every time for prod
 # http://initd.org/psycopg/docs/install.html#binary-install-from-pypi
 # Todo: investigate using binary in python-psycopg2 debian package
-Build-Depends: debhelper (>= 9), python, dh-virtualenv, libpq-dev, python-dev, python-pip, python-setuptools, python-setuptools-scm, python-wheel
+# Todo: remove python-virtualenv when py3k-only
+Build-Depends: debhelper (>= 9), python, python-virtualenv, dh-virtualenv, libpq-dev, python-dev, python-pip, python-setuptools, python-setuptools-scm, python-wheel
 Standards-Version: 3.9.5
 
 Package: portal

--- a/debian/links
+++ b/debian/links
@@ -8,6 +8,6 @@ opt/venvs/portal/bin/gunicorn usr/bin/gunicorn
 opt/venvs/portal/bin/pybabel usr/bin/pybabel
 
 # helpful for installing dependencies directly into virtual environment
-opt/venvs/portal/bin/pip usr/bin/pip
+# opt/venvs/portal/bin/pip usr/bin/pip
 # opt/venvs/portal/bin/python usr/bin/python
 opt/venvs/portal/bin/remap_envvars.py usr/bin/remap_envvars.py


### PR DESCRIPTION
* Call python modules in interpreter-agnostic way (`python -m $MODULE`)
* Use python2 `virtualenv` to create virtual environments 
  * debian-provided `virtualenv` binary is py3k-only ([see](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=752467))
* Do not set virtual environment pip as system pip