### PR TITLE
TN-2200 celery report generation doesn't have a request context.

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -334,9 +334,10 @@ class QNR_results(object):
 
         # typically triggered from updating task job - use system
         # as acting user in audits, if no current user is available
+        acting_user = None
         if has_request_context():
             acting_user = current_user()
-        else:
+        if not acting_user:
             acting_user = User.query.filter_by(email='__system__').first()
         for qnr in self.qnrs:
             QuestionnaireResponse.query.get(

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from html.parser import HTMLParser
 import json
 
-from flask import current_app, url_for
+from flask import current_app, has_request_context, url_for
 from flask_swagger import swagger
 import jsonschema
 from sqlalchemy import or_
@@ -334,8 +334,9 @@ class QNR_results(object):
 
         # typically triggered from updating task job - use system
         # as acting user in audits, if no current user is available
-        acting_user = current_user()
-        if not acting_user:
+        if has_request_context():
+            acting_user = current_user()
+        else:
             acting_user = User.query.filter_by(email='__system__').first()
         for qnr in self.qnrs:
             QuestionnaireResponse.query.get(


### PR DESCRIPTION
check for `request_context` before attempting to use, in stack frequently called from celery (where no such request context exists).