### PR TITLE
TN-2054 remove invite roles on new idp

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1239,6 +1239,13 @@ class User(db.Model, UserMixin):
             role_list=[role for role in self.roles if role not in role_list],
             acting_user=acting_user)
 
+    def remove_pre_registered_roles(self):
+        non_registered_roles = current_app.config['PRE_REGISTERED_ROLES']
+        self.update_roles(
+            [role for role in self.roles if role.name not in
+             non_registered_roles],
+            acting_user=self)
+
     def update_roles(self, role_list, acting_user):
         """Update user's roles
 
@@ -1540,11 +1547,7 @@ class User(db.Model, UserMixin):
         self.merge_with(registered_user.id)
 
         # remove special roles from invited user, if present
-        non_registered_roles = current_app.config['PRE_REGISTERED_ROLES']
-        self.update_roles(
-            [role for role in self.roles if role.name not in
-             non_registered_roles],
-            acting_user=self)
+        self.remove_pre_registered_roles()
 
         # delete temporary registered user account
         registered_user.delete_user(acting_user=self)

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -222,6 +222,10 @@ def login_user_with_provider(request, provider):
                 subject_id=user.id,
                 context='login'
             )
+            # Potential path for invited users, now coming in with
+            # matching email from external IdP.  Clear any pre-registered
+            # roles if found.
+            user.remove_pre_registered_roles()
         else:
             # This user has never logged in before.
             # Create a new entry in the user table.


### PR DESCRIPTION
Should a pre-registered user login via external IdPs and have a matching email, we need to recognize this as a registered event and remove pre-registered roles.