### PR TITLE
Resolve Validators Conflict

### DIFF
--- a/portal/views/client.py
+++ b/portal/views/client.py
@@ -110,7 +110,7 @@ class ClientEditForm(FlaskForm):
         """Custom validation to handle multiple, space delimited URLs"""
         origins = field.data.split()
         for url in origins:
-            if not url_validation(url, require_tld=False):
+            if not url_validation(url):
                 raise validators.ValidationError("Invalid URL")
 
     def validate_callback_url(form, field):

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ six==1.12.0               # via bcrypt, packaging, python-dateutil, python-memca
 sqlalchemy==1.2.18         # via alembic, flask-sqlalchemy
 swagger-spec-validator==2.4.3
 urllib3==1.25.6             # via requests
-validators==0.10.1 # pyup: <=0.10.1 # pin until require_tld supported again
+validators==0.14.0 # pyup: <=0.10.1 # pin until require_tld supported again
 vine==1.3.0               # via amqp
 werkzeug==0.14.1          # via flask
 wtforms==2.2.1            # via flask-wtf

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -25,11 +25,6 @@ from tests import OAUTH_INFO_PROVIDER_LOGIN, TEST_USER_ID, TestCase
 class TestAuth(TestCase):
     """Auth API tests"""
 
-    def test_require_tld(self):
-        """we need the require_tld arg in validators.url for localhost"""
-        import validators
-        assert validators.url('http://localhost', require_tld=False)
-
     def test_nouser_logout(self):
         """Confirm logout works without a valid user"""
         response = self.client.get('/logout')


### PR DESCRIPTION
update the requirement.txt to reflect the latest validators version
remove the deprecated attribute require_tld in validators.url() for portal/views/client.py
remove the deprecated test require_tld for test_auth.py