### PR TITLE
TN-2287 followup fixes - display error when completion date is not within window

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1742,9 +1742,16 @@ export default (function() {
             },
             manualEntryModalVis: function(hide) {
                 if (hide) {
+                    /*
+                     * TODO, need to find out why IE is raising vue error here
+                     */
                     this.manualEntry.loading = true;
+                    $("#manualEntryLoader").show();
+                    $("#manualEntryButtonsContainer").hide();
                 } else {
                     this.manualEntry.loading = false;
+                    $("#manualEntryLoader").hide();
+                    $("#manualEntryButtonsContainer").show();
                 }
             },
             continueToAssessment: function(method, completionDate, assessment_url) {
@@ -1774,7 +1781,7 @@ export default (function() {
                 setTimeout(function(callback) {
                     callback = callback || function() {};
                     if (callback) { callback(); }
-                }, 1000, self.manualEntryModalVis);
+                }, 5000, self.manualEntryModalVis);
             },
             setManualEntryDateToToday: function() {
                 this.manualEntry.todayObj = this.modules.tnthDates.getTodayDateObj();

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1131,7 +1131,7 @@
                                         <i class="fa fa-spinner fa-spin fa-2x loading-message"></i>
                                     </div>
                                     <div id="manualEntryButtonsContainer" v-show="!manualEntry.loading">
-                                        <a href="#" id="meSubmit" class="btn btn-default" v-bind:disabled="(!manualEntry.method) || manualEntry.errorMessage != ''">{{_("OK")}}</a>
+                                        <a href="#" id="meSubmit" class="btn btn-default" v-bind:disabled="(!manualEntry.method) || manualEntry.errorMessage">{{_("OK")}}</a>
                                         <button type="button" class="btn btn-default" data-dismiss="modal">{{_("Cancel")}}</button>
                                     </div>
                                 </div>


### PR DESCRIPTION
Followup fixes for this story:  https://jira.movember.com/browse/TN-2287

Noting where testing that when completion date entered was not within expected window,  error message **did not** display as would have expected - only seeing submission button being disabled, which can be confusing to user.

Fixes include:
-  display error message when completion date for paper manual entry is not entered within a valid PROM window
- remove loading indicator when there is error
- reset error message to null instead of empty string when clearing error, fix based on previous feedback