### PR TITLE
fix error reporting for calling organization api to report more detail

### DIFF
--- a/portal/static/js/src/accountCreation.js
+++ b/portal/static/js/src/accountCreation.js
@@ -490,8 +490,11 @@ import {CurrentUserObj} from "./mixins/CurrentUser.js";
             let self = this;
             CurrentUserObj.initCurrentUser(function() {
                 OT.init(function() {
-                    self.getOrgs(self.populateOrgsByRole);
-                    self.handleMedidataRave(CurrentUserObj.topLevelOrgs, CurrentUserObj.isAdminUser());
+                    setTimeout(function() {
+                        //delay a bit to call orgs api after current user info is loaded
+                        this.getOrgs(this.populateOrgsByRole);
+                        this.handleMedidataRave(CurrentUserObj.topLevelOrgs, CurrentUserObj.isAdminUser());
+                    }.bind(self), 150);
                 });
             });
         };

--- a/portal/static/js/src/gil.js
+++ b/portal/static/js/src/gil.js
@@ -675,20 +675,12 @@ module.exports = OrgTool = (function() {
     };
     this.getOrgs = function(userId, sync, callback) {
         var self = this;
-        $.ajax ({
-            type: "GET",
-            url: "/api/organization",
-            async: sync? false : true
-        }).done(function(data) {
-
+        callback = callback || function() {};
+        //use common ajax function, which will retry and report error with detail
+        tnthAjax.getOrgs(userId, {sync: sync}, function(data) {
           $("#fillOrgs").attr("userId", userId);
-
           (self.populateOrgsList).apply(self, [data.entry]);
           self.populateUI();
-          if (callback) {
-            callback();
-          }
-
           $("#modal-org").on("hide.bs.modal", function(e) {
             if (typeof sessionStorage !== "undefined") {
               sessionStorage.setItem("noOrgModalViewed", "true");
@@ -745,11 +737,7 @@ module.exports = OrgTool = (function() {
                   };
               });
           });
-        }).fail(function(xhr) {
-          window.app.global.reportError(userId, "/api/organization", xhr.responseText);
-          if (callback) {
-            callback();
-          }
+          callback(data);
         });
     },
     this.updateOrg = function(userId, callback) {

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -71,10 +71,12 @@ export default { /*global $ */
                     }, 3000); //retry after 3 seconds
                 })(self, url, method, userId, params, callback);
             } else {
-                params.attempts = 0;
                 fieldHelper.showError(targetField);
                 callback({"error": true, "data": xhr});
                 self.sendError(xhr, url, userId, params);
+                //reset attempts after reporting error so we know how many attempts have been made
+                //multiple attempts can signify server not being responsive or busy network
+                params.attempts = 0;
             }
         });
     },


### PR DESCRIPTION
trying to get more detailed information for this type of error related to calling organization API: `Received error {'actor': 'user 10980',
 'message': 'Error generated in JS - no detail available',
 'page_url': '/api/organization',
 'subject_id': '10980'}`

Changes include:
- in GIL, switch to use common ajax function for calling API, so as to get more detail about the call, e.g. retry attempts, parameters sent.
- delay calling organization API on account creation page to allow current user object to finish initialization
- reset ajax call attempts **after** reporting error so we know how many attempts have been made
