### PR TITLE
Use python3 venv module for packaging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,12 +35,6 @@ unit_tests:
     TOXENV: py3
   <<: *unit_test_definition
 
-unit_tests-python2:
-  variables:
-    TOXENV: py27
-  <<: *unit_test_definition
-  image: python:2.7
-
 docgen_test:
   variables:
     TOXENV: docs

--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: CIRG, University of Washington <truenth-dev@uw.edu>
 # docs suggest building psycopg2 from source every time for prod
 # http://initd.org/psycopg/docs/install.html#binary-install-from-pypi
 # Todo: investigate using binary in python-psycopg2 debian package
+# Todo: remove all python2 dependencies when dh-virtualenv is python3 by default
 Build-Depends: debhelper (>= 9), python3, dh-virtualenv, libpq-dev, python3-dev, python3-pip, python3-setuptools, python3-setuptools-scm, python3-venv, python3-wheel
 Standards-Version: 3.9.5
 

--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,7 @@
 DH_VIRTUALENV_ARGS = \
 	--requirements='requirements.prod.txt' \
 	--python='/usr/bin/python3' \
+	--preinstall=wheel \
 	--extra-pip-arg='--progress-bar=off' \
 	--extra-pip-arg='--quiet'
 

--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,7 @@
 DH_VIRTUALENV_ARGS = \
 	--requirements='requirements.prod.txt' \
 	--python='/usr/bin/python3' \
+	--builtin-venv \
 	--preinstall=wheel \
 	--extra-pip-arg='--progress-bar=off' \
 	--extra-pip-arg='--quiet'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch as builder
+FROM debian:buster as builder
 
 ENV \
     ARTIFACT_DIR=/tmp/artifacts \
@@ -36,7 +36,7 @@ RUN \
 
 # -----------------------------------------------------------------------------
 
-FROM debian:stretch as production
+FROM debian:buster as production
 
 ENV \
     ARTIFACT_DIR=/tmp/artifacts \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ ENV \
     RUN_USER=www-data
 
 # Install locally from $ARTIFACT_DIR by default
-ARG debian_sources_entry="deb file:${ARTIFACT_DIR} ./"
+ARG debian_sources_entry="deb [trusted=yes] file:${ARTIFACT_DIR} ./"
 
 RUN echo $debian_sources_entry > /etc/apt/sources.list.d/truenth-portal.list
 
@@ -54,7 +54,7 @@ COPY --from=builder "${ARTIFACT_DIR}" "${ARTIFACT_DIR}"
 
 RUN \
     apt-get update --quiet > /dev/null && \
-    apt-get install --quiet --quiet --allow-unauthenticated portal && \
+    apt-get install --quiet --quiet portal && \
     rm --force --recursive --verbose "${ARTIFACT_DIR}"
 
 ENV \

--- a/manage.py
+++ b/manage.py
@@ -10,7 +10,6 @@ import alembic.config
 import click
 from flask import url_for
 from flask_migrate import Migrate
-from past.builtins import basestring
 import redis
 import requests
 from sqlalchemy import func
@@ -366,7 +365,7 @@ def config(config_key):
         return
     print(json.dumps(
         # Skip un-serializable values
-        {k: v for k, v in app.config.items() if isinstance(v, basestring)},
+        {k: v for k, v in app.config.items() if isinstance(v, str)},
         indent=2,
     ))
 

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -5,7 +5,6 @@ import jsonschema
 
 from flask import current_app, url_for
 from flask_swagger import swagger
-from past.builtins import basestring
 from sqlalchemy import or_
 from sqlalchemy.dialects.postgresql import ENUM, JSONB
 
@@ -734,7 +733,7 @@ def generate_qnr_csv(qnr_bundle):
                     column = csv_null_value if column is None else column
 
                     # Handle JSON column escaping/enclosing
-                    if not isinstance(column, basestring):
+                    if not isinstance(column, str):
                         column = json.dumps(column).replace('"', '""')
                     row.append('"' + column + '"')
 

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -16,7 +16,6 @@ from flask_babel import gettext as _
 from flask_login import current_user as flask_login_current_user
 from flask_user import UserMixin, _call_or_get
 from fuzzywuzzy import fuzz
-from past.builtins import basestring
 from sqlalchemy import UniqueConstraint, and_, func, or_
 from sqlalchemy.dialects.postgresql import ENUM
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -459,7 +458,7 @@ class User(db.Model, UserMixin):
         # Called in different contexts - only compare string
         # value if it's a base string type, as opposed to when
         # its being used in a query statement (email.ilike('foo'))
-        if isinstance(self._email, basestring):
+        if isinstance(self._email, str):
             if self._email.startswith(INVITE_PREFIX):
                 # strip the invite prefix for UI
                 return self._email[len(INVITE_PREFIX):]

--- a/portal/models/value_quantity.py
+++ b/portal/models/value_quantity.py
@@ -1,5 +1,3 @@
-from past.builtins import basestring
-
 from ..database import db
 
 
@@ -23,7 +21,7 @@ class ValueQuantity(db.Model):
             try:
                 self.value = int(value) != 0
             except (TypeError, ValueError) as e:
-                if value is None or isinstance(value, basestring):
+                if value is None or isinstance(value, str):
                     pass
                 else:
                     raise e

--- a/portal/views/crossdomain.py
+++ b/portal/views/crossdomain.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from functools import update_wrapper
 
 from flask import current_app, make_response, request
-from past.builtins import basestring
 
 from ..models.client import validate_origin
 
@@ -45,7 +44,7 @@ def crossdomain(
     """
 
     def get_headers():
-        if headers is not None and not isinstance(headers, basestring):
+        if headers is not None and not isinstance(headers, str):
             return ', '.join(x.upper() for x in headers)
         return headers
 
@@ -59,7 +58,7 @@ def crossdomain(
     def get_origin():
         """Given origin used blind, request.origin requires validation"""
         if origin:
-            if not isinstance(origin, basestring):
+            if not isinstance(origin, str):
                 return ', '.join(origin)
             return origin
 

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -9,7 +9,6 @@ import urllib
 
 from flask_swagger import swagger
 from flask_webtest import SessionScope
-from past.builtins import basestring
 from swagger_spec_validator import validate_spec_url
 
 from portal.config.config import TestConfig
@@ -179,7 +178,7 @@ class TestPortal(TestCase):
         body = message.style_message(message.body)
         assert 'DOCTYPE' in body
         assert 'style' in body
-        assert isinstance(body, basestring)
+        assert isinstance(body, str)
 
         self.login()
         response = self.client.get('/invite/{0}'.format(message.id))


### PR DESCRIPTION
* Use `venv` module with [dh-virtualenv](https://github.com/spotify/dh-virtualenv) to create debian-packaged virtual environment
  * currently uses `virtualenv` binary
* Switch to new debian (buster) images
  * work around pip bootstrapping issues (see #3201)
* Remove py2/3 compatibility code(`past.basestring`)
* Assume local repo trusted when installing portal debian package
