### PR TITLE
TN-483 remove inline js from eproms base html file

### DIFF
--- a/portal/eproms/templates/eproms/base.html
+++ b/portal/eproms/templates/eproms/base.html
@@ -118,9 +118,5 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.16/vue.min.js"></script>
 {% endif %}
 {%block additional_scripts %}<!--for any other scripts needed -->{% endblock %}
-<script>
-{% block document_ready -%}
-{%- endblock %}
-</script>
 </body>
 </html>


### PR DESCRIPTION
address part of this story: 
https://jira.movember.com/browse/TN-483

there are a few others but trickier to remove, .e.g portal-wrapper and footer.  will look more in-depth later