### PR TITLE
TN-2470 include desired "next" after login within our custom templates

### DIFF
--- a/portal/eproms/templates/eproms/landing.html
+++ b/portal/eproms/templates/eproms/landing.html
@@ -18,6 +18,7 @@
         <form action="{{url_for('user.login')}}" method="POST" class="form tnth-form to-validate" role="form" data-toggle="validator">
             <div class="headline">{{ app_text('landing title') }}</div>
             <div class="inputs-container">
+                <input type="hidden" name="next" value="/next-after-login" />
                 <input type="hidden" name="csrf_token" id="csrf_token" value="{{ csrf_token() }}"/>
                 <div class="fields-container">
                     <div class="input-field-container">

--- a/portal/gil/templates/gil/base.html
+++ b/portal/gil/templates/gil/base.html
@@ -190,6 +190,7 @@
           <div class="box-modal__inner"><a class="box-modal__close" data-dismiss="modal" aria-label="Close"></a>
             <h3 class="box-modal__title">{{_("Login")}}</h3>
              <form action="{{url_for('user.login')}}" method="POST" class="form">
+              <input type="hidden" name="next" value="/next-after-login" />
               <input type="hidden" name="csrf_token" id="csrf_token" value="{{ csrf_token() }}"/>
               <input name="email" type="text" placeholder="{{_('Email Address')}}" required>
               <input name="password" type="password" placeholder="{{_('Password')}}" required>


### PR DESCRIPTION
The login-as timeout wasn't getting reverted on subsequent login, as our custom login templates didn't include the necessary flask-user expected "next" form field.

Now, logins using our front end forms will also redirect to /next-after-login as designed and intended.