### PR TITLE
Bug fix: exempt input fields in manual entry modal from disabling

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -576,6 +576,9 @@ export default (function() {
                             self.disableInputTextFields();
                             return;
                         }
+                        /*  
+                         * enable input text field when in edit view
+                         */
                         self.enableInputTextField(container.find("input[type='text']"));
                     });
                 });
@@ -652,7 +655,12 @@ export default (function() {
                     return false;
                 }
                 fields.each(function() {
-                    $(this).attr("disabled", true);
+                    /*
+                     *  will not disable input field if marked as exempt from disabling
+                     */
+                    if (!$(this).attr("data-exempt-from-disabling")) {
+                        $(this).attr("disabled", true);
+                    }
                 });
             },
             initSections: function(callback) {
@@ -660,6 +668,9 @@ export default (function() {
                 $("#mainDiv [data-profile-section-id]").each(function() {
                     var sectionId = $(this).attr("data-profile-section-id");
                     if (!sectionsInitialized[sectionId]) {
+                        /*
+                         * disabling input text fields within each section
+                         */
                         self.disableInputTextFields($(this).find("input[type='text']"));
                         setTimeout(function() {
                             self.initSection(sectionId);

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1096,10 +1096,10 @@
                                             <label class="text-muted" for="manualEntryDateFieldsContainer">{{_("Questionnaire completion date")}}</label>
                                             <div id="manualEntryDateFieldsContainer" class="flex">
                                                 <div class="flex-item">
-                                                    <input class="form-control" id="qCompletionDay" aria-label="{{_('Completion Day')}}" name="qCompletionDay" placeholder="DD" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Date must be valid and in the required format.')}}" autocomplete="off" data-trigger-event="change" v-model="manualEntry.todayObj.displayDay" required />
+                                                    <input class="form-control" id="qCompletionDay" aria-label="{{_('Completion Day')}}"  data-exempt-from-disabling="true" name="qCompletionDay" placeholder="DD" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Date must be valid and in the required format.')}}" autocomplete="off" data-trigger-event="change" v-model="manualEntry.todayObj.displayDay" required />
                                                 </div>
                                                 <div class="flex-item" id="qCompletionMonthContainer">
-                                                    <select class="form-control" aria-label="{{_('Month')}}" name="qCompletionMonth" id="qCompletionMonth" data-error="{{_('Date must be valid and in the required format.')}}" v-model="manualEntry.todayObj.displayMonth" data-trigger-event="change" required>
+                                                    <select class="form-control" aria-label="{{_('Month')}}" name="qCompletionMonth" id="qCompletionMonth" data-exempt-from-disabling="true" data-error="{{_('Date must be valid and in the required format.')}}" v-model="manualEntry.todayObj.displayMonth" data-trigger-event="change" required>
                                                         <option value="">{{_("Month")}}...</option>
                                                         <option value="01">{{_("January")}}</option>
                                                         <option value="02">{{_("February")}}</option>
@@ -1116,7 +1116,7 @@
                                                     </select>
                                                 </div>
                                                 <div class="flex-item" id="qCompletionYearContainer">
-                                                    <input class="form-control" id="qCompletionYear" name="qCompletionYear" aria-label="{{_('Completion Year')}}" placeholder="YYYY" pattern = "(19|20)\d{2}" type="text" maxlength="4" data-error="{{_('Date must be valid and in the required format.')}}" data-trigger-event="change" autocomplete="off" v-model="manualEntry.todayObj.displayYear" required />
+                                                    <input class="form-control" id="qCompletionYear" name="qCompletionYear" aria-label="{{_('Completion Year')}}" data-exempt-from-disabling="true" placeholder="YYYY" pattern = "(19|20)\d{2}" type="text" maxlength="4" data-error="{{_('Date must be valid and in the required format.')}}" data-trigger-event="change" autocomplete="off" v-model="manualEntry.todayObj.displayYear" required />
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
Address a bug introduced when text input fields on profile page are disabled upon page load to prevent auto-populating from Last Pass plugin.  Text fields are enabled when in edit view (on clicking of edit button).  However, input fields in certain sections (e.g. manual entry modal) should remain editable.

Fix is to add indicator on a text input field, i.e. field attribute, that prevents it from being disabled automatically
