### PR TITLE
initial queries birthday validation fix

### DIFF
--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -8,7 +8,7 @@ var tnthDates =  { /*global i18next */
         d = parseInt(d);
         y = parseInt(y);
         var errorField = $("#" + errorFieldId);
-        if (!m || !d || !/(19|20)\d{2}/.test(y)) {  /* prevent premature validation until year has been entered */
+        if (!m || !d || !/\d{4}/.test(y)) {  /* prevent premature validation until year has been entered */
             errorField.html("");
             return false;
         }

--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -277,7 +277,7 @@
               </div>
             </div>
             <div class="help-block with-errors"></div>
-            <span id="errorbirthday" class="help-block tnth-hide custom-error"></span>
+            <span id="errorbirthday" class="help-block custom-error"></span>
         </div>
       </div>
   {%- endmacro %}


### PR DESCRIPTION
It was found that entering future date during initial queries doesn't allow user to continue but no error message is displayed to indicate as such.

Fixes include:
allow error message to display when birthday validation failed by removing css class that hides the error message container
allow message for validation error against future date to display (after entering 4 digits)