### PR TITLE
TN-2340 use questionnaire_response.authored in timepoint calculation

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -529,7 +529,8 @@ def aggregate_responses(
                 providers.append(org_ref)
             document["subject"]["careProvider"] = providers
 
-        _, timepoint = qb_status_visit_name(subject.id, encounter.start_time)
+        _, timepoint = qb_status_visit_name(
+            subject.id, questionnaire_response.authored)
         document["timepoint"] = timepoint
 
         # Hack: add missing "resource" wrapper for DTSU2 compliance


### PR DESCRIPTION
questionnaire_response.authored must be used when calculating the visit (timepoint) - encounter.start_time doesn't typically match in paper entry scenarios.