### PR TITLE
TN-2163 user's QB timeline requires invalidation on assessment update.

### DIFF
--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -870,6 +870,7 @@ def assessment_update(patient_id):
         context='assessment',
     )
     response.update({'message': 'questionnaire response updated successfully'})
+    invalidate_users_QBT(patient.id)
     return jsonify(response)
 
 


### PR DESCRIPTION
Force a qb_timeline cache update on a assessment PUT.
