### PR TITLE
Add library to fix build errors

### DIFF
--- a/portal/package.json
+++ b/portal/package.json
@@ -27,6 +27,7 @@
     "ajv": "^6.10.0",
     "babel-loader": "^8.0.4",
     "clean-css": "^4.2.1",
+    "core-js-compat": "^3.4.7",
     "css-loader": "^3.2.0",
     "del": "^3.0.0",
     "fs": "0.0.1-security",


### PR DESCRIPTION
Add `core-js-compat` to [fix babel build errors](https://stackoverflow.com/questions/59145601/module-build-failed-from-node-modules-babel-loader-lib-index-js-error-cann)