### PR TITLE
Feature/frontend export data followups

### DIFF
--- a/portal/static/js/src/components/ExportInstruments.vue
+++ b/portal/static/js/src/components/ExportInstruments.vue
@@ -110,7 +110,9 @@
                 });
             },
             initExportEvent: function() {
-                console.log("export event initiated");
+                /*
+                 * custom UI events associated with exporting data
+                 */
                 let self = this;
                  $("#dataDownloadModal").on("hide.bs.modal", function () {
                     $("#"+self.getInitElementId()).removeAttr("data-export-in-progress");

--- a/portal/static/js/src/components/ExportInstruments.vue
+++ b/portal/static/js/src/components/ExportInstruments.vue
@@ -27,7 +27,7 @@
                         </div>
                         <div id="instrumentsExportErrorMessage" class="error-message"></div>
                         <!-- display export status -->
-                        <ExportDataLoader :initElementId="getInitElementId()" :exportUrl="getExportUrl()"></ExportDataLoader>
+                        <ExportDataLoader :initElementId="getInitElementId()" :exportUrl="getExportUrl()" v-on:initExportCustomEvent="initExportEvent"></ExportDataLoader>
                     </div>
                     <div class="modal-footer">
                         <button class="btn btn-default" id="patientsDownloadButton" :disabled="!hasInstrumentsSelection()" v-text="exportLabel"></button>
@@ -107,6 +107,13 @@
                     self.instruments.dataType = "csv";
                     $("#patientsInstrumentList").addClass("ready");
                     $(this).find("[name='instrument']").prop("checked", false);
+                });
+            },
+            initExportEvent: function() {
+                console.log("export event initiated");
+                let self = this;
+                 $("#dataDownloadModal").on("hide.bs.modal", function () {
+                    $("#"+self.getInitElementId()).removeAttr("data-export-in-progress");
                 });
             },
             setDataType: function (event) {

--- a/portal/static/js/src/components/asyncExportDataLoader.vue
+++ b/portal/static/js/src/components/asyncExportDataLoader.vue
@@ -31,7 +31,7 @@
                 exportTimeElapsed: 0,
                 statusDisplayTimeoutID: 0,
                 arrExportDataTimeoutID: [],
-                maximumPendingTime: 45000,
+                maximumPendingTime: 45000, //allow 45 seconds of PENDING status
                 arrIncompleteStatus: ["PENDING", "PROGRESS", "STARTED"],
                 requestSubmittedDisplay: ExportInstrumentsData["requestSubmittedDisplay"],
                 failedRequestDisplay: ExportInstrumentsData["failedRequestDisplay"]


### PR DESCRIPTION
Address some of the issues I found when testing this story:
https://jira.movember.com/browse/TN-2312

When testing exporting research data while celery worker **is not** running, the UI hangs at PENDING status (API returns PENDING status without progress percentage).
Fix is to add check for long interval PENDING status, and display error message if too much time elapsed at PENDING status
Also, noting that the requests are still being made when the export data modal has been closed.
Fix is to desist request on modal closing via custom initiating UI event.