### PR TITLE
try updated intersphinx link for werkzeug

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,6 @@ docgen_test:
   variables:
     TOXENV: docs
   <<: *test_definition
-  allow_failure: true
 
 i18n_test_eproms:
   variables:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -318,5 +318,5 @@ texinfo_documents = [(
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'werkzeug': ('http://werkzeug.pocoo.org/docs/latest', None),
+    'werkzeug': ('https://werkzeug.palletsprojects.com/', None),
 }


### PR DESCRIPTION
Intermittent build failures seem to be increasing for the documentation werkzeug link.

Found a possibly better supported redirect target to obtain the latest werkzeug documentation URL.

If this doesn't work, we'll need to use the direct link, which is less attractive as it's version specific.