### PR TITLE
fix JS error related to display of audit records

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1911,7 +1911,7 @@ export default (function() {
                         return false;
                     }
                     var ww = $(window).width(), fData = [], len = ((ww < 650) ? 20 : (ww < 800 ? 40 : 80)), errorMessage="";
-                    (data.audits).forEach(function(item) {
+                    (data.audits).forEach(function(item, itemIndex) {
                         item.by = item.by.reference || "-";
                         var r = /\d+/g;
                         var m = r.exec(String(item.by));
@@ -1919,14 +1919,14 @@ export default (function() {
                             item.by = m[0];
                         }
                         item.lastUpdated = self.modules.tnthDates.formatDateString(item.lastUpdated, "iso");
-                        item.comment = item.comment ? self.escapeHtml(item.comment) : "";
+                        item.comment = item.comment ? String(item.comment) : "";
                         var c = String(item.comment);
                         try {
                             c = decodeURIComponent(c);
                         } catch(e) { //catch error, output to console e.g. URI malformed error. output error to console for debugging purpose
                             console.log("Error decoding auditing comment " + c);
                             console.log(e);
-                            errorMessage = e.message + "" + e.stack;
+                            errorMessage = "Audit record #" + itemIndex + " " + e.message + "" + e.stack;
                         }
                         item.comment = c.length > len ? (c.substring(0, len + 1) + "<span class='second hide'>" + (c.substr(len + 1)) + "</span><br/><sub onclick='{showText}' class='pointer text-muted'>" + i18next.t("More...") + "</sub>") : item.comment;
                         item.comment = (item.comment).replace("{showText}", "(function (obj) {" +


### PR DESCRIPTION
address JS error related to display audit log records.  example stack: 
`Received error {'actor': 'user 10518',
 'message': 'Error generated in JS - malformed URI '
            'sequenceinitAuditLogSection/</<@https://truenth-test.cirg.washington.edu/static/js/dist/profile.bundle.js:1:157564\n'
            'initAuditLogSection/<@https://truenth-test.cirg.washington.edu/static/js/dist/profile.bundle.js:1:157322\n'
            'auditLog/<@https://truenth-test.cirg.washington.edu/static/js/dist/profile.bundle.js:1:22962\n'
            'sendRequest/<@https://truenth-test.cirg.washington.edu/static/js/dist/profile.bundle.js:1:1987\n'
            'r.prototype.initWorker/<@https://truenth-test.cirg.washington.edu/static/js/dist/profile.bundle.js:1:36647\n',
 'page_url': '/api/user/11121/audit',
 'subject_id': '11121'}` 

Issue stemmed from frontend code escaping the audit log content _**twice**_.  That is fixed.
Additional change includes:  adding audit record number to each error message generated related to displaying an audit record for ease of debugging later.
