### PR TITLE
TN-2464 multi RP transitions pre start

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -440,6 +440,11 @@ class RP_flyweight(object):
         # reset in case of another advancement
         self.skipped_nxt_start = None
 
+        # confirm the now current isn't already retired. rare situation that
+        # happens when an org has retired multiple RPs before a user's trigger
+        if self.consider_transition():
+            self.transition()
+
 
 def ordered_qbs(user, classification=None):
     """Generator to yield ordered qbs for a user


### PR DESCRIPTION
in case of multiple RPs that were retired before a user's initial trigger, need to advance RPs multiple times in the transition process.