### PR TITLE
Force str(Message) in logging to eliminate bogus error log text.

### DIFF
--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -180,8 +180,7 @@ class EmailMessage(db.Model):
         else:
             # This should never happen, alert if it does
             current_app.logger.error(
-                "Unable to generate audit log for email {}".format(
-                    str(Message)))
+                "Unable to generate audit log for email: %s", str(Message))
         # If an exception was raised when attempting the send, re-raise now
         # for clients to manage
         if exc:

--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -180,7 +180,8 @@ class EmailMessage(db.Model):
         else:
             # This should never happen, alert if it does
             current_app.logger.error(
-                "Unable to generate audit log for email {}".format(Message))
+                "Unable to generate audit log for email {}".format(
+                    str(Message)))
         # If an exception was raised when attempting the send, re-raise now
         # for clients to manage
         if exc:


### PR DESCRIPTION
There's a comment in the code:
```            # This should never happen, alert if it does ```

generating emails with the following useless content:

```Unable to generate audit log for email <class 'flask_mail.Message'>```

Although `format()` is documented to automatically call an object's __str__ method, it doesn't look to be functioning from the log statement.  Force the call to improve our visibility on this situation.