### PR TITLE
Resolve Pytest Conflicts

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -17,7 +17,7 @@ psycopg2-binary==2.8.3
 py==1.8.0                 # via tox
 pygments==2.4.2           # via sphinx
 pyparsing==2.4.1.1          # via packaging
-pytest==4.6.3
+pytest==5.2.2
 pytest-flask==0.15.0
 selenium==3.141.0
 snowballstemmer==2.0.0    # via sphinx

--- a/tests/test_date_tools.py
+++ b/tests/test_date_tools.py
@@ -53,4 +53,4 @@ def test_int_date(app_logger):
     acceptance_date = 1394413200000
     with pytest.raises(BadRequest) as e:
         dt = FHIR_datetime.parse(acceptance_date, 'acceptance date')
-    assert 'acceptance date' in str(e)
+    assert 'acceptance date' in str(e.value)

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -545,7 +545,7 @@ class TestOrganization(TestCase):
         self.shallow_org_tree()
         with pytest.raises(ValueError) as context:
             OrgTree().all_leaves_below_id(0)  # none of the above
-        assert 'not found' in str(context)
+        assert 'not found' in str(context.value)
 
         nodes = OrgTree().all_leaves_below_id(101)
         assert 1 == len(nodes)


### PR DESCRIPTION
update the requirement.dev.txt to reflect the latest pytest version
update the deprecated usage for error message in test_date_tools.py
update the deprecated usage for error message in test_organization.pyw