### PR TITLE
Cleanup string extraction tooling

### DIFF
--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -39,7 +39,6 @@ def get_db_strings():
                 msgid = getattr(entry, field_name)
                 if not msgid:
                     continue
-                msgid = '"{}"'.format(re.sub('"', r'\\"', msgid))
                 msgid_map[msgid].add("{model_name}:{field_ref}".format(
                     model_name=model.__name__,
                     field_ref=entry.name,
@@ -58,7 +57,7 @@ def get_static_strings():
         'Expired',
     )
     msgid_map.update({
-        '"{}"'.format(s): {'assessment_status:%s' % s} for s in status_strings
+        s: {'assessment_status:%s' % s} for s in status_strings
     })
 
     enum_options = {
@@ -68,7 +67,7 @@ def get_static_strings():
         for value in enum.enums:
             for function_name in options:
                 value = getattr(value, function_name)()
-            msgid_map['"{}"'.format(value)] = {'{}:{}'.format(enum.name, value)}
+            msgid_map[value] = {'{}:{}'.format(enum.name, value)}
     return msgid_map
 
 

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -40,7 +40,7 @@ def get_db_strings():
                 if not msgid:
                     continue
                 msgid = '"{}"'.format(re.sub('"', r'\\"', msgid))
-                msgid_map[msgid].add("{model_name}: {field_ref}".format(
+                msgid_map[msgid].add("{model_name}:{field_ref}".format(
                     model_name=model.__name__,
                     field_ref=entry.name,
                 ))
@@ -58,8 +58,7 @@ def get_static_strings():
         'Expired',
     )
     msgid_map.update({
-        '"{}"'.format(s):
-            {'assessment_status: %s' % s} for s in status_strings
+        '"{}"'.format(s): {'assessment_status:%s' % s} for s in status_strings
     })
 
     enum_options = {
@@ -69,7 +68,7 @@ def get_static_strings():
         for value in enum.enums:
             for function_name in options:
                 value = getattr(value, function_name)()
-            msgid_map['"{}"'.format(value)] = {'{}: {}'.format(
+            msgid_map['"{}"'.format(value)] = {'{}:{}'.format(
                 enum.name, value)}
     return msgid_map
 

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -45,6 +45,7 @@ def get_db_strings():
                 msgid = getattr(entry, field_name)
                 if not msgid:
                     continue
+                # use model/field name for gettext reference
                 msgid_map[msgid].add("{model_name}:{field_ref}".format(
                     model_name=model.__name__,
                     field_ref=entry.name,
@@ -73,6 +74,7 @@ def get_static_strings():
         for value in enum.enums:
             for function_name in options:
                 value = getattr(value, function_name)()
+            # use enum name/value for gettext reference
             msgid_map[value] = {'{}:{}'.format(enum.name, value)}
     return msgid_map
 

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -24,6 +24,11 @@ from .user import current_user
 
 
 def get_db_strings():
+    """
+    Extract user-facing database strings
+
+    Requires a databases loaded with the latest site-persistence data
+    """
     msgid_map = defaultdict(set)
     i18n_fields = {
         AppText: ('custom_text',),
@@ -48,14 +53,19 @@ def get_db_strings():
 
 
 def get_static_strings():
-    """Manually add strings that are otherwise difficult to extract"""
+    """
+    Extract strings from constants and other static values in code (enums)
+    """
     msgid_map = {}
 
+    # python-native enums
     enums = (OverallStatus, )
     for enum in enums:
         for member in enum:
+            # include enum class name with each value in PO reference
             msgid_map[str(member)] = {'{}:{}'.format(enum.__name__, member)}
 
+    # SQLA (postgres-specific) enums
     SQLA_enum_options = {
         classification_types_enum: ('title',),
     }

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -68,8 +68,7 @@ def get_static_strings():
         for value in enum.enums:
             for function_name in options:
                 value = getattr(value, function_name)()
-            msgid_map['"{}"'.format(value)] = {'{}:{}'.format(
-                enum.name, value)}
+            msgid_map['"{}"'.format(value)] = {'{}:{}'.format(enum.name, value)}
     return msgid_map
 
 

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -16,6 +16,7 @@ from .app_text import AppText
 from .coding import Coding
 from .intervention import Intervention
 from .organization import Organization
+from .overall_status import OverallStatus
 from .questionnaire_bank import QuestionnaireBank, classification_types_enum
 from .research_protocol import ResearchProtocol
 from .role import Role
@@ -49,21 +50,16 @@ def get_db_strings():
 def get_static_strings():
     """Manually add strings that are otherwise difficult to extract"""
     msgid_map = {}
-    status_strings = (
-        'Completed',
-        'Due',
-        'In Progress',
-        'Overdue',
-        'Expired',
-    )
-    msgid_map.update({
-        s: {'assessment_status:%s' % s} for s in status_strings
-    })
 
-    enum_options = {
+    enums = (OverallStatus, )
+    for enum in enums:
+        for member in enum:
+            msgid_map[str(member)] = {'{}:{}'.format(enum.__name__, member)}
+
+    SQLA_enum_options = {
         classification_types_enum: ('title',),
     }
-    for enum, options in enum_options.items():
+    for enum, options in SQLA_enum_options.items():
         for value in enum.enums:
             for function_name in options:
                 value = getattr(value, function_name)()

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -80,22 +80,21 @@ def get_static_strings():
 @babel.localeselector
 def get_locale():
     # confirm request context - not available from celery tasks
-    if not has_request_context():
-        return current_app.config.get("DEFAULT_LOCALE")
+    if has_request_context():
+        if current_user() and current_user().locale_code:
+            return current_user().locale_code
 
-    if current_user() and current_user().locale_code:
-        return current_user().locale_code
-
-    # look for session variable in pre-logged-in state
-    if session.get('locale_code'):
-        return session['locale_code']
-    browser_pref = negotiate_locale(
-        preferred=(
-            l.replace('-', '_') for l in request.accept_languages.values()
-        ),
-        available=(
-            c.code for c in Coding.query.filter_by(system=IETF_LANGUAGE_TAG)
-        ),
-    )
-    if browser_pref:
-        return browser_pref
+        # look for session variable in pre-logged-in state
+        if session.get('locale_code'):
+            return session['locale_code']
+        browser_pref = negotiate_locale(
+            preferred=(
+                l.replace('-', '_') for l in request.accept_languages.values()
+            ),
+            available=(
+                c.code for c in Coding.query.filter_by(system=IETF_LANGUAGE_TAG)
+            ),
+        )
+        if browser_pref:
+            return browser_pref
+    return current_app.config.get("DEFAULT_LOCALE")

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -24,8 +24,8 @@ from .user import current_user
 
 
 def get_db_strings():
-    """
-    Extract user-facing database strings
+    """Extract user-facing database strings
+
 
     Requires a databases loaded with the latest site-persistence data
     """
@@ -54,9 +54,7 @@ def get_db_strings():
 
 
 def get_static_strings():
-    """
-    Extract strings from constants and other static values in code (enums)
-    """
+    """Extract strings from constants and other static values in code (enums)"""
     msgid_map = {}
 
     # python-native enums

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -80,21 +80,22 @@ def get_static_strings():
 @babel.localeselector
 def get_locale():
     # confirm request context - not available from celery tasks
-    if has_request_context():
-        if current_user() and current_user().locale_code:
-            return current_user().locale_code
+    if not has_request_context():
+        return current_app.config.get("DEFAULT_LOCALE")
 
-        # look for session variable in pre-logged-in state
-        if session.get('locale_code'):
-            return session['locale_code']
-        browser_pref = negotiate_locale(
-            preferred=(
-                l.replace('-', '_') for l in request.accept_languages.values()
-            ),
-            available=(
-                c.code for c in Coding.query.filter_by(system=IETF_LANGUAGE_TAG)
-            ),
-        )
-        if browser_pref:
-            return browser_pref
-    return current_app.config.get("DEFAULT_LOCALE")
+    if current_user() and current_user().locale_code:
+        return current_user().locale_code
+
+    # look for session variable in pre-logged-in state
+    if session.get('locale_code'):
+        return session['locale_code']
+    browser_pref = negotiate_locale(
+        preferred=(
+            l.replace('-', '_') for l in request.accept_languages.values()
+        ),
+        available=(
+            c.code for c in Coding.query.filter_by(system=IETF_LANGUAGE_TAG)
+        ),
+    )
+    if browser_pref:
+        return browser_pref

--- a/portal/models/i18n_utils.py
+++ b/portal/models/i18n_utils.py
@@ -316,6 +316,7 @@ def compile_pos():
 
 
 def upsert_to_template_file():
+    """Upsert new strings into existing POT file"""
     db_translatables = get_db_strings()
     if not db_translatables:
         sys.exit("no DB strings extracted")
@@ -335,14 +336,17 @@ def upsert_to_template_file():
             for i, line in enumerate(potlines):
                 if not line.split() or (line.split()[0] != "msgid"):
                     continue
+
                 msgid = line.split(" ", 1)[1].strip()
                 if msgid not in db_translatables:
                     continue
+
                 for location in db_translatables[msgid]:
                     locstring = "# " + location + "\n"
                     if not any(t == locstring for t in potlines[i - 4:i]):
                         potlines.insert(i, locstring)
                 del db_translatables[msgid]
+
             for entry, locations in db_translatables.items():
                 if not entry:
                     continue

--- a/portal/models/i18n_utils.py
+++ b/portal/models/i18n_utils.py
@@ -319,11 +319,6 @@ def upsert_to_template_file(pot_filepath, new_strings):
 
     Existing strings in the POT file will have references combined
     """
-
-    # remove double quotes wrapping every key
-    # todo remove from other helpers
-    new_strings = {new_string[1:-1]: refs for new_string, refs in new_strings.items()}
-
     pot_file = pofile(pot_filepath)
     for new_string, references in new_strings.items():
         new_entry = POEntry(

--- a/portal/models/i18n_utils.py
+++ b/portal/models/i18n_utils.py
@@ -316,7 +316,7 @@ def compile_pos():
 
 
 def upsert_to_template_file():
-    """Upsert new strings into existing POT file"""
+    """Upsert newly extracted strings into existing POT file"""
     db_translatables = get_db_strings()
     if not db_translatables:
         sys.exit("no DB strings extracted")

--- a/portal/models/i18n_utils.py
+++ b/portal/models/i18n_utils.py
@@ -381,6 +381,7 @@ def build_pot_files():
     current_app.logger.debug("messages.pot file generated")
 
     # update .pot file with values not extracted by pybabel
+    # todo: pass set of POEntry
     new_strings = {}
     new_strings.update(get_db_strings())
     new_strings.update(get_static_strings())

--- a/portal/models/i18n_utils.py
+++ b/portal/models/i18n_utils.py
@@ -400,7 +400,7 @@ def smartling_upload():
     build_pot_files()
 
     upload_url = 'https://api.smartling.com/files-api/v2/projects/{}/file'
-    project_id = current_app.config.get("SMARTLING_PROJECT_ID")
+    project_id = current_app.config["SMARTLING_PROJECT_ID"]
     creds = {'bearer_token': smartling_authenticate()}
     for pot_file_path in POT_FILES:
         with open(pot_file_path, 'rb') as potfile:

--- a/portal/models/i18n_utils.py
+++ b/portal/models/i18n_utils.py
@@ -324,7 +324,7 @@ def upsert_to_template_file(pot_filepath, new_strings):
         new_entry = POEntry(
             msgid=new_string,
             # list of (filepath, lineno) tuples
-            occurrences=[ (o, '') for o in references ],
+            occurrences=[(o, '') for o in references],
         )
 
         existing_entry = pot_file.find(new_entry.msgid)
@@ -352,7 +352,7 @@ def fix_references(pot_fpath):
         entry.occurrences = new_occurrences
 
     pot_file.save(pot_fpath)
-    current_app.logger.debug("messages.pot file references fixed")
+    current_app.logger.debug("%s file references fixed", pot_fpath)
 
 
 def build_pot_files():


### PR DESCRIPTION
* Rewrite POT file generation to idiomatic code, with `polib`
* Fix POT file reference format for static & DB strings
  * Use available object metadata as gettext references (translation context)
