### PR TITLE
Debian virtualenv workaround

### DIFF
--- a/bin/nodejs-wrapper.sh
+++ b/bin/nodejs-wrapper.sh
@@ -31,24 +31,6 @@ setup_python_venv() {
     fi
 
 
-    echo virtualenv debug
-    which virtualenv || true
-    virtualenv --version || true
-    python -m virtualenv --version || true
-    head "$(which virtualenv)" || true
-
-    echo wheels debug
-    ls -lt /usr/share/python-wheels
-
-    echo python debug
-    which python || true
-    python --version || true
-
-    echo pip debug
-    which pip || true
-    pip --version || true
-    pip freeze || true
-
     echo "Creating new Python virtual environment: ${python_venv_path}"
     python -m virtualenv "${python_venv_path}"
 }

--- a/bin/nodejs-wrapper.sh
+++ b/bin/nodejs-wrapper.sh
@@ -32,6 +32,24 @@ setup_python_venv() {
 
     echo "Creating new Python virtual environment: ${python_venv_path}"
     virtualenv "${python_venv_path}"
+
+    echo virtualenv debug
+    which virtualenv || true
+    virtualenv --version || true
+    head "$(which virtualenv)" || true
+
+    echo wheels debug
+    ls -lt /usr/share/python-wheels
+
+    echo python debug
+    which python || true
+    python --version || true
+
+    echo pip debug
+    which pip || true
+    pip --version || true
+    pip freeze || true
+
 }
 
 

--- a/bin/nodejs-wrapper.sh
+++ b/bin/nodejs-wrapper.sh
@@ -30,12 +30,11 @@ setup_python_venv() {
         return
     fi
 
-    echo "Creating new Python virtual environment: ${python_venv_path}"
-    virtualenv "${python_venv_path}"
 
     echo virtualenv debug
     which virtualenv || true
     virtualenv --version || true
+    python -m virtualenv --version || true
     head "$(which virtualenv)" || true
 
     echo wheels debug
@@ -50,6 +49,8 @@ setup_python_venv() {
     pip --version || true
     pip freeze || true
 
+    echo "Creating new Python virtual environment: ${python_venv_path}"
+    python -m virtualenv "${python_venv_path}"
 }
 
 

--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,6 @@ override_dh_virtualenv:
 	# lines preceding `dh_virtualenv` occur before venv creation and pip install
 
 	# Build front-end files
-	find / -name "*.whl" -print
 	# work around virtualenv/pip/urllib3 bug
 	# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=880472
 	# https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1743886

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,7 @@ override_dh_virtualenv:
 	# lines preceding `dh_virtualenv` occur before venv creation and pip install
 
 	# Build front-end files
+	find / -name "*.whl" -print
 	rm -Rfv /usr/share/python-wheels/*
 	bin/build-frontend-files.sh
 

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,10 @@ override_dh_virtualenv:
 
 	# Build front-end files
 	find / -name "*.whl" -print
-	rm -Rfv /usr/share/python-wheels/*
+	# work around virtualenv/pip/urllib3 bug
+	# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=880472
+	# https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1743886
+	python -m pip install --user --upgrade pip
 	bin/build-frontend-files.sh
 
 	# Build front-end translations (JSON) from gettext files (PO)

--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ override_dh_virtualenv:
 	# work around virtualenv/pip/urllib3 bug
 	# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=880472
 	# https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1743886
-	python -m pip install --user --upgrade pip
+	python -m pip install --user --upgrade virtualenv
 	bin/build-frontend-files.sh
 
 	# Build front-end translations (JSON) from gettext files (PO)

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,7 @@ override_dh_virtualenv:
 	# lines preceding `dh_virtualenv` occur before venv creation and pip install
 
 	# Build front-end files
+	rm -Rfv /usr/share/python-wheels/*
 	bin/build-frontend-files.sh
 
 	# Build front-end translations (JSON) from gettext files (PO)


### PR DESCRIPTION
* Invoke python commands in interpreter-agnostic way (`python -m foo bar` vs `foo bar`) 
* Work around [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=880472) in [debian python wheels ](https://packages.debian.org/stretch/python-pip-whl) with virtualenv
* Install latest version of `virtualenv` locally, ignoring [`virtualenv` (py3k) provided by debian package](https://packages.debian.org/stretch/virtualenv)