### PR TITLE
Access to exception message requires python 3 syntax.

### DIFF
--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -312,7 +312,7 @@ def patient_timeline(patient_id):
 
         update_users_QBT(patient_id, invalidate_existing=purge)
     except ValueError as ve:
-        abort(500, ve.message)
+        abort(500, str(ve))
 
     results = []
     # We order by at (to get the latest status for a given QB) and

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -348,7 +348,7 @@ def delete_user(user_id):
     try:
         user.delete_user(acting_user=current_user())
     except ValueError as v:
-        return jsonify(message=v.message)
+        return jsonify(message=str(v))
     return jsonify(message="deleted")
 
 


### PR DESCRIPTION
found 2 remaining exception catching blocks looking for the exception message in the python 2 syntax - which generates server errors in python 3.