### PR TITLE
fix system message display til the end date of the maintenance window

### DIFF
--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -145,16 +145,26 @@ var tnthDates =  { /*global i18next */
     "getGivenDate": function(y, m, d) {
         return "" + y + m + d;
     },
+    "isSystemDate": function(dateString) {
+        /* IOS (8601) date format test */
+        /**
+         * RegExp to test a string for a full ISO 8601 Date
+         * Does not do any sort of date validation, only checks if the string is according to the ISO 8601 spec.
+         *  YYYY-MM-DDThh:mm:ss
+         *  YYYY-MM-DDThh:mm:ssTZD
+         *  YYYY-MM-DDThh:mm:ss.sTZD
+         * @see: https://www.w3.org/TR/NOTE-datetime
+         * @type {RegExp}
+         */
+        var IOSDateTest = /^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(([+-](\d)?\d:\d\d)|Z)?$/i;
+        return IOSDateTest.test(dateString);
+    },
     "formatDateString": function(dateString, format) { //NB For dateString in ISO-8601 format date as returned from server e.g. '2011-06-29T16:52:48'
         if (dateString) {
-            /* IOS (8601) date format test */
-            var IOSDateTest = /^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$/;
             var d = new Date(dateString);
             var day, month, year, hours, minutes, seconds, nd;
-            if (!IOSDateTest && !isNaN(d) && !this.isDateObj(d)) { //note instantiating ios formatted date using Date object resulted in error in IE
-                return "";
-            }
-            if (IOSDateTest.test(dateString)) {
+             /* IOS (8601) date format test */
+            if (this.isSystemDate(dateString)) {
                 //IOS date, no need to convert again to date object, just parse it as is
                 //issue when passing it into Date object, the output date is inconsistent across from browsers
                 var dArray = $.trim($.trim(dateString).replace(/[\.TZ:\-]/gi, " ")).split(" ");
@@ -165,6 +175,9 @@ var tnthDates =  { /*global i18next */
                 minutes = dArray[4] || "0";
                 seconds = dArray[5] || "0";
             } else {
+                if (!this.isDateObj(d)) { //note instantiating ios formatted date using Date object resulted in error in IE
+                    return "";
+                }
                 day = d.getDate();
                 month = d.getMonth() + 1;
                 year = d.getFullYear();

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -342,7 +342,7 @@ var Utility = (function() {
                 document.getElementById(systemMaintenanceElId).classList.add("tnth-hide");
             };
             //date object automatically convert iso date/time to local date/time as it assumes a timezone of UTC if date in ISO format
-            //format dates in system format first, if not already
+            //format dates in system ISO 8601 format first, if not already
             //valid date examples: 2018-06-09T16:00:00Z, 2019-07-09T22:30:00-7:00, 2019-05-24T15:54:14.876Z
             var startDate = new Date(tnthDates.formatDateString(data.MAINTENANCE_WINDOW[0], "system")),
                 endDate = new Date(tnthDates.formatDateString(data.MAINTENANCE_WINDOW[1], "system"));

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -356,8 +356,8 @@ var Utility = (function() {
                 return;
             }
 
-            var hoursTil = hoursDiff(new Date(), endDate); //use end date of the maintenance window
-            if (hoursTil < 0 || isNaN(hoursTil)) { //maintenance window has passed
+            var hoursTilEnd = hoursDiff(new Date(), endDate); //use end date of the maintenance window
+            if (hoursTilEnd < 0 || isNaN(hoursTilEnd)) { //maintenance window has passed
                 hideSystemMaintenanceElement();
                 return;
             }

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -342,16 +342,19 @@ var Utility = (function() {
                 document.getElementById(systemMaintenanceElId).classList.add("tnth-hide");
             };
             //date object automatically convert iso date/time to local date/time as it assumes a timezone of UTC if date in ISO format
-            var startDate = new Date(data.MAINTENANCE_WINDOW[0]), endDate = new Date(data.MAINTENANCE_WINDOW[1]);
+            //format dates in system format first, if not already
+            //valid date examples: 2018-06-09T16:00:00Z, 2019-07-09T22:30:00-7:00, 2019-05-24T15:54:14.876Z
+            var startDate = new Date(tnthDates.formatDateString(data.MAINTENANCE_WINDOW[0], "system")),
+                endDate = new Date(tnthDates.formatDateString(data.MAINTENANCE_WINDOW[1], "system"));
             if (!tnthDates.isDate(startDate)) {
                 //display error in console
-                console.log("invalid start date entry - must be in valid system format: YYYY-MM-DDTHH:MM:SSZ ", data.MAINTENANCE_WINDOW[0]);
+                console.log("invalid start date entry - must be in valid format", data.MAINTENANCE_WINDOW[0]);
                 hideSystemMaintenanceElement();
                 return;
             }
             if (!tnthDates.isDate(endDate)) {
                 //indicate error in console
-                console.log("invalid end date entry - must be in valid system format: YYYY-MM-DDTHH:MM:SSZ ", data.MAINTENANCE_WINDOW[1]);
+                console.log("invalid end date entry - must be in valid format", data.MAINTENANCE_WINDOW[1]);
                 hideSystemMaintenanceElement();
                 return;
             }


### PR DESCRIPTION
https://jira.movember.com/browse/TN-2137

- use **end date** of system maintenance window to allow system maintenance message to display until the end of the window (currently the message goes away when the start date of the maintenance window hits).
- added support for entries of other ISO 8601 formats, e.g. 2018-06-09T16:00:00Z, 2019-07-09T22:30:00-7:00, 2019-05-24T15:54:14.876Z
- add invalid date check for start/end date entries for the system maintenance window