### PR TITLE
TN-1983 add missing `entry_method` header to CSV format

### DIFF
--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -215,7 +215,8 @@ def adherence_report(
                 Organization.query.get(org_id).name.replace(' ', '-'))
         results['filename_prefix'] = base_name
         results['column_headers'] = [
-            'user_id', 'study_id', 'status', 'visit', 'site', 'consent']
+            'user_id', 'study_id', 'status', 'visit', 'entry_method', 'site',
+            'consent']
 
     return results
 


### PR DESCRIPTION
Without `entry_method` in CSV column headers, that column was excluded from the report.