### PR TITLE
TN-2138 fix copyright year to correctly reflect that set by configuration

### DIFF
--- a/portal/static/js/src/modules/Global.js
+++ b/portal/static/js/src/modules/Global.js
@@ -197,10 +197,14 @@ export default { /*global $ i18next */ /*initializing functions performed only o
         var configSuffix = "COPYRIGHT_YEAR";
         var stCopyRight = sessionStorage.getItem("config_"+configSuffix);
         if (stCopyRight) {
-            callback({configSuffix : stCopyRight});
+            let copyrightObject = {};
+             //specifically set property key of object via variable, otherwise it will be interpreted literally as string
+             //caveat for setting object key via variable: https://stackoverflow.com/questions/11508463/javascript-set-object-key-by-variable
+            copyrightObject[configSuffix] = stCopyRight;
+            callback(copyrightObject);
             return;
         }
-        Utility.sendRequest("/api/settings/"+configSuffix,false, function(data) {
+        Utility.ajaxRequest("/api/settings/"+configSuffix, false, function(data) {
             if (data && data.hasOwnProperty(configSuffix)) {
                 sessionStorage.setItem("config_"+configSuffix, data[configSuffix]);
             }
@@ -228,7 +232,7 @@ export default { /*global $ i18next */ /*initializing functions performed only o
             var userLocale = self.getUserLocale(), footerElements = $("#homeFooter .copyright");
             var copyright_year = new Date().getFullYear();
             self.getCopyrightYear(function(data) {
-                if (data && data.COPYRIGHT_YEAR) {
+                if (data && data.hasOwnProperty("COPYRIGHT_YEAR")) {
                     copyright_year = data.COPYRIGHT_YEAR;
                 }
                 var getContent = (country_code, copyright_year) => {

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -1110,7 +1110,7 @@ select:not([multiple]) {
     width: 40%;
   }
   .copyright {
-    line-height: 1.25;
+    line-height: 1.5;
   }
   .logo-container {
     text-align: right;


### PR DESCRIPTION
https://jira.movember.com/browse/TN-2138

Fix copyright year in footer to correctly reflect that set by configuration
Fix incorrect interpretation of object key set via variable by browser (object key set by variable was interpreted literally as string)