### PR TITLE
TN-2298 follow fix - use css to hide home link for LE page

### DIFF
--- a/portal/gil/static/js/lived_experience.js
+++ b/portal/gil/static/js/lived_experience.js
@@ -16,7 +16,4 @@ $(document).ready(function() {
           }
       });
     }
-    if ($("main").attr("data-section") === "livedexperience") {
-      $("#lnReadMoreStory").hide();
-    }
 });

--- a/portal/gil/templates/gil/lived-experience.html
+++ b/portal/gil/templates/gil/lived-experience.html
@@ -2,7 +2,7 @@
 {% block title %}{{super()}} {{_("Lived Experience")}}{% endblock %}
 {% block head %} {{super()}}{% endblock %}
 {% block main %}
-    <main class="main main--white lived-experience-main" data-section="livedexperience">
+    <main class="main main--white lived-experience-main home" data-section="livedexperience">
       {{super()}}
       {% block header %}
         <header class="header header--white {%if user%}no-banner{%endif%}">

--- a/portal/gil/templates/gil/lived_experience_base.html
+++ b/portal/gil/templates/gil/lived_experience_base.html
@@ -11,7 +11,7 @@
               <div class="button-callout"><a href="#" class="button button--large button--teal" data-toggle="modal" data-target="#modal-register">{{_("Join Us")}}</a></div>
             {% endif %}
             <div class="button-callout"><a href="{{url_for('.contact')}}" class="button button--large button--teal" id="lnShareYourStory">{{_("Share Your Story")}}</a></div>
-            <div class="button-callout"><a href="{{url_for('.lived_experience')}}" class="button button--large button--teal" id="lnReadMoreStory">{{_("Read More Stories")}}</a></div>
+            <div class="button-callout home-button"><a href="{{url_for('.lived_experience')}}" class="button button--large button--teal" id="lnReadMoreStory">{{_("Read More Stories")}}</a></div>
           </div>
         </div>
       </div>

--- a/portal/static/less/gil.less
+++ b/portal/static/less/gil.less
@@ -8221,7 +8221,11 @@ aside {
         transition: all 150ms ease-in
     }
 }
-
+main.home + aside {
+    .home-button {
+        display: none;
+    }
+}
 @media (min-width:450px) {
     aside .module-wrap--background {
         padding-top: 5%


### PR DESCRIPTION
hide home link on LE main page
Fix includes:
Using css to hide home link button - general css class is used so can be applied to other GIL pages if need to.