### PR TITLE
TN-2450 

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -661,11 +661,9 @@ def consolidate_answer_pairs(answers):
 
     answer_types = [list(a.keys())[0] for a in answers]
 
-    # Exit early if assumptions not met
-    if (
-        len(answers) % 2 or
-        answer_types.count('valueCoding') != answer_types.count('valueString')
-    ):
+    # Exit early if assumptions not met, i.e. ordered pairs of
+    # 'valueCoding' followed by 'valueString' keys
+    if answer_types != ['valueCoding', 'valueString'] * int(len(answers)/2):
         return answers
 
     filtered_answers = []

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -662,8 +662,8 @@ def consolidate_answer_pairs(answers):
     answer_types = [list(a.keys())[0] for a in answers]
 
     # Exit early if assumptions not met, i.e. ordered pairs of
-    # 'valueCoding' followed by 'valueString' keys
-    if answer_types != ['valueCoding', 'valueString'] * int(len(answers)/2):
+    # 'valueString' followed by 'valueCoding' keys
+    if answer_types != ['valueString', 'valueCoding'] * int(len(answers)/2):
         return answers
 
     filtered_answers = []


### PR DESCRIPTION
only proceed with filtering answers if the given answers follow the expected format, pairs of (`valueCoding`, `valueString`) keys.