### PR TITLE
Feature/visit date 3 mo

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -440,7 +440,6 @@ class RP_flyweight(object):
             self.next_qbd()
             if start < self.cur_start + relativedelta(months=1):
                 # due to early start for RP v5, add a month before comparison
-                current_app.logger.debug("breaking with self.cur_start{} and previous start{}".format(self.cur_start, start))
                 break
 
         # reset in case of another advancement

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -536,8 +536,11 @@ def visit_name(qbd):
     if not qbd.questionnaire_bank:
         return None
     if qbd.recur:
-        # Round up 15 days to accommodate RP v5's backdating
-        srd = RelativeDelta(qbd.recur.start) + RelativeDelta(days=15)
+        srd = RelativeDelta(qbd.recur.start)
+        if qbd.questionnaire_bank.research_protocol.name.endswith('v5'):
+            # TODO: remove this ugly hack.  V5 starts early, must add 1 month
+            # but that can't be done across the board as others don't need
+            srd += RelativeDelta(months=1)
         sm = srd.months or 0
         sm += (srd.years * 12) if srd.years else 0
         clrd = RelativeDelta(qbd.recur.cycle_length)

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -537,7 +537,9 @@ def visit_name(qbd):
         return None
     if qbd.recur:
         srd = RelativeDelta(qbd.recur.start)
-        if qbd.questionnaire_bank.research_protocol.name.endswith('v5'):
+        if (
+                qbd.questionnaire_bank.research_protocol and
+                qbd.questionnaire_bank.research_protocol.name.endswith('v5')):
             # TODO: remove this ugly hack.  V5 starts early, must add 1 month
             # but that can't be done across the board as others don't need
             srd += RelativeDelta(months=1)

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -117,6 +117,8 @@ class TestQuestionnaireBank(TestCase):
         recur3 = Recur(
             start='{"months": 3}', cycle_length='{"months": 6}',
             termination='{"months": 24}')
+        if rp_name == 'v5':
+            recur3.start = '{"months": 2}'
         exists = Recur.query.filter_by(
             start=recur3.start, cycle_length=recur3.cycle_length,
             termination=recur3.termination).first()
@@ -126,6 +128,8 @@ class TestQuestionnaireBank(TestCase):
         recur6 = Recur(
             start='{"months": 6}', cycle_length='{"years": 1}',
             termination='{"years": 3, "months": 3}')
+        if rp_name == 'v5':
+            recur6.start = '{"months": 5}'
         exists = Recur.query.filter_by(
             start=recur6.start, cycle_length=recur6.cycle_length,
             termination=recur6.termination).first()


### PR DESCRIPTION
Warren noticed the visit dates for RP v5 show odd values such as 5 months (should be 6) and other off by one errors.
This stems from the v5 assessments being open a month early, but are still considered or referred to by the even 3 month interval.
