### PR TITLE
TN-2177 filter out user_documents w/o intervention_id

### DIFF
--- a/portal/templates/admin/patients_by_org.html
+++ b/portal/templates/admin/patients_by_org.html
@@ -92,7 +92,7 @@
                         <td class="rowlink-skip text-center reports-field {%if patient.staff_html() %}staff-html{% endif %}">{%-if patient.staff_html() -%}<div class="btn btn-tnth-primary staff-html">{{ patient.staff_html() | safe }}</div>{%-endif-%}
                             {% if not patient.deleted and patient.documents %}
                               <div class="intervention-btn-container">
-                                {% for doc in patient.documents.distinct('intervention_id').filter_by(document_type='PatientReport') | sort(attribute='intervention_id') %}{% if doc.intervention %}<a class="btn btn-tnth-primary btn-report btn-report-{{loop.index}}" data-patient-id="{{patient.id}}" data-document-type="{{doc.intervention.description}}">{% if doc.intervention.description == 'Symptom Tracker' %}{{_('ST')}}{% else %}{{ _('DS')}}{% endif %}</a>{% endif %}{% endfor %}
+                                {% for doc in patient.documents.distinct('intervention_id').filter_by(document_type='PatientReport') | selectattr('intervention_id') | sort(attribute='intervention_id') %}{% if doc.intervention %}<a class="btn btn-tnth-primary btn-report btn-report-{{loop.index}}" data-patient-id="{{patient.id}}" data-document-type="{{doc.intervention.description}}">{% if doc.intervention.description == 'Symptom Tracker' %}{{_('ST')}}{% else %}{{ _('DS')}}{% endif %}</a>{% endif %}{% endfor %}
                               </div>
                             {% endif %}
                         </td>


### PR DESCRIPTION
unnoticed till py3, we were including nulls in the sort filter used to determine if a user_document came from ST or DS.

add another filter so only the user_documents with a defined intervention_id are included for comparison.