### PR TITLE
TN-2143 exercise and diet fix unapplied stylesheet issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ coverage.xml
 *.mo
 
 # generated CSS files
-portal/*/static/css/*.css
 portal/static/css/*.css
 
 # nodeJS virtual environment and files


### PR DESCRIPTION
Fixes [TN-2143](https://jira.movember.com/browse/TN-2143): currently exercise and diet page is not styled in Production
* remove `.gitignore` (ie [generated `.dockerignore` rule](https://github.com/uwcirg/truenth-portal/blob/develop/.gitignore#L38-L40)) rule