### PR TITLE
TN-2202 in py3, dict.values() returns a non-index-able type.

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -714,7 +714,7 @@ def generate_qnr_csv(qnr_bundle):
             for answer in answers:
                 if answer:
                     # Use first value of answer (most are single-entry dicts)
-                    answer_data = {'other_text': answer.values()[0]}
+                    answer_data = {'other_text': list(answer.values())[0]}
 
                     # ...unless nested code (ie valueCode)
                     if list(answer.keys())[0] == 'valueCoding':


### PR DESCRIPTION
Overlooked a `values()` call, applied the same fix as used for the `keys()` side.