### PR TITLE
Obsolete redirect if logged in user attempts /go

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -214,7 +214,10 @@ def specific_clinic_entry():
 
     """
     if current_user():
-        return redirect(url_for('portal.home'))
+        if current_app.config.get('GIL'):
+            return redirect(url_for('gil.home'))
+        else:
+            return redirect(url_for('eproms.home'))
 
     form = ShortcutAliasForm(request.form)
 


### PR DESCRIPTION
Need to redirect to appropriate blueprint, eproms/home or gil/home