### PR TITLE
TN-2408, TN-2409 force qnr association re-eval

### DIFF
--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -304,6 +304,12 @@ def patient_timeline(patient_id):
 
     purge = request.args.get('purge', False)
     try:
+        # If purge was given special 'all' value, also wipe out associated
+        # questionnaire_response : qb relationships.
+        if purge == 'all':
+            QuestionnaireResponse.purge_qb_relationship(
+                subject_id=patient_id, acting_user_id=current_user().id)
+
         update_users_QBT(patient_id, invalidate_existing=purge)
     except ValueError as ve:
         abort(500, ve.message)

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -942,7 +942,10 @@ def delete_user_consents(user_id):
         comment="Deleted consent agreement", context='consent')
     remove_uc.status = 'deleted'
     # The deleted consent may have altered the cached assessment
-    # status - invalidate this user's data at this time.
+    # status, even the qb assignments - invalidate this user's data at this time.
+    QuestionnaireResponse.purge_qb_relationship(
+        subject_id=user_id, acting_user_id=current_user().id)
+
     invalidate_users_QBT(user_id=user_id)
     db.session.commit()
 

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -942,7 +942,7 @@ def delete_user_consents(user_id):
         comment="Deleted consent agreement", context='consent')
     remove_uc.status = 'deleted'
     # The deleted consent may have altered the cached assessment
-    # status, even the qb assignments - invalidate this user's data at this time.
+    # status, even the qb assignments - force re-eval by invalidating now
     QuestionnaireResponse.purge_qb_relationship(
         subject_id=user_id, acting_user_id=current_user().id)
 


### PR DESCRIPTION
Extend /timeline?purge=all to also remove and therefore force re-eval of QNR->QB associations.
Do the same on a consent deletion.