### PR TITLE
TN-2322 prevent lastpass plugin from autofilling email field in profile

### DIFF
--- a/portal/static/js/src/modules/Validator.js
+++ b/portal/static/js/src/modules/Validator.js
@@ -37,10 +37,12 @@ var ValidatorObj = { /*global  $ i18next */
                 }
                 if (data.unique) {
                     $("#erroremail").html("").parents(".form-group").removeClass("has-error");
+                    $("#erroremail").removeClass("with-errors");
                     update($el);
                     return true;
                 }
                 $("#erroremail").html(i18next.t("This e-mail address is already in use. Please enter a different address.")).parents(".form-group").addClass("has-error");
+                return false;
             });
         }
         return emailReg.test(emailVal);
@@ -91,7 +93,7 @@ var ValidatorObj = { /*global  $ i18next */
         $("form.to-validate[data-toggle=validator] [data-birthday]").attr("novalidate", true).on(VALIDATION_EVENTS,function() {
             return self.birthdayValidation($("#month").val(), $("#date").val(), $("#year").val(), "errorbirthday"); /* applied to month, day and year fields of birthday group elements */
         });
-        $("form.to-validate[data-toggle=validator] [data-customemail]").attr("novalidate", true).on(VALIDATION_EVENTS, function() {
+        $("form.to-validate[data-toggle=validator] [data-customemail]").attr("novalidate", true).on("change", function() {
             return self.emailValidation($(this));
         });
         $("form.to-validate[data-toggle=validator] [data-htmltags]").attr("novalidate", true).on(VALIDATION_EVENTS, function() {

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -573,7 +573,10 @@ export default (function() {
                         if (!container.hasClass("edit")) {
                             self.fillSectionView(container.attr("data-sections"));
                             self.handleOptionalCoreData();
+                            self.disableInputTextFields();
+                            return;
                         }
+                        self.enableInputTextField(container.find("input[type='text']"));
                     });
                 });
             },
@@ -631,11 +634,32 @@ export default (function() {
                     });
                 });
             },
+            enableInputTextField: function(fields) {
+                if (!fields) {
+                    return false;
+                }
+                let self = this;
+                fields.each(function() {
+                    if (self.isDisableField($(this).attr("data-protected-group"))) {
+                        return true;
+                    }
+                    $(this).attr("disabled", false);
+                });
+            },
+            disableInputTextFields: function(fields) {
+                if (!fields) {
+                    return false;
+                }
+                fields.each(function() {
+                    $(this).attr("disabled", true);
+                });
+            },
             initSections: function(callback) {
                 var self = this, sectionsInitialized = {}, initCount = 0;
                 $("#mainDiv [data-profile-section-id]").each(function() {
                     var sectionId = $(this).attr("data-profile-section-id");
                     if (!sectionsInitialized[sectionId]) {
+                        self.disableInputTextFields($(this).find("input[type='text']"));
                         setTimeout(function() {
                             self.initSection(sectionId);
                         }, initCount += 20);
@@ -967,9 +991,6 @@ export default (function() {
                         self.postDemoData($(this), self.getTelecomData());
                     }
                 });
-                setTimeout(function() { //enable field once data loaded and initialized
-                    $("#email").removeAttr("disabled");
-                }, 500);
             },
             updateEmailVis: function() {
                 var hasError = $("#emailGroup").hasClass("has-error");

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -986,14 +986,14 @@ export default (function() {
                     e.stopPropagation();
                     $("#erroremail").html("");
                 });
-                $("#email").on("postEventUpdate", function() {
+                $("#profileForm").on("postEventUpdate", "#email", function(e) {
                     if (self.updateEmailVis()) { //should only update email if there is no validation error
                         self.postDemoData($(this), self.getTelecomData());
                     }
                 });
             },
             updateEmailVis: function() {
-                var hasError = $("#emailGroup").hasClass("has-error");
+                var hasError = $("#emailGroup").hasClass("has-error") || $("#erroremail").hasClass("with-errors");
                 var emailValue = $("#email").val();
                 if (!hasError) {
                     this.demo.data.email = emailValue;

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -596,6 +596,7 @@ export default (function() {
                         }
                         triggerEvent = triggerEvent + " change";
                         if ($(this).attr("type") === "text") {
+                            $(this).attr("data-lpignore", true); //prevent lasspass icon be drawn inside of input field
                             $(this).on("keypress", function(e) {
                                 e.stopPropagation();
                                 if (e.keyCode === 13) { //account for hitting enter key when updating text field
@@ -966,6 +967,9 @@ export default (function() {
                         self.postDemoData($(this), self.getTelecomData());
                     }
                 });
+                setTimeout(function() { //enable field once data loaded and initialized
+                    $("#email").removeAttr("disabled");
+                }, 500);
             },
             updateEmailVis: function() {
                 var hasError = $("#emailGroup").hasClass("has-error");

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -640,7 +640,8 @@ export default (function() {
                 }
                 let self = this;
                 fields.each(function() {
-                    if (self.isDisableField($(this).attr("data-protected-group"))) {
+                    //do not enable fields that are designated to be disabled (e.g. protected fields as those from MedidataRave)
+                    if (self.isDisableField($(this).attr("data-protected-fieldid"))) {
                         return true;
                     }
                     $(this).attr("disabled", false);

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -138,7 +138,7 @@ body {
 }
 @media (min-width: 768px) {
   .save-loader-wrapper {
-    min-height: 8px;
+    min-height: 12px;
   }
 }
 

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -174,7 +174,7 @@
 {% macro profileName(person, isFocus=False) -%}
     <div class="form-group profile-name-label"><label>{{ _("Name") }}</label></div>
     <div class="row profile-section name-section" data-profile-section-id="name">
-        <div id="firstNameContainer" class="col-lg-5 col-md-6 col-sm-4 col-xs-10 first-name-container" data-loader-container="true">
+        <div id="firstNameContainer" class="col-lg-5 col-md-5 col-sm-4 col-xs-10 first-name-container" data-loader-container="true">
             <div id="firstNameGroup" class="form-group float-input-label">
                 <input {{"autofocus" if isFocus}} required="required" data-error="{{ _('First name is required and must not contain invalid characters.') }}" class="form-control float-text" id="firstname" name="firstname" aria-label="{{_('First name')}}" placeholder="{{ _('First Name') }}" value="{{ person.first_name if person and person.first_name }}" type="text"  autocomplete="off" data-htmltags="true" data-error-field="errorfirstname" v-model.lazy="demo.data.name.given"/>
                 <div class="help-block with-errors"></div>
@@ -182,7 +182,7 @@
             </div>
             {{saveLoaderDiv("firstNameContainer")}}
         </div>
-        <div id="lastNameContainer" class="col-lg-5 col-md-6 col-sm-4 col-xs-10 last-name-container" data-loader-container="true">
+        <div id="lastNameContainer" class="col-lg-5 col-md-5 col-sm-4 col-xs-10 last-name-container" data-loader-container="true">
             <div id="lastNameGroup" class="form-group float-input-label">
                 <input required="required" data-error="{{ _('Last name is required and must not contain invalid characters.') }}" class="form-control float-text" id="lastname" name="lastname" aria-label="{{_('Last name')}}" placeholder="{{ _('Last Name') }}" value="{{ person.last_name if person and person.last_name }}" type="text" autocomplete="off" data-error-field="errorlastname" data-htmltags="true" v-model.lazy="demo.data.name.family"/>
                 <div class="help-block with-errors"></div>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -124,7 +124,7 @@
     <div class="form-group profile-section" id="bdGroup" data-profile-section-id="birthday">
         <label id="birthdateLabel" class="profile-birthdate-label">{{ _("Birth Date") }}</label>
         <div class="flex">
-            <div class="flex-item" id="bdDateContainer" data-loader-container="true"><input class="form-control bd-element" id="date" aria-label="{{_('Birth Date')}}" name="birthdayDate" placeholder="DD" data-birthday="true" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Birth date must be valid and in the required format.')}}" data-error-field="errorbirthday" autocomplete="off" data-trigger-event="change" v-model.lazy="demo.data.birthDay" v-bind:disabled="isDisableField('dob')" v-bind:required="!isDisableField('dob')"  data-protected-group="dob" />
+            <div class="flex-item" id="bdDateContainer" data-loader-container="true"><input class="form-control bd-element" id="date" aria-label="{{_('Birth Date')}}" name="birthdayDate" placeholder="DD" data-birthday="true" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Birth date must be valid and in the required format.')}}" data-error-field="errorbirthday" autocomplete="off" data-trigger-event="change" v-model.lazy="demo.data.birthDay" v-bind:disabled="isDisableField('dob')" v-bind:required="!isDisableField('dob')"  data-protected-fieldid="dob" />
             {{saveLoaderDiv("bdDateContainer")}}
             </div>
             <div class="flex-item" id="bdMonthContainer" data-loader-container="true">
@@ -146,7 +146,7 @@
                 {{saveLoaderDiv("bdMonthContainer")}}
             </div>
             <div class="flex-item" id="bdYearContainer" data-loader-container="true">
-                <input class="form-control bd-element" id="year" name="birthdayYear" aria-label="{{_('Birth Year')}}" placeholder="YYYY" pattern = "(19|20)\d{2}" data-birthday="true" type="text" maxlength="4" data-error="{{_('Birth date must be valid and in the required format.')}}" data-error-field="errorbirthday" data-trigger-event="change" autocomplete="off" v-model.lazy="demo.data.birthYear" v-bind:disabled="isDisableField('dob')" v-bind:required="!isDisableField('dob')" data-protected-group="dob"/>
+                <input class="form-control bd-element" id="year" name="birthdayYear" aria-label="{{_('Birth Year')}}" placeholder="YYYY" pattern = "(19|20)\d{2}" data-birthday="true" type="text" maxlength="4" data-error="{{_('Birth date must be valid and in the required format.')}}" data-error-field="errorbirthday" data-trigger-event="change" autocomplete="off" v-model.lazy="demo.data.birthYear" v-bind:disabled="isDisableField('dob')" v-bind:required="!isDisableField('dob')" data-protected-fieldid="dob"/>
                 {{saveLoaderDiv("bdYearContainer")}}
             </div>
         </div>
@@ -1025,7 +1025,7 @@
 {% macro profileStudyID(user) -%}
     <div id="profileStudyIDContainer" class="form-group" data-loader-container="true" data-profile-section-id="identifier">
         <label class="text-muted">{{_("Study ID")}} <span class="text-muted smaller-text optional-display-text">({{ _("Optional") }})</span></label>
-        <input type="text" id="profileStudyId" data-identifier="true" data-systemtype="external_study_id" data-userid="{{user.id if user}}" class="form-control" v-model.lazy="demo.data.studyId" v-bind:disabled="isDisableField('study_id')" data-protected-group="study_id"/>
+        <input type="text" id="profileStudyId" data-identifier="true" data-systemtype="external_study_id" data-userid="{{user.id if user}}" class="form-control" v-model.lazy="demo.data.studyId" v-bind:disabled="isDisableField('study_id')" data-protected-fieldid="study_id"/>
         <div class="help-block with-errors"></div>
         <div id="errorprofileStudyId" class="error-message"></div>
         {{saveLoaderDiv("profileStudyIDContainer")}}

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -276,7 +276,7 @@
 {% macro profileEmail(person) -%}
     <div class="form-group float-input-label profile-section data-update-on-validated" id="emailGroup" data-error-field="erroremail" data-loader-container="true" data-profile-section-id="email">
         <label for="email">{{_("Email Address")}}</label>
-        <input type="text" class="form-control" id="email" name="email" data-save-container-id="emailGroup" placeholder="{{ _('Email Address') }}" value="{{ person.email if person and person.email and person.email != '__no_email__' }}" data-customemail="true" data-error-field="erroremail" {% if person and person.has_role(ROLE.PATIENT.value)%}data-optional="true"{% else %}required{% endif %} />
+        <input type="text" class="form-control" id="email" name="email" disabled data-save-container-id="emailGroup" placeholder="{{ _('Email Address') }}" value="{{ person.email if person and person.email and person.email != '__no_email__' }}" data-customemail="true" data-error-field="erroremail" {% if person and person.has_role(ROLE.PATIENT.value)%}data-optional="true"{% else %}required{% endif %} />
         <div class="help-block with-errors" id="erroremail"></div>
         {{saveLoaderDiv("emailGroup")}}
     </div>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -124,7 +124,7 @@
     <div class="form-group profile-section" id="bdGroup" data-profile-section-id="birthday">
         <label id="birthdateLabel" class="profile-birthdate-label">{{ _("Birth Date") }}</label>
         <div class="flex">
-            <div class="flex-item" id="bdDateContainer" data-loader-container="true"><input class="form-control bd-element" id="date" aria-label="{{_('Birth Date')}}" name="birthdayDate" placeholder="DD" data-birthday="true" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Birth date must be valid and in the required format.')}}" data-error-field="errorbirthday" autocomplete="off" data-trigger-event="change" v-model.lazy="demo.data.birthDay" v-bind:disabled="isDisableField('dob')" v-bind:required="!isDisableField('dob')" />
+            <div class="flex-item" id="bdDateContainer" data-loader-container="true"><input class="form-control bd-element" id="date" aria-label="{{_('Birth Date')}}" name="birthdayDate" placeholder="DD" data-birthday="true" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Birth date must be valid and in the required format.')}}" data-error-field="errorbirthday" autocomplete="off" data-trigger-event="change" v-model.lazy="demo.data.birthDay" v-bind:disabled="isDisableField('dob')" v-bind:required="!isDisableField('dob')"  data-protected-group="dob" />
             {{saveLoaderDiv("bdDateContainer")}}
             </div>
             <div class="flex-item" id="bdMonthContainer" data-loader-container="true">
@@ -146,7 +146,7 @@
                 {{saveLoaderDiv("bdMonthContainer")}}
             </div>
             <div class="flex-item" id="bdYearContainer" data-loader-container="true">
-                <input class="form-control bd-element" id="year" name="birthdayYear" aria-label="{{_('Birth Year')}}" placeholder="YYYY" pattern = "(19|20)\d{2}" data-birthday="true" type="text" maxlength="4" data-error="{{_('Birth date must be valid and in the required format.')}}" data-error-field="errorbirthday" data-trigger-event="change" autocomplete="off" v-model.lazy="demo.data.birthYear" v-bind:disabled="isDisableField('dob')" v-bind:required="!isDisableField('dob')" />
+                <input class="form-control bd-element" id="year" name="birthdayYear" aria-label="{{_('Birth Year')}}" placeholder="YYYY" pattern = "(19|20)\d{2}" data-birthday="true" type="text" maxlength="4" data-error="{{_('Birth date must be valid and in the required format.')}}" data-error-field="errorbirthday" data-trigger-event="change" autocomplete="off" v-model.lazy="demo.data.birthYear" v-bind:disabled="isDisableField('dob')" v-bind:required="!isDisableField('dob')" data-protected-group="dob"/>
                 {{saveLoaderDiv("bdYearContainer")}}
             </div>
         </div>
@@ -276,7 +276,7 @@
 {% macro profileEmail(person) -%}
     <div class="form-group float-input-label profile-section data-update-on-validated" id="emailGroup" data-error-field="erroremail" data-loader-container="true" data-profile-section-id="email">
         <label for="email">{{_("Email Address")}}</label>
-        <input type="text" class="form-control" id="email" name="email" disabled data-save-container-id="emailGroup" placeholder="{{ _('Email Address') }}" value="{{ person.email if person and person.email and person.email != '__no_email__' }}" data-customemail="true" data-error-field="erroremail" {% if person and person.has_role(ROLE.PATIENT.value)%}data-optional="true"{% else %}required{% endif %} />
+        <input type="text" class="form-control" id="email" name="email" data-save-container-id="emailGroup" placeholder="{{ _('Email Address') }}" value="{{ person.email if person and person.email and person.email != '__no_email__' }}" data-customemail="true" data-error-field="erroremail" {% if person and person.has_role(ROLE.PATIENT.value)%}data-optional="true"{% else %}required{% endif %} />
         <div class="help-block with-errors" id="erroremail"></div>
         {{saveLoaderDiv("emailGroup")}}
     </div>
@@ -1025,7 +1025,7 @@
 {% macro profileStudyID(user) -%}
     <div id="profileStudyIDContainer" class="form-group" data-loader-container="true" data-profile-section-id="identifier">
         <label class="text-muted">{{_("Study ID")}} <span class="text-muted smaller-text optional-display-text">({{ _("Optional") }})</span></label>
-        <input type="text" id="profileStudyId" data-identifier="true" data-systemtype="external_study_id" data-userid="{{user.id if user}}" class="form-control" v-model.lazy="demo.data.studyId" v-bind:disabled="isDisableField('study_id')"/>
+        <input type="text" id="profileStudyId" data-identifier="true" data-systemtype="external_study_id" data-userid="{{user.id if user}}" class="form-control" v-model.lazy="demo.data.studyId" v-bind:disabled="isDisableField('study_id')" data-protected-group="study_id"/>
         <div class="help-block with-errors"></div>
         <div id="errorprofileStudyId" class="error-message"></div>
         {{saveLoaderDiv("profileStudyIDContainer")}}


### PR DESCRIPTION
https://jira.movember.com/browse/TN-2322
Noting here that these changes **only** apply to the email field on the profile page
Fix includes:

- Disable text fields on the profile page initially (thus prevents LastPass plugin from autofilling the field on page load) and re-enable them only when Edit button on each section is clicked.
- Fix bug associated with ajax post call being fired off even when validation occurred due to duplicate email address input.

Tested this on Firefox and Chrome with LastPass plugin activated - although I myself have not been able to reproduce auto submission of email address even **before** these changes( I did see email address being auto-filled though) so it'd be good to have someone else try out these changes. 