### PR TITLE
Simplify/Clean-up Build Process

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -36,6 +36,7 @@ echo "Loading debian package-specific defaults..."
 . "/etc/default/${PACKAGE_NAME}"
 PROJECT_DIR="${PROJECT_DIR:-$venv_install_dir}"
 
+# check for required environment variables
 : "${FILE_UPLOAD_DIR?Need to set FILE_UPLOAD_DIR}"
 : "${PERSISTENCE_EXCLUSIONS_DIR?Need to set PERSISTENCE_EXCLUSIONS_DIR}"
 : "${PROJECT_DIR?Need to set PROJECT_DIR}"
@@ -53,7 +54,8 @@ chown --verbose "$RUN_USER:$RUN_USER" \
     "${PERSISTENCE_EXCLUSIONS_DIR}" \
     "${PROJECT_DIR}/var/portal-instance/"
 
-echo "Adding remap_envvars.py wrapper to run at start..."
+# Add script to run before every (bash) shell; see BASH_ENV
+echo "Adding runtime envvar-setting script to shell startup scripts..."
 cat > /etc/profile.d/remap_envvars.sh << 'SCRIPT_CONTENTS'
 #!/bin/sh -e
 echo Remapping database URL to postgresql standard env vars...

--- a/debian/postinst
+++ b/debian/postinst
@@ -56,9 +56,13 @@ chown --verbose "$RUN_USER:$RUN_USER" \
 
 # Add script to run before every (bash) shell; see BASH_ENV
 echo "Adding runtime envvar-setting script to shell startup scripts..."
-cat > /etc/profile.d/remap_envvars.sh << 'SCRIPT_CONTENTS'
+cat > /etc/profile.d/remap_envvars.sh << SCRIPT_CONTENTS
 #!/bin/sh -e
+
+echo Setting run-time environment variables from package defaults...
+. "/etc/default/${PACKAGE_NAME}"
+
 echo Remapping database URL to postgresql standard env vars...
-eval $(remap_envvars.py)
+eval \$(remap_envvars.py)"
 
 SCRIPT_CONTENTS

--- a/debian/rules
+++ b/debian/rules
@@ -27,17 +27,6 @@ override_dh_builddeb:
 	# lines preceding `dh_builddeb` occur after venv creation && `pip install`
 	# but before debian package creation
 
-	# Manually fix paths erroneously pointing to build environment
-	find \
-		'$(VENV_BUILD_DIR)/portal/lib/' \
-		-name easy-install.pth \
-		-exec \
-			sed \
-				--in-place \
-				--expression 's|$(VENV_BUILD_DIR)/|/opt/venvs/|g' \
-				{} \; \
-		-print
-
 
 	# change directory to something other than the original checkout
 	# `flask` commands will ignore given entrypoint (FLASK_APP) otherwise


### PR DESCRIPTION
* Remove old `dh-virtualenv` workaround
* Fix loading of package defaults for `FILE_UPLOAD_DIR`, `PERSISTENCE_EXCLUSIONS_DIR`
