### PR TITLE
TN-2202 in py3, dict.keys() returns a non-index-able type.

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -225,7 +225,7 @@ class QuestionnaireResponse(db.Model):
             for answer in combined_answers:
 
                 # Add text answer before coded answer
-                if answer.keys()[0] == 'valueCoding':
+                if list(answer.keys())[0] == 'valueCoding':
 
                     # Prefer text looked up from code over sibling valueString answer
                     text_answer = questionnaire_map.get(
@@ -560,7 +560,7 @@ def consolidate_answer_pairs(answers):
         answers for ease of display
     """
 
-    answer_types = [a.keys()[0] for a in answers]
+    answer_types = [list(a.keys())[0] for a in answers]
 
     # Exit early if assumptions not met
     if (
@@ -572,7 +572,7 @@ def consolidate_answer_pairs(answers):
     filtered_answers = []
     for pair in zip(*[iter(answers)] * 2):
         # Sort so first pair is always valueCoding
-        pair = sorted(pair, key=lambda k: k.keys()[0])
+        pair = sorted(pair, key=lambda k: list(k.keys())[0])
         coded_answer, string_answer = pair
 
         coded_answer['valueCoding']['text'] = string_answer['valueString']
@@ -715,7 +715,7 @@ def generate_qnr_csv(qnr_bundle):
                     answer_data = {'other_text': answer.values()[0]}
 
                     # ...unless nested code (ie valueCode)
-                    if answer.keys()[0] == 'valueCoding':
+                    if list(answer.keys())[0] == 'valueCoding':
                         answer_data.update({
                             'answer_code': answer['valueCoding']['code'],
 


### PR DESCRIPTION
Any attempt to index the results of a dict.keys() call fails on py3 with:

```TypeError: 'dict_keys' object does not support indexing```

Fix by casting any `dict_keys` result to a `list` before attempting an index.