### PR TITLE
TN-2277 handle QNRs w/o identifiers

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -691,13 +691,16 @@ def generate_qnr_csv(qnr_bundle):
     for qnr in qnr_bundle['entry']:
         site_id, site_name = get_site(qnr)
         row_data = {
-            'identifier': qnr['identifier']['value'],
+            'identifier': (
+                qnr['identifier']['value'] if 'identifier' in qnr else None),
             'status': qnr['status'],
             'truenth_subject_id': get_identifier(
                 qnr['subject']['identifier'],
                 use='official'
             ),
-            'author_id': qnr['author']['reference'].split('/')[-1],
+            'author_id': (
+                qnr['author']['reference'].split('/')[-1]
+                if 'author' in qnr else None),
             'site_id': site_id,
             'site_name': site_name,
             # Todo: correctly pick external study of interest


### PR DESCRIPTION
csv exports were failing from QNRs w/o an identifier or author attributes defined.

NB, the identifier in question is used to uniquely identify a QNR - say with an assessment engine session ID, not the questionnaire association as incorrectly assumed in the parent story