### PR TITLE
Assessment List/Report: Fix date display issue in IE

### DIFF
--- a/portal/static/js/src/components/AssessmentReport.vue
+++ b/portal/static/js/src/components/AssessmentReport.vue
@@ -78,21 +78,7 @@
                 });
                 entry = entry[0] || entries[0];
                 self.caption.title = i18next.t(entries[0].questionnaire.display);
-                var lastUpdatedDateObj = new Date(sessionAuthoredDate);
-                if (tnthDates.isDateObj(lastUpdatedDateObj)) { //make sure the date is valid before formatting it
-                    self.caption.lastUpdated = new Date(lastUpdatedDateObj.toUTCString().slice(0, -4));
-                    self.caption.lastUpdated = self.caption.lastUpdated.toLocaleDateString("en-GB", { //use native date function
-                        day: "numeric",
-                        month: "short",
-                        year: "numeric",
-                        hour: "2-digit",
-                        minute: "2-digit",
-                        second: "2-digit"
-                    });
-
-                } else {
-                    self.caption.lastUpdated = sessionAuthoredDate; //display the date/time as is
-                }
+                self.caption.lastUpdated = tnthDates.setUTCDateToLocaleDateString(sessionAuthoredDate);
                 self.caption.timezone = i18next.t("GMT, Y-M-D");
                 (entry.group.question).forEach(function(entry) {
                     var q = (entry.text ? entry.text.replace(/^[\d\w]{1,3}\./, "") : ""),

--- a/portal/static/js/src/components/AssessmentReport.vue
+++ b/portal/static/js/src/components/AssessmentReport.vue
@@ -93,7 +93,7 @@
                     });
 
                 } else {
-                    self.caption.lastUpdated = sessionAuthoredDate;
+                    self.caption.lastUpdated = sessionAuthoredDate; //display the date/time as is
                 }
                 self.caption.timezone = i18next.t("GMT, Y-M-D");
                 (entry.group.question).forEach(function(entry) {

--- a/portal/static/js/src/components/AssessmentReport.vue
+++ b/portal/static/js/src/components/AssessmentReport.vue
@@ -35,6 +35,7 @@
 </template>
 <script>
     import AssessmentReportData from "../data/common/AssessmentReportData.js";
+    import tnthDates from "../modules/TnthDate.js";
 	export default {
     /* global i18next */
     data: function() {
@@ -61,6 +62,8 @@
                 url: "/api/patient/" + this.userId + "/assessment/" + this.instrumentId
             }).done(function(data) {
                 var sessionAuthoredDate = $("#_report_authored_date").val();
+                console.log("date: ", sessionAuthoredDate);
+                ///
                 self.errorMessage = "";
                 if (data.error) {
                     self.errorMessage = self.serverError;
@@ -78,15 +81,20 @@
                 entry = entry[0] || entries[0];
                 self.caption.title = i18next.t(entries[0].questionnaire.display);
                 var lastUpdatedDateObj = new Date(sessionAuthoredDate);
-                self.caption.lastUpdated = new Date(lastUpdatedDateObj.toUTCString().slice(0, -4));
-                self.caption.lastUpdated = self.caption.lastUpdated.toLocaleDateString("en-GB", { //use native date function
-                    day: "numeric",
-                    month: "short",
-                    year: "numeric",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    second: "2-digit"
-                });
+                if (tnthDates.isDateObj(lastUpdatedDateObj)) { //make sure the date is valid before formatting it
+                    self.caption.lastUpdated = new Date(lastUpdatedDateObj.toUTCString().slice(0, -4));
+                    self.caption.lastUpdated = self.caption.lastUpdated.toLocaleDateString("en-GB", { //use native date function
+                        day: "numeric",
+                        month: "short",
+                        year: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        second: "2-digit"
+                    });
+
+                } else {
+                    self.caption.lastUpdated = sessionAuthoredDate;
+                }
                 self.caption.timezone = i18next.t("GMT, Y-M-D");
                 (entry.group.question).forEach(function(entry) {
                     var q = (entry.text ? entry.text.replace(/^[\d\w]{1,3}\./, "") : ""),

--- a/portal/static/js/src/components/AssessmentReport.vue
+++ b/portal/static/js/src/components/AssessmentReport.vue
@@ -62,8 +62,6 @@
                 url: "/api/patient/" + this.userId + "/assessment/" + this.instrumentId
             }).done(function(data) {
                 var sessionAuthoredDate = $("#_report_authored_date").val();
-                console.log("date: ", sessionAuthoredDate);
-                ///
                 self.errorMessage = "";
                 if (data.error) {
                     self.errorMessage = self.serverError;

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -176,7 +176,7 @@ var tnthDates =  { /*global i18next */
                 seconds = dArray[5] || "0";
             } else {
                 if (!this.isDateObj(d)) { //note instantiating ios formatted date using Date object resulted in error in IE
-                    return "";
+                    return dateString; //return dateString as is without any parsing
                 }
                 day = d.getDate();
                 month = d.getMonth() + 1;

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -145,6 +145,31 @@ var tnthDates =  { /*global i18next */
     "getGivenDate": function(y, m, d) {
         return "" + y + m + d;
     },
+    /*
+     *  given a UTC date string, converted to locale/language sensitive date string
+     */
+    "setUTCDateToLocaleDateString": function(utcDateString, params) {
+        if (!utcDateString) {
+            return "";
+        }
+        var dateObj = new Date(utcDateString);
+        if (!this.isDateObj(dateObj)) {
+            return utcDateString; //return date string as is without re-formattiing
+        }
+        if (!params) {
+            params = { //date format parameters
+                day: "numeric",
+                month: "short",
+                year: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+                second: "2-digit"
+            };
+        }
+        var reformattedLocaleDateString = new Date(dateObj.toUTCString().slice(0, -4));
+        reformattedLocaleDateString = reformattedLocaleDateString.toLocaleDateString("en-GB", params); //native Javascript date function, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
+        return reformattedLocaleDateString;
+    },
     "isSystemDate": function(dateString) {
         /* IOS (8601) date format test */
         /**


### PR DESCRIPTION
Found issue in IE when displaying assessment date:
allow IE to display assessment authored date as is without re-formatting if parsing error occurred

Fixes include:
 - let TnthDate date module returns date string as is instead of an empty string when parsing of date string failed
- display assessment report date string as is if parsing error occurred