### PR TITLE
Feature/profile assessment list status fix

### DIFF
--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -265,6 +265,16 @@ var Utility = (function() {
         }
         return obj;
     };
+    UtilityObj.prototype.capitalize = function(str) {
+        if (!str) {
+            return "";
+        }
+        const word = [];
+        for(let char of str.split(" ")){
+            word.push(char[0].toUpperCase() + char.slice(1))
+        }
+        return word.join(" ");
+    };
     UtilityObj.prototype.getUrlParameter = function(name) {
         name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
         var regex = new RegExp("[\\?&]" + name + "=([^&#]*)");
@@ -354,3 +364,4 @@ var Utility = (function() {
 export default Utility;
 export var getExportFileName = Utility.getExportFileName; /* expose common functions */
 export var getUrlParameter= Utility.getUrlParameter;
+export var capitalize = Utility.capitalize;

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -271,7 +271,7 @@ var Utility = (function() {
         }
         const word = [];
         for(let char of str.split(" ")){
-            word.push(char[0].toUpperCase() + char.slice(1))
+            word.push(char[0].toUpperCase() + char.slice(1));
         }
         return word.join(" ");
     };

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1507,7 +1507,8 @@ export default (function() {
                             title: i18next.t("Click to view report"),
                             link: reportLink,
                             display: i18next.t(entry.questionnaire.display),
-                            status: i18next.t(entry.status),
+                            //title case the status to allow it to be translated correctly
+                            status: i18next.t(Utility.capitalize(String(entry.status).replace(/[\-\_]/g, " "))),
                             class: (index % 2 !== 0 ? "class='odd'" : "class='even'"),
                             date: self.modules.tnthDates.formatDateString(entry.authored, "iso")
                         });


### PR DESCRIPTION
address https://jira.movember.com/browse/TN-2066

Enforce title-casing of assessment statuses in profile's assessment list section to allow them to be translated correctly 
@ivan-c Ivan, I did try out my changes for both Swiss-German and Portuguese - looked to be working but let me know if you see any issue.