### PR TITLE
Noticed an easy optimization when debugging

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -394,14 +394,16 @@ def ordered_qbs(user, classification=None):
                 #   it belongs to both
 
                 transition_now = False
-                qnrs_for_period = user_qnrs.authored_during_period(
-                    start=users_start, end=users_expiration)
-                if len(qnrs_for_period) == 0:
-                    transition_now = True
-
                 curOnly, common, nextOnly = left_center_right(
                     current_qbd.questionnaire_instruments,
                     next_qbd.questionnaire_instruments)
+                combined_instruments = curOnly.union(common).union(nextOnly)
+                qnrs_for_period = user_qnrs.authored_during_period(
+                    start=users_start, end=users_expiration,
+                    restrict_to_instruments=combined_instruments)
+                if len(qnrs_for_period) == 0:
+                    transition_now = True
+
                 period_instruments = set(
                     [q.instrument for q in qnrs_for_period])
                 if not transition_now and period_instruments & curOnly:

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -394,10 +394,10 @@ def ordered_qbs(user, classification=None):
                 #   it belongs to both
 
                 transition_now = False
-                curOnly, common, nextOnly = left_center_right(
+                cur_only, common, next_only = left_center_right(
                     current_qbd.questionnaire_instruments,
                     next_qbd.questionnaire_instruments)
-                combined_instruments = curOnly.union(common).union(nextOnly)
+                combined_instruments = cur_only.union(common).union(next_only)
                 qnrs_for_period = user_qnrs.authored_during_period(
                     start=users_start, end=users_expiration,
                     restrict_to_instruments=combined_instruments)
@@ -406,8 +406,8 @@ def ordered_qbs(user, classification=None):
 
                 period_instruments = set(
                     [q.instrument for q in qnrs_for_period])
-                if not transition_now and period_instruments & curOnly:
-                    if period_instruments & nextOnly:
+                if not transition_now and period_instruments & cur_only:
+                    if period_instruments & next_only:
                         raise ValueError(
                             "Transition ERROR, {} has deterministic QNRs"
                             "for multiple RPs {}:{} during same visit".format(

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -442,7 +442,8 @@ class QNR_results(object):
                 continue
             if qnr.authored >= end:
                 return results
-            if restrict_to_instruments and qnr.instrument not in restrict_to_instruments:
+            if (restrict_to_instruments and
+                    qnr.instrument not in restrict_to_instruments):
                 continue
             results.append(qnr)
         return results

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -434,7 +434,7 @@ class QNR_results(object):
         associated = [qnr for qnr in self.qnrs if qnr.qb_id is not None]
         return len(self.qnrs) != len(associated)
 
-    def authored_during_period(self, start, end):
+    def authored_during_period(self, start, end, restrict_to_instruments=None):
         """Return the ordered list of QNRs with authored in [start, end)"""
         results = []
         for qnr in self.qnrs:
@@ -442,6 +442,8 @@ class QNR_results(object):
                 continue
             if qnr.authored >= end:
                 return results
+            if restrict_to_instruments and qnr.instrument not in restrict_to_instruments:
+                continue
             results.append(qnr)
         return results
 


### PR DESCRIPTION
 no value in returning QNRs that don't apply to current RP Questionnaire Banks when determining transition timing.  mostly simplifies it for the human, but also restricts passing unwanted results about.