### PR TITLE
TN-2417 provide ugly workaround to failed query

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -340,15 +340,41 @@ class QNR_results(object):
             ).filter(
                 QuestionnaireResponse.qb_iteration == self.qb_iteration)
         self._qnrs = []
+        requery = False
         for qnr in query:
+            if qnr.instrument_id is None:
+                current_app.logger.warning(
+                    "QNR {} query returned no instrument".format(qnr.id))
+                instrument = None
+                requery = True
+            else:
+                instrument = qnr.instrument_id.split('/')[-1]
             self._qnrs.append(QNR(
                 qnr_id=qnr.id,
                 qb_id=qnr.questionnaire_bank_id,
                 iteration=qnr.qb_iteration,
                 status=qnr.status,
-                instrument=qnr.instrument_id.split('/')[-1],
+                instrument=instrument,
                 authored=qnr.authored,
                 encounter_id=qnr.encounter_id))
+
+        if requery:
+            # Ugly workaround till we figure out why this is happening
+            # see TN-2417
+            for i, qnr in enumerate(self._qnrs):
+                if qnr.instrument is None:
+                    doc = QuestionnaireResponse.query.filter(
+                        QuestionnaireResponse.id == qnr.qnr_id).with_entities(
+                        QuestionnaireResponse.document).first()
+                    if doc is None:
+                        current_app.logger.warning(
+                            "doc still None on second try for "
+                            "qnr {}".format(qnr.qnr_id))
+                    else:
+                        self._qnrs[i] = qnr._replace(
+                            instrument=
+                            doc[0]['questionnaire']['reference'].split(
+                                '/')[-1])
         return self._qnrs
 
     def assign_qb_relationships(self, qb_generator):


### PR DESCRIPTION
Hopefully a temporary workaround, run a second query for the entire json document if the query for the json path field fails.
