### PR TITLE
TN-2287 correct date validation handling for manual entry

### DIFF
--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -4007,7 +4007,7 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
   margin-top: 1em;
   label {
     position: relative;
-    top: 0.35em;
+    top: 2px;
     margin-bottom: 4px;
   }
 }

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1120,10 +1120,10 @@
                                                     <input class="form-control" id="qCompletionYear" name="qCompletionYear" aria-label="{{_('Completion Year')}}" data-exempt-from-disabling="true" placeholder="YYYY" pattern = "(19|20)\d{2}" type="text" maxlength="4" data-error="{{_('Date must be valid and in the required format.')}}" data-trigger-event="change" autocomplete="off" v-model="manualEntry.todayObj.displayYear" required />
                                                 </div>
                                             </div>
-                                        </div>
                                         {% raw %}
-                                            <div id="manualEntryMessageContainer" class="error-message">{{manualEntry.errorMessage}}</div>
+                                            <div id="manualEntryMessageContainer" class="error-message help-block with-errors">{{manualEntry.errorMessage}}</div>
                                         {% endraw %}
+                                        </div>
                                     </div>
                                 </div>
                                 <div class="modal-footer">


### PR DESCRIPTION
Address https://jira.movember.com/browse/TN-2287
Issue: 
In entering completion date for Paper Prom, submission button still remained disabled **after** correcting an invalid date entry.

Changes include

- clear error message after incorrect date entry has been corrected
- add bootstrap error css class to input validation
- remove redundant code for validating date