### PR TITLE
Feature/correct v5 reminders

### DIFF
--- a/portal/config/eproms/CommunicationRequest.json
+++ b/portal/config/eproms/CommunicationRequest.json
@@ -1767,7 +1767,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 0,
+      "qb_iteration": 1,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start6mo_yearly_end30mo"
       },
@@ -1818,7 +1818,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 3}",
-      "qb_iteration": 0,
+      "qb_iteration": 1,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start6mo_yearly_end30mo"
       },
@@ -1869,7 +1869,7 @@
       ],
       "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 4}",
-      "qb_iteration": 0,
+      "qb_iteration": 1,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start6mo_yearly_end30mo"
       },
@@ -1920,7 +1920,7 @@
       ],
       "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
       "notify_post_qb_start": "{\"weeks\": 5}",
-      "qb_iteration": 0,
+      "qb_iteration": 1,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start6mo_yearly_end30mo"
       },
@@ -1971,7 +1971,7 @@
       ],
       "lr_uuid": "d9514c96-4769-993f-f6e4-03a67d8f7424",
       "notify_post_qb_start": "{\"weeks\": 6}",
-      "qb_iteration": 0,
+      "qb_iteration": 1,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start6mo_yearly_end30mo"
       },
@@ -2617,7 +2617,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 0,
+      "qb_iteration": 2,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start6mo_yearly_end30mo"
       },

--- a/portal/config/eproms/CommunicationRequest.json
+++ b/portal/config/eproms/CommunicationRequest.json
@@ -2838,7 +2838,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 3,
+      "qb_iteration": 5,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },

--- a/portal/config/eproms/CommunicationRequest.json
+++ b/portal/config/eproms/CommunicationRequest.json
@@ -2498,7 +2498,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 3,
+      "qb_iteration": 4,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -2515,7 +2515,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 3}",
-      "qb_iteration": 3,
+      "qb_iteration": 4,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -2532,7 +2532,7 @@
       ],
       "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 4}",
-      "qb_iteration": 3,
+      "qb_iteration": 4,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -2549,7 +2549,7 @@
       ],
       "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
       "notify_post_qb_start": "{\"weeks\": 5}",
-      "qb_iteration": 3,
+      "qb_iteration": 4,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -2566,7 +2566,7 @@
       ],
       "lr_uuid": "d9514c96-4769-993f-f6e4-03a67d8f7424",
       "notify_post_qb_start": "{\"weeks\": 6}",
-      "qb_iteration": 3,
+      "qb_iteration": 4,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -2855,7 +2855,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 3}",
-      "qb_iteration": 3,
+      "qb_iteration": 5,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -2872,7 +2872,7 @@
       ],
       "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 4}",
-      "qb_iteration": 3,
+      "qb_iteration": 5,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -2889,7 +2889,7 @@
       ],
       "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
       "notify_post_qb_start": "{\"weeks\": 5}",
-      "qb_iteration": 3,
+      "qb_iteration": 5,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -2906,7 +2906,7 @@
       ],
       "lr_uuid": "d9514c96-4769-993f-f6e4-03a67d8f7424",
       "notify_post_qb_start": "{\"weeks\": 6}",
-      "qb_iteration": 3,
+      "qb_iteration": 5,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3178,7 +3178,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 3,
+      "qb_iteration": 6,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3195,7 +3195,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 3}",
-      "qb_iteration": 3,
+      "qb_iteration": 6,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3212,7 +3212,7 @@
       ],
       "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 4}",
-      "qb_iteration": 3,
+      "qb_iteration": 6,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3229,7 +3229,7 @@
       ],
       "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
       "notify_post_qb_start": "{\"weeks\": 5}",
-      "qb_iteration": 3,
+      "qb_iteration": 6,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3246,7 +3246,7 @@
       ],
       "lr_uuid": "d9514c96-4769-993f-f6e4-03a67d8f7424",
       "notify_post_qb_start": "{\"weeks\": 6}",
-      "qb_iteration": 3,
+      "qb_iteration": 6,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3348,7 +3348,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 3,
+      "qb_iteration": 7,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3365,7 +3365,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 3}",
-      "qb_iteration": 3,
+      "qb_iteration": 7,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3382,7 +3382,7 @@
       ],
       "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 4}",
-      "qb_iteration": 3,
+      "qb_iteration": 7,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3399,7 +3399,7 @@
       ],
       "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
       "notify_post_qb_start": "{\"weeks\": 5}",
-      "qb_iteration": 3,
+      "qb_iteration": 7,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3416,7 +3416,7 @@
       ],
       "lr_uuid": "d9514c96-4769-993f-f6e4-03a67d8f7424",
       "notify_post_qb_start": "{\"weeks\": 6}",
-      "qb_iteration": 3,
+      "qb_iteration": 7,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3433,7 +3433,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 2,
+      "qb_iteration": 3,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_annual_pattern"
       },
@@ -3450,7 +3450,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 3}",
-      "qb_iteration": 2,
+      "qb_iteration": 3,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_annual_pattern"
       },
@@ -3467,7 +3467,7 @@
       ],
       "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 4}",
-      "qb_iteration": 2,
+      "qb_iteration": 3,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_annual_pattern"
       },
@@ -3484,7 +3484,7 @@
       ],
       "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
       "notify_post_qb_start": "{\"weeks\": 5}",
-      "qb_iteration": 2,
+      "qb_iteration": 3,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_annual_pattern"
       },
@@ -3501,7 +3501,7 @@
       ],
       "lr_uuid": "d9514c96-4769-993f-f6e4-03a67d8f7424",
       "notify_post_qb_start": "{\"weeks\": 6}",
-      "qb_iteration": 2,
+      "qb_iteration": 3,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_annual_pattern"
       },
@@ -3518,7 +3518,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 3,
+      "qb_iteration": 8,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3535,7 +3535,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 3}",
-      "qb_iteration": 3,
+      "qb_iteration": 8,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3552,7 +3552,7 @@
       ],
       "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 4}",
-      "qb_iteration": 3,
+      "qb_iteration": 8,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3569,7 +3569,7 @@
       ],
       "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
       "notify_post_qb_start": "{\"weeks\": 5}",
-      "qb_iteration": 3,
+      "qb_iteration": 8,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3586,7 +3586,7 @@
       ],
       "lr_uuid": "d9514c96-4769-993f-f6e4-03a67d8f7424",
       "notify_post_qb_start": "{\"weeks\": 6}",
-      "qb_iteration": 3,
+      "qb_iteration": 8,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3603,7 +3603,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 0,
+      "qb_iteration": 1,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start3.5years_yearly"
       },
@@ -3620,7 +3620,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 3}",
-      "qb_iteration": 0,
+      "qb_iteration": 1,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start3.5years_yearly"
       },
@@ -3637,7 +3637,7 @@
       ],
       "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 4}",
-      "qb_iteration": 0,
+      "qb_iteration": 1,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start3.5years_yearly"
       },
@@ -3654,7 +3654,7 @@
       ],
       "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
       "notify_post_qb_start": "{\"weeks\": 5}",
-      "qb_iteration": 0,
+      "qb_iteration": 1,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start3.5years_yearly"
       },
@@ -3671,7 +3671,7 @@
       ],
       "lr_uuid": "d9514c96-4769-993f-f6e4-03a67d8f7424",
       "notify_post_qb_start": "{\"weeks\": 6}",
-      "qb_iteration": 0,
+      "qb_iteration": 1,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_start3.5years_yearly"
       },
@@ -3688,7 +3688,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 3,
+      "qb_iteration": 9,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3705,7 +3705,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 3}",
-      "qb_iteration": 3,
+      "qb_iteration": 9,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3722,7 +3722,7 @@
       ],
       "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 4}",
-      "qb_iteration": 3,
+      "qb_iteration": 9,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3739,7 +3739,7 @@
       ],
       "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
       "notify_post_qb_start": "{\"weeks\": 5}",
-      "qb_iteration": 3,
+      "qb_iteration": 9,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3756,7 +3756,7 @@
       ],
       "lr_uuid": "d9514c96-4769-993f-f6e4-03a67d8f7424",
       "notify_post_qb_start": "{\"weeks\": 6}",
-      "qb_iteration": 3,
+      "qb_iteration": 9,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_3mo_pattern"
       },
@@ -3773,7 +3773,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 2}",
-      "qb_iteration": 2,
+      "qb_iteration": 4,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_annual_pattern"
       },
@@ -3790,7 +3790,7 @@
       ],
       "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 3}",
-      "qb_iteration": 2,
+      "qb_iteration": 4,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_annual_pattern"
       },
@@ -3807,7 +3807,7 @@
       ],
       "lr_uuid": "b98cd174-7894-db68-b335-9e36e055592d",
       "notify_post_qb_start": "{\"weeks\": 4}",
-      "qb_iteration": 2,
+      "qb_iteration": 4,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_annual_pattern"
       },
@@ -3824,7 +3824,7 @@
       ],
       "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
       "notify_post_qb_start": "{\"weeks\": 5}",
-      "qb_iteration": 2,
+      "qb_iteration": 4,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_annual_pattern"
       },
@@ -3841,7 +3841,7 @@
       ],
       "lr_uuid": "d9514c96-4769-993f-f6e4-03a67d8f7424",
       "notify_post_qb_start": "{\"weeks\": 6}",
-      "qb_iteration": 2,
+      "qb_iteration": 4,
       "questionnaire_bank": {
         "reference": "api/questionnaire_bank/IRONMAN_v5_recurring_annual_pattern"
       },

--- a/portal/models/communication_request.py
+++ b/portal/models/communication_request.py
@@ -159,16 +159,19 @@ class CommunicationRequest(db.Model):
         @return: the new or matched CommunicationRequest
 
         """
-        existing = CommunicationRequest.query.filter(
-            CommunicationRequest.questionnaire_bank_id ==
-            self.questionnaire_bank_id
-        ).filter(
-            CommunicationRequest.notify_post_qb_start ==
-            self.notify_post_qb_start
-        ).filter(
-            CommunicationRequest.qb_iteration ==
-            self.qb_iteration
-        ).first()
+        if self.identifiers.count() == 1:
+            existing = CommunicationRequest.find_by_identifier(self.identifiers.first())
+        else:
+            existing = CommunicationRequest.query.filter(
+                CommunicationRequest.questionnaire_bank_id ==
+                self.questionnaire_bank_id
+            ).filter(
+                CommunicationRequest.notify_post_qb_start ==
+                self.notify_post_qb_start
+            ).filter(
+                CommunicationRequest.qb_iteration ==
+                self.qb_iteration
+            ).first()
         if not existing:
             db.session.add(self)
             if commit_immediately:


### PR DESCRIPTION
For v5 changes, corrected site_persistence to use identifiers first when looking up communication requests.
Also needed to correct several cut&paste errors on qb_iteration for respective month intervals.