### PR TITLE
TN-2197 py3 version of SMTPHandler renamed attribute `timeout`.

### DIFF
--- a/portal/logs.py
+++ b/portal/logs.py
@@ -32,7 +32,7 @@ class SSLSMTPHandler(SMTPHandler):
             smtp_config = {
                 'host': self.mailhost,
                 'port': port,
-                'timeout': self._timeout,
+                'timeout': self.timeout,
             }
             # todo: make `use_ssl` a proper attribute
             if hasattr(self, 'use_ssl') and self.use_ssl:


### PR DESCRIPTION
This change should enable us to see error emails again.