### PR TITLE
Prevent gunicorn from blocking on disk access

### DIFF
--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -8,6 +8,12 @@ services:
       # Number of worker processes for handling requests
       # http://docs.gunicorn.org/en/stable/settings.html#workers
       WEB_CONCURRENCY: 4
+      # mount a tmpfs to prevent gunicorn from blocking
+      # http://docs.gunicorn.org/en/stable/faq.html#blocking-os-fchmod
+      GUNICORN_CMD_ARGS: --worker-tmp-dir /run --timeout 90
+    volumes:
+      - target: /run
+        type: tmpfs
     healthcheck:
       test: flask healthcheck
       start_period: 2m

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -8,11 +8,10 @@ services:
       # Number of worker processes for handling requests
       # http://docs.gunicorn.org/en/stable/settings.html#workers
       WEB_CONCURRENCY: 4
-      # mount a tmpfs to prevent gunicorn from blocking
-      # http://docs.gunicorn.org/en/stable/faq.html#blocking-os-fchmod
-      GUNICORN_CMD_ARGS: --worker-tmp-dir /run --timeout 90
+    # mount a tmpfs to prevent gunicorn from blocking
+    # http://docs.gunicorn.org/en/stable/faq.html#blocking-os-fchmod
     volumes:
-      - target: /run
+      - target: /tmp
         type: tmpfs
     healthcheck:
       test: flask healthcheck


### PR DESCRIPTION
See

[How do I avoid Gunicorn excessively blocking in os.fchmod?](http://docs.gunicorn.org/en/stable/faq.html#how-do-i-avoid-gunicorn-excessively-blocking-in-os-fchmod)

[Docker is different: configuring Gunicorn for containers](https://pythonspeed.com/articles/gunicorn-in-docker/)
