### PR TITLE
TN-2298 remove other story link from LE main page

### DIFF
--- a/portal/gil/static/js/lived_experience.js
+++ b/portal/gil/static/js/lived_experience.js
@@ -17,9 +17,6 @@ $(document).ready(function() {
       });
     }
     if ($("main").attr("data-section") === "livedexperience") {
-      $("#lnReadMoreStory").addClass("disabled").on("click", function(e) {
-          e.preventDefault();
-          return false;
-      });
+      $("#lnReadMoreStory").hide();
     }
 });

--- a/portal/static/less/gil.less
+++ b/portal/static/less/gil.less
@@ -8155,7 +8155,7 @@ aside {
     .module-wrap--background .module--shift__right,
     .module-wrap--background .module--shift__left {
         z-index: 2;
-        padding: 4% 1% 4% 1%
+        padding: 4% 1.5% 4% 1.5%
     }
 }
 
@@ -8264,7 +8264,7 @@ aside .module-wrap--background .module__head {
 
 aside .module--flex {
     display: flex;
-    justify-content: space-around;
+    justify-content: center;
     max-width: 100%;
     margin: 0 auto;
     flex-wrap: wrap


### PR DESCRIPTION
Per latest feedback to this story:
https://jira.movember.com/browse/TN-2298

- remove "READ OTHER STORIES" link from LE main page
- styling fix of button layout