### PR TITLE
Feature/round up visit names

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -431,13 +431,16 @@ class RP_flyweight(object):
         if self.skipped_nxt_start:
             assert self.skipped_nxt_start < start
             start = self.skipped_nxt_start
+        entropy_check = 99
         while True:
-            # Fear not, won't loop forever as `next_qbd` will
-            # quickly exhaust, thus raising an exception, in
-            # the event of a config error where RPs somehow
-            # change the start, expiration synchronization.
+            entropy_check -= 1
+            if entropy_check < 0:
+                raise RuntimeError("entropy wins again; QB configs out of sync")
+
             self.next_qbd()
-            if start == self.cur_start:
+            if start < self.cur_start + relativedelta(months=1):
+                # due to early start for RP v5, add a month before comparison
+                current_app.logger.debug("breaking with self.cur_start{} and previous start{}".format(self.cur_start, start))
                 break
 
         # reset in case of another advancement

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -536,7 +536,8 @@ def visit_name(qbd):
     if not qbd.questionnaire_bank:
         return None
     if qbd.recur:
-        srd = RelativeDelta(qbd.recur.start)
+        # Round up 15 days to accommodate RP v5's backdating
+        srd = RelativeDelta(qbd.recur.start) + RelativeDelta(days=15)
         sm = srd.months or 0
         sm += (srd.years * 12) if srd.years else 0
         clrd = RelativeDelta(qbd.recur.cycle_length)


### PR DESCRIPTION
Fix for visit names not landing on 3 month intervals w/ RP v5 and logic error in generator catch-up when changing to new RP that has different start dates. 