### PR TITLE
Audit Log runtime JS error fix

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1894,7 +1894,7 @@ export default (function() {
                         $("#profileAuditLogErrorMessage").text(i18next.t("No audit log item found."));
                         return false;
                     }
-                    var ww = $(window).width(), fData = [], len = ((ww < 650) ? 20 : (ww < 800 ? 40 : 80));
+                    var ww = $(window).width(), fData = [], len = ((ww < 650) ? 20 : (ww < 800 ? 40 : 80)), errorMessage="";
                     (data.audits).forEach(function(item) {
                         item.by = item.by.reference || "-";
                         var r = /\d+/g;
@@ -1910,6 +1910,7 @@ export default (function() {
                         } catch(e) { //catch error, output to console e.g. URI malformed error. output error to console for debugging purpose
                             console.log("Error decoding auditing comment " + c);
                             console.log(e);
+                            errorMessage = e.message + "" + e.stack;
                         }
                         item.comment = c.length > len ? (c.substring(0, len + 1) + "<span class='second hide'>" + (c.substr(len + 1)) + "</span><br/><sub onclick='{showText}' class='pointer text-muted'>" + i18next.t("More...") + "</sub>") : item.comment;
                         item.comment = (item.comment).replace("{showText}", "(function (obj) {" +
@@ -1922,6 +1923,10 @@ export default (function() {
                         );
                         fData.push(item);
                     });
+                    if (errorMessage) {
+                        //report error if rendering audit log generates runtime JS error
+                        self.modules.tnthAjax.reportError(self.subjectId, "/api/user/" + self.subjectId + "/audit", errorMessage);
+                    }
                     $("#profileAuditLogTable").html("");
                     $("#profileAuditLogTable").bootstrapTable(self.setBootstrapTableConfig({
                         data: fData,

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1904,7 +1904,13 @@ export default (function() {
                         }
                         item.lastUpdated = self.modules.tnthDates.formatDateString(item.lastUpdated, "iso");
                         item.comment = item.comment ? self.escapeHtml(item.comment) : "";
-                        var c = decodeURIComponent(String(item.comment));
+                        var c = String(item.comment);
+                        try {
+                            c = decodeURIComponent(c);
+                        } catch(e) { //catch error, output to console e.g. URI malformed error. output error to console for debugging purpose
+                            console.log("Error decoding auditing comment " + c);
+                            console.log(e);
+                        }
                         item.comment = c.length > len ? (c.substring(0, len + 1) + "<span class='second hide'>" + (c.substr(len + 1)) + "</span><br/><sub onclick='{showText}' class='pointer text-muted'>" + i18next.t("More...") + "</sub>") : item.comment;
                         item.comment = (item.comment).replace("{showText}", "(function (obj) {" +
                             "if (obj) {" +


### PR DESCRIPTION
stumbled on this error while working in my instance:
Runtime JS error, i.e. URI error, malformed URI, generated in audit log display of some user accounts in profile:
example audit entry that throws error: 
`... by SELECT performers.id AS performers_id, performers.reference_txt AS performers_reference_txt, performers.codeable_concept_id AS performers_codeable_concept_id 
FROM performers, observation_performers 
WHERE **%(param_1)s** = observation_performers.observation_id AND performers.id = observation_performers.performer_id with status`  
**%(** when decodeURIComponent function is applied (to decode escaped characters) to it generates the error

try and catch statement is added to catch such error
