### PR TITLE
TN-2447 reduce fields requested from external IdPs

### DIFF
--- a/portal/models/flaskdanceprovider.py
+++ b/portal/models/flaskdanceprovider.py
@@ -123,16 +123,6 @@ class FlaskDanceProvider:
             user_info.email = get_value_from_json('email')
             user_info.image_url = get_value_from_json('image_url')
 
-            # These properties may not be defined
-            user_info.gender = get_value_from_json(
-                'gender',
-                required=False
-            )
-            user_info.birthdate = get_value_from_json(
-                'birthdate',
-                required=False
-            )
-
             return user_info
         except Exception as err:
             current_app.logger.error(
@@ -207,8 +197,6 @@ class GoogleFlaskDanceProvider(FlaskDanceProvider):
                 'last_name': 'family_name',
                 'email': 'email',
                 'image_url': 'picture',
-                'gender': 'gender',
-                'birthdate': 'birthday',
             }
         )
 
@@ -243,8 +231,6 @@ class MockFlaskDanceProvider(FlaskDanceProvider):
                 'last_name': 'last_name',
                 'email': 'email',
                 'image_url': 'picture.data.url',
-                'gender': 'gender',
-                'birthdate': 'birthdate',
             }
         )
 
@@ -307,6 +293,4 @@ class FlaskProviderUserInfo(object):
         self.first_name = None
         self.last_name = None
         self.email = None
-        self.birthdate = None
-        self.gender = None
         self.image_url = None

--- a/portal/models/flaskdanceprovider.py
+++ b/portal/models/flaskdanceprovider.py
@@ -170,8 +170,6 @@ class FacebookFlaskDanceProvider(FlaskDanceProvider):
                 'last_name': 'last_name',
                 'email': 'email',
                 'image_url': 'picture.data.url',
-                'gender': 'gender',
-                'birthdate': 'birthday',
             }
         )
 
@@ -187,7 +185,7 @@ class FacebookFlaskDanceProvider(FlaskDanceProvider):
             '/me',
             params={
                 'fields':
-                    'id,email,birthday,first_name,last_name,gender,picture'
+                    'id,email,first_name,last_name,picture'
             }
         )
 

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1805,8 +1805,6 @@ def add_user(user_info):
     user = User(
         first_name=user_info.first_name,
         last_name=user_info.last_name,
-        birthdate=user_info.birthdate,
-        gender=user_info.gender,
         email=user_info.email,
         image_url=user_info.image_url
     )

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -64,7 +64,7 @@ google_blueprint = make_google_blueprint(
 )
 
 facebook_blueprint = make_facebook_blueprint(
-    scope=['email', 'user_birthday', 'user_gender'],
+    scope=['email'],
     login_url='/login/facebook/',
 )
 


### PR DESCRIPTION
FB has added additional permission barriers for attributes like user_birthdate and user_gender.

As suggested in the comments of TN-2447, reduce the request to external IdPs - no longer request either birthdate or gender.