### PR TITLE
Build front-end code in isolated stage

### DIFF
--- a/bin/nodejs-wrapper.sh
+++ b/bin/nodejs-wrapper.sh
@@ -31,7 +31,12 @@ setup_python_venv() {
     fi
 
     echo "Creating new Python virtual environment: ${python_venv_path}"
-    virtualenv "${python_venv_path}"
+    if command -v virtualenv; then
+        virtualenv "${python_venv_path}"
+    else
+        python3 -m venv "${python_venv_path}"
+    fi
+
 }
 
 

--- a/bin/nodejs-wrapper.sh
+++ b/bin/nodejs-wrapper.sh
@@ -31,7 +31,7 @@ setup_python_venv() {
     fi
 
     echo "Creating new Python virtual environment: ${python_venv_path}"
-    if command -v virtualenv; then
+    if command -v virtualenv > /dev/null; then
         virtualenv "${python_venv_path}"
     else
         python3 -m venv "${python_venv_path}"

--- a/bin/nodejs-wrapper.sh
+++ b/bin/nodejs-wrapper.sh
@@ -41,6 +41,8 @@ setup_python_venv() {
 
 
 setup_node_venv() {
+    setup_python_venv
+
     # Setup a virtual environment for NodeJS on the given path, if not present
     local default_node_venv_path="${repo_root}/node_env"
     local node_venv_path="${2:-$default_node_venv_path}"
@@ -70,8 +72,6 @@ if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
 fi
 
 # Setup virtual environments
-setup_python_venv
-
 node_venv="${repo_root}/node_env"
 setup_node_venv "" "$node_venv"
 

--- a/bin/nodejs-wrapper.sh
+++ b/bin/nodejs-wrapper.sh
@@ -41,6 +41,11 @@ setup_python_venv() {
 
 
 setup_node_venv() {
+    if command -v npm; then
+        # Exit early if npm already installed
+        return
+    fi
+
     setup_python_venv
 
     # Setup a virtual environment for NodeJS on the given path, if not present
@@ -75,9 +80,11 @@ fi
 node_venv="${repo_root}/node_env"
 setup_node_venv "" "$node_venv"
 
+if [ -f "${node_venv}/bin/activate" ]; then
+    . "${node_venv}/bin/activate"
+    echo "Activating NodeJS virtual environment..."
+fi
 
-echo "Activating NodeJS virtual environment..."
-. "${node_venv}/bin/activate"
 
 echo "Installing NodeJS dependencies..."
 npm --prefix "${repo_root}/portal" install --no-progress --quiet

--- a/debian/rules
+++ b/debian/rules
@@ -16,9 +16,6 @@ VENV_BUILD_DIR = '$(PWD)/debian/portal/opt/venvs'
 override_dh_virtualenv:
 	# lines preceding `dh_virtualenv` occur before venv creation and pip install
 
-	# Build front-end files
-	bin/build-frontend-files.sh
-
 	# Build front-end translations (JSON) from gettext files (PO)
 	bin/build-frontend-translations.sh
 

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ VENV_BUILD_DIR = '$(PWD)/debian/portal/opt/venvs'
 
 override_dh_virtualenv:
 	# lines preceding `dh_virtualenv` occur before venv creation and pip install
-
+	# todo: conditionally build front-end file if necessary (check if any JS bundles exist)
 	dh_virtualenv $(DH_VIRTUALENV_ARGS)
 
 override_dh_builddeb:

--- a/debian/rules
+++ b/debian/rules
@@ -16,9 +16,6 @@ VENV_BUILD_DIR = '$(PWD)/debian/portal/opt/venvs'
 override_dh_virtualenv:
 	# lines preceding `dh_virtualenv` occur before venv creation and pip install
 
-	# Build front-end translations (JSON) from gettext files (PO)
-	bin/build-frontend-translations.sh
-
 	dh_virtualenv $(DH_VIRTUALENV_ARGS)
 
 override_dh_builddeb:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,29 @@
+FROM debian:buster as frontend
+
+
+ENV \
+    DEBIAN_FRONTEND=noninteractive
+
+WORKDIR "$HOME/portal"
+
+# Copy repo into image
+COPY . .
+
+# Squelch superfluous output; apt-get has poor verbosity control
+RUN \
+    apt-get update --quiet > /dev/null && \
+    apt-get install --quiet --quiet --no-install-recommends \
+        python3 \
+        python3-venv \
+        python3-setuptools-scm \
+        python3-wheel \
+        | grep "Setting up" | awk '{print $3 $4}' ORS=' '
+        # only print package names, versions
+
+RUN bin/build-frontend-files.sh
+
+# -----------------------------------------------------------------------------
+
 FROM debian:stretch as builder
 
 ENV \
@@ -14,10 +40,15 @@ RUN \
         git | grep "Setting up" | awk '{print $3 $4}' ORS=' '
         # only print package names, versions
 
-WORKDIR "$HOME/portal"
+WORKDIR "/portal"
 
 # Copy repo into image
 COPY . .
+
+# Copy front-end files built in previous stage
+COPY --from=frontend "/portal/portal/static" "/portal/portal/static"
+COPY --from=frontend "/portal/portal/gil/static" "/portal/portal/gil/static"
+COPY --from=frontend "/portal/portal/eproms/static" "/portal/portal/eproms/static"
 
 # Install build dependencies
 RUN \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,24 +1,9 @@
-FROM debian:buster as frontend
-
-
-ENV \
-    DEBIAN_FRONTEND=noninteractive
+FROM node:10 as frontend
 
 WORKDIR "/portal"
 
 # Copy repo into image
 COPY . .
-
-# Squelch superfluous output; apt-get has poor verbosity control
-RUN \
-    apt-get update --quiet > /dev/null && \
-    apt-get install --quiet --quiet --no-install-recommends \
-        python3 \
-        python3-venv \
-        python3-setuptools-scm \
-        python3-wheel \
-        | grep "Setting up" | awk '{print $3 $4}' ORS=' '
-        # only print package names, versions
 
 RUN bin/build-frontend-files.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,10 @@ FROM node:10 as frontend
 
 WORKDIR "/portal"
 
-# Copy repo into image
-COPY . .
+# Copy required front-end files only
+# preserve partial checkout structure
+COPY bin/ bin/
+COPY portal/ portal/
 
 RUN bin/build-frontend-files.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM debian:buster as frontend
 ENV \
     DEBIAN_FRONTEND=noninteractive
 
-WORKDIR "$HOME/portal"
+WORKDIR "/portal"
 
 # Copy repo into image
 COPY . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN \
 
 RUN bin/build-frontend-files.sh
 
+RUN bin/build-frontend-translations.sh
 # -----------------------------------------------------------------------------
 
 FROM debian:stretch as builder


### PR DESCRIPTION
* Move front-end build process to separate docker stage
* Change `nodejs-wrapper.sh` to pass through commands if `npm` installed already

Todo:

- [ ] Use Makefile functionality to conditionally build front-end files if (bundles) absent