### PR TITLE
TN-2110 SR RCT patients & partners, remove associated auth_providers

### DIFF
--- a/portal/migrations/versions/c242e22f5a47_.py
+++ b/portal/migrations/versions/c242e22f5a47_.py
@@ -48,6 +48,12 @@ def upgrade():
             email=email, id=r[0])
         changed_user_ids.append(r[0])
 
+    # remove any associated auth_provider rows
+    if changed_user_ids:
+        conn.execute(
+            text("DELETE FROM auth_providers WHERE user_id IN :user_ids"),
+            user_ids=tuple(changed_user_ids))
+
     # add audit data
     now = datetime.utcnow()
     version = lookup_version()


### PR DESCRIPTION
Minor extension to the migration for TN-2110, now removing any associated auth_provider rows to close Google & FB backdoor.

NB - it migration c242e22f5a47 was already run, downgrade first to up pick this change. 