### PR TITLE
TN-2627 encounter api & allow pre-registered users in via url authentication

### DIFF
--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -161,6 +161,7 @@ class BaseConfig(object):
     USER_ENABLE_CHANGE_USERNAME = False  # prereq for disabling username
     USER_ENABLE_CONFIRM_EMAIL = False  # don't force email conf on new accounts
     USER_SHOW_USERNAME_EMAIL_DOES_NOT_EXIST = False
+    ENABLE_URL_AUTHENTICATED = os.environ.get('ENABLE_URL_AUTHENTICATED', 'false').lower() == 'true'
 
     STAFF_BULK_DATA_ACCESS = True
     PATIENT_LIST_ADDL_FIELDS = []  # 'status', 'reports'

--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -28,7 +28,7 @@ from ..models.intervention import Intervention
 from ..models.message import EmailMessage
 from ..models.organization import Organization
 from ..models.role import ROLE
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import current_user, get_user
 from ..views.auth import next_after_login
 from ..views.external_assets import (
     asset_by_uuid,
@@ -246,7 +246,7 @@ def website_consent_script(patient_id):
         """
         validate_origin(redirect_url)
     user = current_user()
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'view')
     org = patient.first_top_organization()
     """
     NOTE, we are getting PATIENT's website consent terms here

--- a/portal/gil/views.py
+++ b/portal/gil/views.py
@@ -12,7 +12,7 @@ from flask import (
 from jinja2 import TemplateNotFound
 
 from ..database import db
-from ..extensions import recaptcha
+from ..extensions import oauth, recaptcha
 from ..models.app_text import (
     AboutATMA,
     PrivacyATMA,
@@ -26,7 +26,7 @@ from ..models.intervention import Intervention
 from ..models.message import EmailMessage
 from ..models.organization import Organization, OrganizationIdentifier, OrgTree
 from ..models.role import ROLE
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import current_user, get_user
 from ..system_uri import SHORTCUT_ALIAS
 from ..views.auth import next_after_login
 from ..views.crossdomain import crossdomain
@@ -115,19 +115,14 @@ def home():
 
 @gil.route('/gil-interventions-items/<int:user_id>')
 @crossdomain()
+@oauth.require_oauth()
 def gil_interventions_items(user_id):
     """ this is needed to filter the GIL menu based on user's intervention(s)
         trying to do this so code is more easily managed from front end side
         Currently it is also accessed via ajax call from gil footer
         see: api/gil-footer-html/
     """
-    user = None
-
-    if user_id:
-        user = get_user_or_abort(user_id)
-    else:
-        user = current_user()
-
+    user = get_user(user_id, permission='view')
     user_interventions = []
 
     if user:

--- a/portal/models/audit.py
+++ b/portal/models/audit.py
@@ -51,14 +51,14 @@ class Audit(db.Model):
 
     def as_fhir(self):
         """Typically included as *meta* data in containing FHIR resource"""
-        from .user import get_user
+        from .user import User
         from .fhir import FHIR_datetime
 
         d = {}
         d['version'] = self.version
         d['lastUpdated'] = FHIR_datetime.as_fhir(self.timestamp)
         d['by'] = Reference.patient(self.user_id).as_fhir()
-        d['by']['display'] = get_user(self.user_id).display_name
+        d['by']['display'] = User.query.get(self.user_id).display_name
         d['on'] = Reference.patient(self.subject_id).as_fhir()
         d['context'] = self.context
         if self.comment:

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -327,15 +327,13 @@ def update_card_html_on_completion():
                 "When you are done, completed questionnaires will be "
                 "shown here.")
             completed_placeholder = """
-                <div>
-                  <div class="portal-description disabled">
+                <div class="portal-description disabled">
                     <h4 class="portal-description-title">
                       {header}
                     </h4>
                     <div class="portal-description-body">
                       <p>{message}</p>
                     </div>
-                  </div>
                 </div>""".format(header=header, message=message)
 
             completed_html = """

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -327,12 +327,14 @@ def update_card_html_on_completion():
                 "When you are done, completed questionnaires will be "
                 "shown here.")
             completed_placeholder = """
-                <div class="portal-description disabled">
-                  <h4 class="portal-description-title">
-                    {header}
-                  </h4>
-                  <div class="portal-description-body">
-                    <p>{message}</p>
+                <div class="portal-weak-auth-disabled">
+                  <div class="portal-description disabled">
+                    <h4 class="portal-description-title">
+                      {header}
+                    </h4>
+                    <div class="portal-description-body">
+                      <p>{message}</p>
+                    </div>
                   </div>
                 </div>""".format(header=header, message=message)
 

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -327,7 +327,7 @@ def update_card_html_on_completion():
                 "When you are done, completed questionnaires will be "
                 "shown here.")
             completed_placeholder = """
-                <div class="portal-weak-auth-disabled">
+                <div>
                   <div class="portal-description disabled">
                     <h4 class="portal-description-title">
                       {header}
@@ -345,7 +345,7 @@ def update_card_html_on_completion():
                   </h4>
                   <div class="portal-description-body">
                     <p>
-                      <a href="{recent_survey_link}">
+                      <a class="portal-weak-auth-disabled" href="{recent_survey_link}">
                         {message}
                       </a>
                     </p>

--- a/portal/models/procedure.py
+++ b/portal/models/procedure.py
@@ -4,7 +4,7 @@ from ..date_tools import FHIR_datetime, as_fhir
 from .codeable_concept import CodeableConcept
 from .encounter import Encounter
 from .reference import Reference
-from .user import get_user
+from .user import User
 
 
 class Procedure(db.Model):
@@ -76,7 +76,7 @@ class Procedure(db.Model):
         if 'encounter' in data:
             p.encounter = Encounter.from_fhir(data['encounter'])
         else:
-            p.encounter = get_user(audit.user_id).current_encounter
+            p.encounter = User.query.get(audit.user_id).current_encounter
         p.user_id = Reference.parse(data['subject']).id
         if 'performedDateTime' in data:
             p.start_time = FHIR_datetime.parse(

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -434,7 +434,8 @@ class User(db.Model, UserMixin):
         the subject, if a different user is performing the action.
         """
         query = Encounter.query.filter(Encounter.user_id == self.id).filter(
-            Encounter.status == 'in-progress')
+            Encounter.status == 'in-progress').order_by(
+            Encounter.start_time.desc())
         if query.count() == 0:
             current_app.logger.error(
                 "Failed to locate in-progress encounter for {}"
@@ -443,7 +444,7 @@ class User(db.Model, UserMixin):
         if query.count() != 1:
             # Not good - we should only have one `active` encounter for
             # the current user.  Log details for debugging and return the
-            # first
+            # most recently started
             msg = "Multiple active encounters found for {}: {}".format(
                 self,
                 [(e.status, str(e.start_time), str(e.end_time))

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1015,7 +1015,8 @@ class User(db.Model, UserMixin):
             value_quantity_id=value_quantity.id).add_if_not_found(True)
         # The audit defines the acting user, to which the current
         # encounter is attached.
-        encounter = get_user(audit.user_id).current_encounter
+        acting_user = User.query.get(audit.user_id)
+        encounter = acting_user.current_encounter
         db.session.add(UserObservation(
             user_id=self.id, encounter=encounter, audit=audit,
             observation_id=observation.id))
@@ -1654,6 +1655,7 @@ class User(db.Model, UserMixin):
         assert (permission in ('view', 'edit'))  # limit vocab for now
         if (
                 not allow_on_url_authenticated_encounters and
+                current_app.config.get('ENABLE_URL_AUTHENTICATED') and
                 self.current_encounter.auth_method == 'url_authenticated'):
             abort(401, "inadequate auth_method: {}".format(
                 self.current_encounter.auth_method))

--- a/portal/static/js/flask_user/ConfirmIdentity.js
+++ b/portal/static/js/flask_user/ConfirmIdentity.js
@@ -1,0 +1,27 @@
+$(document).ready(function() {
+    $("#confirmIdentityModal").modal({
+        "show":true,
+        "backdrop": "static",
+        "focus": true,
+        "keyboard": false
+    });
+    $("#btnConfirmIdentity").on("click", function(e) {
+        e.stopPropagation();
+        /*
+         * record an audit event before redirecting user to survey
+         */
+        $.ajax({
+            type: "POST",
+            url: "/api/auditlog",
+            data: {
+                "message": "User confirmed identity as survey taker"
+            },
+            async: false
+        }).done(function(data) {
+            $("#confirmationErrorMessage").html("");
+            window.location = $("#surveyRedirectURL").val();
+        }).fail(function() {
+            $("#confirmationErrorMessage").html(i18next.t("Unable to update. System/Server Error."));
+        });
+    });
+});

--- a/portal/static/js/src/modules/Global.js
+++ b/portal/static/js/src/modules/Global.js
@@ -94,24 +94,16 @@ export default { /*global $ i18next */ /*initializing functions performed only o
                         return;
                     }
                     if (String(data.auth_method).toLowerCase() === url_auth_method) {
-                        //link to profile in menu and in home page where indicated via css class
-                        ["#tnthNavWrapper .profile-menu-link",
-                        "#mainDiv .portal-weak-auth-disabled"].forEach(
-                            item => {
-                                if ($(item).length) {
-                                    //this will redirect user to login page
-                                    const loginPath = "/user/sign-in";
-                                    if ($(item)[0].nodeName.toLowerCase() === "a") {
-                                        $(item).attr("href", loginPath);
-                                    } else {
-                                        $(item).off("click").on("click", function() {
-                                            window.location = loginPath;
-                                            return false;
-                                        });
-                                    }
-                                }
-                            }
-                        );
+                        const loginPath = "/user/sign-in";
+                        //links needing to redirect to login page 
+                        $(".url-authenticated-disabled-link").each(function() {
+                            let originalHref = $(this).attr("href");
+                            $(this).attr("href", `${loginPath}?next=${originalHref}`);
+                        });
+                        //elements needing to be hidden
+                        $(".url-authenticated-hide").each(function() {
+                            $(this).hide();
+                        });
                     }
                 });
             }

--- a/portal/static/js/src/modules/Global.js
+++ b/portal/static/js/src/modules/Global.js
@@ -84,7 +84,7 @@ export default { /*global $ i18next */ /*initializing functions performed only o
                 if (!userId) {
                     return;
                 }
-                const url_auth_method = "password_authenticated";
+                const url_auth_method = "url_authenticated";
                 //call to check if the current user is authenticated via url authenticated method
                 $.ajax({
                     type: "GET",
@@ -102,7 +102,7 @@ export default { /*global $ i18next */ /*initializing functions performed only o
                                     //this will redirect user to login page
                                     const loginPath = "/user/sign-in";
                                     if ($(item)[0].nodeName.toLowerCase() === "a") {
-                                        $(item).attr("href", lognPath);
+                                        $(item).attr("href", loginPath);
                                     } else {
                                         $(item).off("click").on("click", function() {
                                             window.location = loginPath;

--- a/portal/static/js/src/modules/Global.js
+++ b/portal/static/js/src/modules/Global.js
@@ -52,6 +52,71 @@ export default { /*global $ i18next */ /*initializing functions performed only o
         this.initValidator();
         this.handleClientInterventionForm();
     },
+    "getCurrentUser": function(callback) {
+        callback = callback || function() {};
+        let cachedCurrentUserId = sessionStorage.getItem("current_user_id");
+        if (cachedCurrentUserId) {
+            callback(cachedCurrentUserId);
+            return cachedCurrentUserId;
+        }
+        $.ajax({
+            type: "GET",
+            url: "/api/me",
+            async: false
+        }).done(function(data) {
+            var userId = "";
+            if (data) { userId = data.id; }
+            if (!userId) {
+                callback();
+                return;
+            }
+            sessionStorage.setItem("current_user_id", userId);
+            callback(userId);
+        }).fail(function() {
+            callback();
+        });
+
+        return cachedCurrentUserId;
+    },
+    "checkURLAuthenticated": function() {
+        this.getCurrentUser(
+            function(userId) {
+                if (!userId) {
+                    return;
+                }
+                const url_auth_method = "password_authenticated";
+                //call to check if the current user is authenticated via url authenticated method
+                $.ajax({
+                    type: "GET",
+                    url: `/api/user/${userId}/encounter`
+                }).done(function(data) {
+                    if (!data || !data.auth_method) {
+                        return;
+                    }
+                    if (String(data.auth_method).toLowerCase() === url_auth_method) {
+                        //link to profile in menu and in home page where indicated via css class
+                        ["#tnthNavWrapper .profile-menu-link",
+                        "#mainDiv .portal-weak-auth-disabled"].forEach(
+                            item => {
+                                if ($(item).length) {
+                                    //this will redirect user to login page
+                                    const loginPath = "/user/sign-in";
+                                    if ($(item)[0].nodeName.toLowerCase() === "a") {
+                                        $(item).attr("href", lognPath);
+                                    } else {
+                                        $(item).off("click").on("click", function() {
+                                            window.location = loginPath;
+                                            return false;
+                                        });
+                                    }
+                                }
+                            }
+                        );
+                    }
+                });
+            }
+        );
+    },
     "prePopulateEmail": function() {
         var requestEmail =  Utility.getUrlParameter("email"), emailField = document.querySelector("#email");
         if (requestEmail && emailField) { /*global Utility getUrlParameter */
@@ -107,6 +172,7 @@ export default { /*global $ i18next */ /*initializing functions performed only o
                     self.handleLogout();
                 });
                 self.handleDisableLinks();
+                self.checkURLAuthenticated();
             }, 350);
             self.getNotification(function(data) { //ajax to get notifications information
                 self.notifications(data);
@@ -163,13 +229,7 @@ export default { /*global $ i18next */ /*initializing functions performed only o
             return false;
         }
         var locale = "en_us";
-        $.ajax({
-            type: "GET",
-            url: "/api/me",
-            async: false
-        }).done(function(data) {
-            var userId = "";
-            if (data) { userId = data.id; }
+        this.getCurrentUser(function(userId) {
             if (!userId) {
                 locale = "en_us";
                 return false;
@@ -190,7 +250,7 @@ export default { /*global $ i18next */ /*initializing functions performed only o
                     }
                 });
             });
-        }).fail(function() {});
+        });
         return locale;
     },
     "getCopyrightYear": function(callback) {

--- a/portal/static/js/src/modules/Global.js
+++ b/portal/static/js/src/modules/Global.js
@@ -96,12 +96,12 @@ export default { /*global $ i18next */ /*initializing functions performed only o
                     if (String(data.auth_method).toLowerCase() === url_auth_method) {
                         const loginPath = "/user/sign-in";
                         //links needing to redirect to login page 
-                        $(".url-authenticated-disabled-link").each(function() {
+                        $(".portal-weak-auth-disabled").each(function() {
                             let originalHref = $(this).attr("href");
                             $(this).attr("href", `${loginPath}?next=${originalHref}`);
                         });
                         //elements needing to be hidden
-                        $(".url-authenticated-hide").each(function() {
+                        $(".portal-weak-auth-hide").each(function() {
                             $(this).hide();
                         });
                     }

--- a/portal/templates/confirm_identity.html
+++ b/portal/templates/confirm_identity.html
@@ -1,0 +1,26 @@
+{% extends "layout.html" %}
+{% block main %}
+    <input type="hidden" id="surveyRedirectURL" value="{{redirect_url}}" />
+    <div class="modal fade" id="confirmIdentityModal" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+                <div class="modal-header-title">{{_("Identity verification")}}</div>
+            </div>
+            <div class="modal-body">
+                <div class="body-content">
+                    <div>{{_("I confirm that I am a participant in the Ironman study and am completing this questionnaire myself.")}}</div>
+                </div>
+                <div id="confirmationErrorMessage" class="error-message"></div>
+            </div>
+            <div class="modal-footer">
+                <button id="btnConfirmIdentity" class="btn btn-default">{{_("Yes")}}</button>
+                <a href="{{url_for('eproms.home')}}" class="btn btn-default">{{_("No")}}</a>
+            </div>
+          </div>
+        </div>
+    </div>
+{% endblock %}
+{%- block additional_scripts %}<script src="{{ url_for('static', filename='js/flask_user/ConfirmIdentity.js') }}"></script>{% endblock -%}
+{%- from "flask_user/_macros.html" import footer -%}
+{%- block footer %}{% endblock -%}

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -64,7 +64,7 @@
                         <ul class="tnth-dropdown-menu" style="list-style-type:none">
                             <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
                             {% if 'login_as_id' in session or (user and user.is_registered()) %}
-                            <li><a class="profile-menu-link" href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>
+                            <li><a class="url-authenticated-disabled-link" href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>
                             {% endif %}
                             <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>
                             {% if user and user.has_role(ROLE.APPLICATION_DEVELOPER.value) %}
@@ -94,7 +94,7 @@
                          <button id="tnthUserBtn" type="button" class="tnth-nav-btn tnth-white tnth-dropdown-toggle" data-toggle="tnth-dropdown">
                             {% if enable_links %}&nbsp;&nbsp; {{ _("MENU") }} <i class="fa fa-bars"></i>{% endif %}
                             <img class="profile-img" src="{{movember_profile}}" width="50" height="50" alt="{{_('Profile image')}}"/>
-                            <span class="welcome-text"><em>{{ _("Welcome") }}</em>{% if user.display_name != "Anonymous" %}, {{ user.display_name }}{% endif %}</span>
+                            <span class="welcome-text url-authenticated-hide"><em>{{ _("Welcome") }}</em>{% if user.display_name != "Anonymous" %}, {{ user.display_name }}{% endif %}</span>
                             {% if config.DEBUG_TIMEOUTS %}({{ expires_in }} seconds remaining){% endif %}
                          </button>
                             {% elif login_url %}<ul class="tnth-dropdown-menu" role="menu"><li><a href="{{ login_url }}">{{ _("Log In to TrueNTH") }}</a></li></ul>
@@ -120,7 +120,7 @@
                 <ul class="tnth-navbar-xs" style="list-style-type:none">
                     {% if login_url %}<li><a href="{{ login_url }}">{{ _("Log In to TrueNTH") }}</a></li>{% endif %}
                     <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
-                    {% if 'login_as_id' in session or (user and user.is_registered()) %}<li><a class="profile-menu-link" href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>{% endif %}
+                    {% if 'login_as_id' in session or (user and user.is_registered()) %}<li><a class="url-authenticated-disabled-link" href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>{% endif %}
                     <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>
                     {% if user and user.has_role(ROLE.APPLICATION_DEVELOPER.value) %}<li><a href="{{PORTAL}}/clients">{{ _("Client Applications") }}</a></li>{% endif %}
                     {% if user and user.has_role(ROLE.STAFF.value, ROLE.INTERVENTION_STAFF.value) %}<li><a href="{{PORTAL}}/patients/">{{ _("Patients") }}</a></li>{% endif %}

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -94,7 +94,9 @@
                          <button id="tnthUserBtn" type="button" class="tnth-nav-btn tnth-white tnth-dropdown-toggle" data-toggle="tnth-dropdown">
                             {% if enable_links %}&nbsp;&nbsp; {{ _("MENU") }} <i class="fa fa-bars"></i>{% endif %}
                             <img class="profile-img" src="{{movember_profile}}" width="50" height="50" alt="{{_('Profile image')}}"/>
-                            <span class="welcome-text portal-weak-auth-hide"><em>{{ _("Welcome") }}</em>{% if user.display_name != "Anonymous" %}, {{ user.display_name }}{% endif %}</span>
+                            {% if user.current_encounter.auth_method != 'url_authenticated' %}
+                                <span class="welcome-text portal-weak-auth-hide"><em>{{ _("Welcome") }}</em>{% if user.display_name != "Anonymous" %}, {{ user.display_name }}{% endif %}</span>
+                            {% endif %}
                             {% if config.DEBUG_TIMEOUTS %}({{ expires_in }} seconds remaining){% endif %}
                          </button>
                             {% elif login_url %}<ul class="tnth-dropdown-menu" role="menu"><li><a href="{{ login_url }}">{{ _("Log In to TrueNTH") }}</a></li></ul>

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -64,7 +64,7 @@
                         <ul class="tnth-dropdown-menu" style="list-style-type:none">
                             <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
                             {% if 'login_as_id' in session or (user and user.is_registered()) %}
-                            <li><a href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>
+                            <li><a class="profile-menu-link" href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>
                             {% endif %}
                             <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>
                             {% if user and user.has_role(ROLE.APPLICATION_DEVELOPER.value) %}
@@ -120,7 +120,7 @@
                 <ul class="tnth-navbar-xs" style="list-style-type:none">
                     {% if login_url %}<li><a href="{{ login_url }}">{{ _("Log In to TrueNTH") }}</a></li>{% endif %}
                     <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
-                    {% if 'login_as_id' in session or (user and user.is_registered()) %}<li><a href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>{% endif %}
+                    {% if 'login_as_id' in session or (user and user.is_registered()) %}<li><a class="profile-menu-link" href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>{% endif %}
                     <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>
                     {% if user and user.has_role(ROLE.APPLICATION_DEVELOPER.value) %}<li><a href="{{PORTAL}}/clients">{{ _("Client Applications") }}</a></li>{% endif %}
                     {% if user and user.has_role(ROLE.STAFF.value, ROLE.INTERVENTION_STAFF.value) %}<li><a href="{{PORTAL}}/patients/">{{ _("Patients") }}</a></li>{% endif %}

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -64,7 +64,7 @@
                         <ul class="tnth-dropdown-menu" style="list-style-type:none">
                             <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
                             {% if 'login_as_id' in session or (user and user.is_registered()) %}
-                            <li><a class="url-authenticated-disabled-link" href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>
+                            <li><a class="portal-weak-auth-disabled" href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>
                             {% endif %}
                             <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>
                             {% if user and user.has_role(ROLE.APPLICATION_DEVELOPER.value) %}
@@ -94,7 +94,7 @@
                          <button id="tnthUserBtn" type="button" class="tnth-nav-btn tnth-white tnth-dropdown-toggle" data-toggle="tnth-dropdown">
                             {% if enable_links %}&nbsp;&nbsp; {{ _("MENU") }} <i class="fa fa-bars"></i>{% endif %}
                             <img class="profile-img" src="{{movember_profile}}" width="50" height="50" alt="{{_('Profile image')}}"/>
-                            <span class="welcome-text url-authenticated-hide"><em>{{ _("Welcome") }}</em>{% if user.display_name != "Anonymous" %}, {{ user.display_name }}{% endif %}</span>
+                            <span class="welcome-text portal-weak-auth-hide"><em>{{ _("Welcome") }}</em>{% if user.display_name != "Anonymous" %}, {{ user.display_name }}{% endif %}</span>
                             {% if config.DEBUG_TIMEOUTS %}({{ expires_in }} seconds remaining){% endif %}
                          </button>
                             {% elif login_url %}<ul class="tnth-dropdown-menu" role="menu"><li><a href="{{ login_url }}">{{ _("Log In to TrueNTH") }}</a></li></ul>
@@ -120,7 +120,7 @@
                 <ul class="tnth-navbar-xs" style="list-style-type:none">
                     {% if login_url %}<li><a href="{{ login_url }}">{{ _("Log In to TrueNTH") }}</a></li>{% endif %}
                     <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
-                    {% if 'login_as_id' in session or (user and user.is_registered()) %}<li><a class="url-authenticated-disabled-link" href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>{% endif %}
+                    {% if 'login_as_id' in session or (user and user.is_registered()) %}<li><a class="portal-weak-auth-disabled" href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>{% endif %}
                     <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>
                     {% if user and user.has_role(ROLE.APPLICATION_DEVELOPER.value) %}<li><a href="{{PORTAL}}/clients">{{ _("Client Applications") }}</a></li>{% endif %}
                     {% if user and user.has_role(ROLE.STAFF.value, ROLE.INTERVENTION_STAFF.value) %}<li><a href="{{PORTAL}}/patients/">{{ _("Patients") }}</a></li>{% endif %}

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1621,6 +1621,7 @@ def present_needed():
 
     encounter = current_user().current_encounter
     if encounter.auth_method == "url_authenticated":
+        current_app.logger.debug('redirect to confirm identity')
         return redirect('/confirm-identity?redirect_url={}'.format(url))
 
     current_app.logger.debug('present assessment url, redirecting to: %s', url)

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1618,6 +1618,11 @@ def present_needed():
         return redirect('/')
 
     url = url_for('.present_assessment', **args)
+
+    encounter = current_user().current_encounter
+    if encounter.auth_method == "url_authenticated":
+        return redirect('/confirm-identity?redirect_url={}'.format(url))
+
     current_app.logger.debug('present assessment url, redirecting to: %s', url)
     return redirect(url, code=302)
 

--- a/portal/views/audit.py
+++ b/portal/views/audit.py
@@ -6,7 +6,7 @@ from sqlalchemy import or_
 from ..extensions import oauth
 from ..models.audit import Audit
 from ..models.role import ROLE
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import get_user
 from .crossdomain import crossdomain
 
 audit_api = Blueprint('audit_api', __name__, url_prefix='/api')
@@ -77,8 +77,7 @@ def get_audit(user_id):
       - OAuth2AuthzFlow: []
 
     """
-    user = get_user_or_abort(user_id)
-    current_user().check_role(permission='view', other_id=user.id)
+    user = get_user(user_id, 'view')
     audits = Audit.query.filter(or_(
         Audit.user_id == user.id,
         Audit.subject_id == user.id))

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -50,7 +50,7 @@ from ..models.flaskdanceprovider import (
 from ..models.intervention import Intervention, UserIntervention
 from ..models.login import login_user
 from ..models.role import ROLE
-from ..models.user import User, add_user, current_user, get_user_or_abort
+from ..models.user import User, add_user, current_user, get_user
 from .crossdomain import crossdomain
 
 auth = Blueprint('auth', __name__)
@@ -621,9 +621,8 @@ def login_as(user_id, auth_method='staff_authenticated'):
       'staff_handed_to_patient', depending on context.
 
     """
-    # said business rules enforced by check_role()
-    current_user().check_role('edit', user_id)
-    target_user = get_user_or_abort(user_id)
+    # said business rules enforced by get_user()
+    target_user = get_user(user_id, 'edit')
 
     # Guard against abuse
     if not target_user.has_role(ROLE.PATIENT.value, ROLE.PARTNER.value):

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -531,7 +531,7 @@ def next_after_login():
         assert ('invited_verified_user_id' not in session)
         assert ('login_as_id' not in session)
 
-    # Present intial questions (TOU et al) if not already obtained
+    # Present initial questions (TOU et al) if not already obtained
     # NB - this act may be suspended by request from an external
     # client during patient registration
     if (not session.get('suspend_initial_queries', None) and

--- a/portal/views/client.py
+++ b/portal/views/client.py
@@ -34,7 +34,7 @@ from ..models.auth import Token, create_service_token
 from ..models.client import Client, validate_origin
 from ..models.intervention import INTERVENTION, STATIC_INTERVENTIONS
 from ..models.role import ROLE
-from ..models.user import current_user
+from ..models.user import current_user, get_user
 from .crossdomain import crossdomain
 
 client_api = Blueprint('client', __name__)
@@ -186,7 +186,7 @@ def client_reg():
       - OAuth2AuthzFlow: []
 
     """
-    user = current_user()
+    user = get_user(current_user().id, 'view')
     form = ClientEditForm(application_role=INTERVENTION.DEFAULT.name)
     if not form.validate_on_submit():
         return render_template('client_add.html', form=form)
@@ -287,8 +287,8 @@ def client_edit(client_id):
     client = Client.query.get(client_id)
     if not client:
         abort(404)
-    user = current_user()
-    user.check_role(permission='edit', other_id=client.user_id)
+    user = get_user(current_user().id, 'view')
+    get_user(client.user_id, 'edit')  # confirm auth
 
     if request.method == 'POST':
         form = ClientEditForm(request.form)
@@ -420,7 +420,7 @@ def clients_list():
       - OAuth2AuthzFlow: []
 
     """
-    user = current_user()
+    user = get_user(current_user().id, 'view')
     if user.has_role(ROLE.ADMIN.value):
         clients = Client.query.all()
     else:

--- a/portal/views/clinical.py
+++ b/portal/views/clinical.py
@@ -7,7 +7,7 @@ from ..extensions import oauth
 from ..models.audit import Audit
 from ..models.clinical_constants import CC
 from ..models.observation import Observation
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import current_user, get_user
 from ..models.value_quantity import ValueQuantity
 from .crossdomain import crossdomain
 
@@ -360,8 +360,7 @@ def clinical(patient_id):
       - ServiceToken: []
 
     """
-    current_user().check_role(permission='view', other_id=patient_id)
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'view')
     patch_dstu2 = request.args.get('patch_dstu2', False)
     return jsonify(patient.clinical_history(
         requestURL=request.url, patch_dstu2=patch_dstu2))
@@ -430,8 +429,7 @@ def clinical_set(patient_id):
       - ServiceToken: []
 
     """
-    current_user().check_role(permission='edit', other_id=patient_id)
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'edit')
     if (not request.json or 'resourceType' not in request.json
             or request.json['resourceType'] != 'Observation'):
         abort(400, "Requires FHIR resourceType of 'Observation'")
@@ -508,8 +506,7 @@ def clinical_update(patient_id, observation_id):
       - ServiceToken: []
 
     """
-    current_user().check_role(permission='edit', other_id=patient_id)
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'edit')
     if not request.json:
         abort(400, "No update data provided")
     observation = Observation.query.filter_by(id=observation_id).first()
@@ -525,8 +522,7 @@ def clinical_update(patient_id, observation_id):
 
 def clinical_api_shortcut_set(patient_id, codeable_concept):
     """Helper for common code used in clincal api shortcuts"""
-    current_user().check_role(permission='edit', other_id=patient_id)
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'edit')
     if not request.json or 'value' not in request.json:
         abort(400, "Expects 'value' in JSON")
     value = str(request.json['value']).lower()
@@ -549,6 +545,5 @@ def clinical_api_shortcut_set(patient_id, codeable_concept):
 
 def clinical_api_shortcut_get(patient_id, codeable_concept):
     """Helper for common code used in clincal api shortcuts"""
-    current_user().check_role(permission='view', other_id=patient_id)
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'view')
     return jsonify(value=patient.concept_value(codeable_concept))

--- a/portal/views/coredata.py
+++ b/portal/views/coredata.py
@@ -14,7 +14,7 @@ from werkzeug.exceptions import Unauthorized
 from ..extensions import oauth
 from ..models.client import validate_origin
 from ..models.coredata import Coredata
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import current_user, get_user
 from .crossdomain import crossdomain
 
 coredata_api = Blueprint('coredata_api', __name__, url_prefix='/api/coredata')
@@ -65,8 +65,7 @@ def still_needed(user_id):
         'collection_method' defined if needed.
 
     """
-    current_user().check_role(permission='view', other_id=user_id)
-    user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'view')
     needed = Coredata().still_needed(user, **validate_request_args(request))
     return jsonify(still_needed=needed)
 
@@ -87,8 +86,7 @@ def requried(user_id):
         intervention affiliations.
 
     """
-    current_user().check_role(permission='view', other_id=user_id)
-    user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'view')
     required = Coredata().required(user, **validate_request_args(request))
     return jsonify(required=required)
 
@@ -109,8 +107,7 @@ def optional(user_id):
         intervention affiliations.
 
     """
-    current_user().check_role(permission='view', other_id=user_id)
-    user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'view')
     results = Coredata().optional(user, **validate_request_args(request))
     return jsonify(optional=results)
 

--- a/portal/views/demographics.py
+++ b/portal/views/demographics.py
@@ -7,7 +7,7 @@ from ..audit import auditable_event
 from ..database import db
 from ..extensions import oauth
 from ..models.reference import MissingReference
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import current_user, get_user
 from .crossdomain import crossdomain
 
 demographics_api = Blueprint('demographics_api', __name__, url_prefix='/api')
@@ -68,11 +68,9 @@ def demographics(patient_id):
       - ServiceToken: []
 
     """
-    if patient_id:
-        current_user().check_role(permission='view', other_id=patient_id)
-        patient = get_user_or_abort(patient_id)
-    else:
-        patient = current_user()
+    if patient_id is None:
+        patient_id = current_user().id
+    patient = get_user(patient_id, 'view')
     return jsonify(patient.as_fhir(include_empties=False))
 
 
@@ -147,8 +145,7 @@ def demographics_set(patient_id):
       - ServiceToken: []
 
     """
-    current_user().check_role(permission='edit', other_id=patient_id)
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'edit')
     if not request.json:
         abort(
             400,

--- a/portal/views/extend_flask_user.py
+++ b/portal/views/extend_flask_user.py
@@ -6,7 +6,7 @@ from flask_user.views import reset_password
 
 from ..audit import auditable_event
 from ..models.role import ROLE
-from ..models.user import get_user_or_abort
+from ..models.user import unchecked_get_user
 from .portal import challenge_identity
 
 
@@ -15,7 +15,7 @@ def reset_password_view_function(token):
     is_valid, has_expired, user_id = current_app.user_manager.verify_token(
         token,
         current_app.user_manager.reset_password_expiration)
-    user = get_user_or_abort(user_id)
+    user = unchecked_get_user(user_id)
 
     # as this is an entry point for not-yet-logged-in users, capture their
     # locale_code in the session for template rendering prior to logging in.

--- a/portal/views/identifier.py
+++ b/portal/views/identifier.py
@@ -10,7 +10,7 @@ from ..models.identifier import (
     UserIdentifier,
     parse_identifier_params,
 )
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import current_user, get_user
 from .crossdomain import crossdomain
 
 identifier_api = Blueprint('identifier_api', __name__)
@@ -70,8 +70,7 @@ def identifiers(user_id):
       - ServiceToken: []
 
     """
-    current_user().check_role(permission='view', other_id=user_id)
-    user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'view')
 
     # Return current identifiers
     return jsonify(identifier=[i.as_fhir() for i in user.identifiers])
@@ -153,8 +152,7 @@ def add_identifier(user_id):
       - ServiceToken: []
 
     """
-    current_user().check_role(permission='edit', other_id=user_id)
-    user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'edit')
     if not request.json or 'identifier' not in request.json:
         abort(400, "Requires identifier list")
 
@@ -229,7 +227,7 @@ def unique_user_identifier(user_id):
       - ServiceToken: []
 
     """
-    user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'view')
     system, value = parse_identifier_params(request.args.get('identifier'))
     identifier = Identifier(system=system, value=value).add_if_not_found()
     try:

--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -21,7 +21,7 @@ from ..models.identifier import Identifier
 from ..models.organization import Organization, OrganizationIdentifier, OrgTree
 from ..models.reference import MissingReference, Reference
 from ..models.role import ROLE
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import current_user, get_user
 from ..system_uri import IETF_LANGUAGE_TAG, PRACTICE_REGION
 from .crossdomain import crossdomain
 
@@ -481,11 +481,8 @@ def user_organizations(user_id):
       - ServiceToken: []
 
     """
-    current_user().check_role(permission='view', other_id=user_id)
-    user = get_user_or_abort(user_id)
-
-    # Return current organizations
-
+    # Return user's current organizations
+    user = get_user(user_id, 'view')
     return jsonify(organizations=[
         Reference.organization(org.id).as_fhir()
         for org in user.organizations])
@@ -557,8 +554,7 @@ def add_user_organizations(user_id):
       - OAuth2AuthzFlow: []
 
     """
-    current_user().check_role(permission='edit', other_id=user_id)
-    user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'edit')
     if not request.json or 'organizations' not in request.json:
         abort(400, "Requires `organizations` list")
 

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -26,7 +26,7 @@ from ..models.questionnaire_bank import QuestionnaireBank
 from ..models.questionnaire_response import QuestionnaireResponse
 from ..models.reference import Reference
 from ..models.role import ROLE
-from ..models.user import User, current_user, get_user_or_abort
+from ..models.user import User, current_user, get_user
 from .crossdomain import crossdomain
 from .demographics import demographics
 
@@ -211,8 +211,7 @@ def post_patient_deceased(patient_id):
       - ServiceToken: []
 
     """
-    current_user().check_role(permission='edit', other_id=patient_id)
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'edit')
     if not request.json or set(request.json.keys()).isdisjoint(
             {'deceasedDateTime', 'deceasedBoolean'}):
         abort(400, "Requires deceasedDateTime or deceasedBoolean in JSON")
@@ -273,8 +272,7 @@ def post_patient_dob(patient_id):
       - ServiceToken: []
 
     """
-    current_user().check_role(permission='edit', other_id=patient_id)
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'edit')
     if not request.json or 'birthDate' not in request.json:
         abort(400, "Requires `birthDate` in JSON")
 
@@ -296,11 +294,10 @@ def patient_timeline(patient_id):
     from ..models.questionnaire_bank import visit_name
     from ..trace import dump_trace, establish_trace
 
+    get_user(patient_id, permission='view')
     trace = request.args.get('trace', False)
     if trace:
         establish_trace("BEGIN time line lookup for {}".format(patient_id))
-
-    current_user().check_role(permission='view', other_id=patient_id)
 
     purge = request.args.get('purge', False)
     try:

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -19,7 +19,7 @@ from ..models.organization import Organization
 from ..models.qb_timeline import QB_StatusCacheKey, qb_status_visit_name
 from ..models.role import ROLE
 from ..models.table_preference import TablePreference
-from ..models.user import current_user, get_user_or_abort, patients_query
+from ..models.user import current_user, get_user, patients_query
 
 patients = Blueprint('patients', __name__, url_prefix='/patients')
 
@@ -109,8 +109,7 @@ def patient_profile_create():
     '/session-report/<int:subject_id>/<instrument_id>/<authored_date>')
 @oauth.require_oauth()
 def session_report(subject_id, instrument_id, authored_date):
-    current_user().check_role("view", other_id=subject_id)
-    user = get_user_or_abort(subject_id)
+    user = get_user(subject_id, 'view')
     return render_template(
         "sessionReport.html", user=user,
         current_user=current_user(), instrument_id=instrument_id,
@@ -123,8 +122,7 @@ def session_report(subject_id, instrument_id, authored_date):
 def patient_profile(patient_id):
     """individual patient view function, intended for staff"""
     user = current_user()
-    user.check_role("edit", other_id=patient_id)
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'edit')
     consent_agreements = Organization.consent_agreements(
         locale_code=user.locale_code)
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -306,7 +306,7 @@ def access_via_token(token, next_step=None):
     from when it was generated.
 
     If the token is found to be valid, and the user_id isn't associated
-    with a *privilidged* account, the behavior depends on the roles assigned
+    with a *privileged* account, the behavior depends on the roles assigned
     to the token's user_id:
     * WRITE_ONLY users will be directly logged into the weak auth account
     * others will be given a chance to prove their identity

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -542,6 +542,12 @@ def challenge_identity(
     return redirect(form.next_url.data)
 
 
+@portal.route('/confirm-identity', methods=['GET', 'POST'])
+def confirm_identity():
+    return render_template(
+        'confirm_identity.html', user=current_user(),
+        redirect_url=request.args.get("redirect_url", "/"))
+
 @portal.route('/initial-queries', methods=['GET', 'POST'])
 def initial_queries():
     """Initial consent terms, initial queries view function"""

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -414,6 +414,13 @@ def access_via_token(token, next_step=None):
     # If not WRITE_ONLY user, redirect to login page
     # Email field is auto-populated unless using alt auth (fb/google/etc)
     if user.email and user.password:
+        if (
+                not current_app.config.get('GIL') and
+                Coredata().initial_obtained(user)):
+            # TN-2627, allow completion of PROMs w/o authentication
+            login_user(user=user, auth_method='url_authenticated')
+            return next_after_login()
+
         return redirect(url_for('user.login', email=user.email))
     return redirect(url_for('user.login'))
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -415,7 +415,7 @@ def access_via_token(token, next_step=None):
     # Email field is auto-populated unless using alt auth (fb/google/etc)
     if user.email and user.password:
         if (
-                not current_app.config.get('GIL') and
+                current_app.config.get('ENABLE_URL_AUTHENTICATED') and
                 Coredata().initial_obtained(user)):
             # TN-2627, allow completion of PROMs w/o authentication
             login_user(user=user, auth_method='url_authenticated')

--- a/portal/views/procedure.py
+++ b/portal/views/procedure.py
@@ -9,7 +9,7 @@ from ..models.audit import Audit
 from ..models.procedure import Procedure
 from ..models.procedure_codes import TxNotStartedConstants, TxStartedConstants
 from ..models.qb_timeline import invalidate_users_QBT
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import current_user, get_user
 from .crossdomain import crossdomain
 
 procedure_api = Blueprint('procedure_api', __name__, url_prefix='/api')
@@ -56,8 +56,7 @@ def procedure(patient_id):
       - ServiceToken: []
 
     """
-    patient = get_user_or_abort(patient_id)
-    current_user().check_role(permission='view', other_id=patient_id)
+    patient = get_user(patient_id, 'view')
     return jsonify(patient.procedure_history(requestURL=request.url))
 
 
@@ -152,8 +151,7 @@ def post_procedure():
 
     # check the permission now that we know the subject
     patient_id = procedure.user_id
-    current_user().check_role(permission='edit', other_id=patient_id)
-    patient = get_user_or_abort(patient_id)
+    patient = get_user(patient_id, 'edit')
     patient.procedures.append(procedure)
     db.session.commit()
     auditable_event(
@@ -208,7 +206,7 @@ def procedure_delete(procedure_id):
 
     # check the permission now that we know the subject
     patient_id = procedure.user_id
-    current_user().check_role(permission='edit', other_id=patient_id)
+    get_user(patient_id, permission='edit')
     db.session.delete(procedure)
     db.session.commit()
     auditable_event(

--- a/portal/views/role.py
+++ b/portal/views/role.py
@@ -4,7 +4,7 @@ from flask import Blueprint, abort, jsonify, request
 from ..database import db
 from ..extensions import oauth
 from ..models.role import Role
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import current_user, get_user
 from .crossdomain import crossdomain
 
 role_api = Blueprint('role_api', __name__)
@@ -97,11 +97,7 @@ def roles(user_id):
       - ServiceToken: []
 
     """
-    user = current_user()
-    if user.id != user_id:
-        current_user().check_role(permission='view', other_id=user_id)
-        user = get_user_or_abort(user_id)
-
+    user = get_user(user_id, 'view')
     return jsonify(roles=[r.as_json() for r in user.roles])
 
 
@@ -161,10 +157,7 @@ def add_roles(user_id):
       - OAuth2AuthzFlow: []
 
     """
-    user = current_user()
-    if user.id != user_id:
-        current_user().check_role(permission='edit', other_id=user_id)
-        user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'edit')
     if not request.json or 'roles' not in request.json:
         abort(400, "Requires role list")
 
@@ -232,10 +225,7 @@ def delete_roles(user_id):
       - OAuth2AuthzFlow: []
 
     """
-    user = current_user()
-    if user.id != user_id:
-        current_user().check_role(permission='edit', other_id=user_id)
-        user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'edit')
     if not request.json or 'roles' not in request.json:
         abort(400, "Requires role list")
 
@@ -299,10 +289,7 @@ def set_roles(user_id):
       - OAuth2AuthzFlow: []
 
     """
-    user = current_user()
-    if user.id != user_id:
-        current_user().check_role(permission='edit', other_id=user_id)
-        user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'edit')
     if not request.json or 'roles' not in request.json:
         abort(400, "Requires role list")
 

--- a/portal/views/staff.py
+++ b/portal/views/staff.py
@@ -14,7 +14,7 @@ from ..models.app_text import (
 from ..models.communication import load_template_args
 from ..models.organization import Organization, OrgTree, UserOrganization
 from ..models.role import ROLE, Role
-from ..models.user import User, UserRoles, current_user, get_user_or_abort
+from ..models.user import User, UserRoles, current_user, get_user
 
 staff = Blueprint('staff', __name__)
 
@@ -24,11 +24,7 @@ staff = Blueprint('staff', __name__)
 @oauth.require_oauth()
 def staff_registration_email(user_id):
     """Staff Registration Email Content"""
-    if user_id:
-        user = get_user_or_abort(user_id)
-    else:
-        user = current_user()
-
+    user = get_user(user_id, 'view')
     org = user.first_top_organization()
     args = load_template_args(user=user)
 
@@ -47,7 +43,7 @@ def staff_registration_email(user_id):
 @roles_required(ROLE.STAFF_ADMIN.value)
 @oauth.require_oauth()
 def staff_profile_create():
-    user = current_user()
+    user = get_user(current_user().id, 'edit')
     consent_agreements = Organization.consent_agreements(
         locale_code=user.locale_code)
 
@@ -61,7 +57,7 @@ def staff_profile_create():
 @oauth.require_oauth()
 def staff_profile(user_id):
     """staff profile view function"""
-    user = get_user_or_abort(user_id)
+    user = get_user(user_id, 'edit')
     consent_agreements = Organization.consent_agreements(
         locale_code=user.locale_code)
     terms = VersionedResource(
@@ -84,7 +80,7 @@ def staff_index():
     the staff admin's organizations (and any descendant organizations)
 
     """
-    user = current_user()
+    user = get_user(current_user().id, 'edit')
 
     ot = OrgTree()
     staff_role_id = Role.query.filter(
@@ -96,7 +92,7 @@ def staff_index():
 
     user_orgs = set()
 
-    # Build list of all organization ids, and their decendents, the
+    # Build list of all organization ids, and their descendents, the
     # user belongs to
     for org in user.organizations:
         if org.id == 0:  # None of the above doesn't count

--- a/portal/views/tou.py
+++ b/portal/views/tou.py
@@ -232,8 +232,8 @@ def post_user_accepted_tou(user_id):
       - ServiceToken: []
 
     """
-    authd_user = current_user()
-    authd_user.check_role(permission='edit', other_id=user_id)
+    authd_user = get_user(current_user().id, 'view')
+    get_user(user_id, 'edit')  # confirm auth
     audit = Audit(
         user_id=authd_user.id, subject_id=user_id,
         comment="user {} posting accepted ToU for user {}".format(

--- a/portal/views/tou.py
+++ b/portal/views/tou.py
@@ -10,7 +10,7 @@ from ..extensions import oauth
 from ..models.app_text import InitialConsent_ATMA, VersionedResource, app_text
 from ..models.audit import Audit
 from ..models.tou import ToU, tou_types
-from ..models.user import current_user, get_user_or_abort
+from ..models.user import current_user, get_user
 from .crossdomain import crossdomain
 
 tou_api = Blueprint('tou_api', __name__, url_prefix='/api')
@@ -97,8 +97,7 @@ def get_tou(user_id):
       - ServiceToken: []
 
     """
-    user = get_user_or_abort(user_id)
-    current_user().check_role(permission='view', other_id=user.id)
+    user = get_user(user_id, 'view')
     tous = ToU.query.join(Audit).filter(Audit.user_id == user.id)
     if not request.args.get('all'):
         tous = tous.filter(ToU.active.is_(True))
@@ -166,11 +165,7 @@ def get_tou_by_type(user_id, tou_type):
       - ServiceToken: []
 
     """
-    user = get_user_or_abort(user_id)
-    if not user:
-        abort(404)
-    current_user().check_role(permission='view', other_id=user_id)
-
+    get_user(user_id, 'view')
     tou_type = sub('-', ' ', tou_type)
 
     try:
@@ -290,14 +285,13 @@ def accept_tou(user_id=None):
       - ServiceToken: []
 
     """
-    if user_id:
-        user = get_user_or_abort(user_id)
-    else:
-        user = current_user()
+    if user_id is None:
+        user_id = current_user().id
+    user = get_user(user_id, 'edit')
     if not request.json or 'agreement_url' not in request.json:
         abort(400, "Requires JSON with the ToU 'agreement_url'")
     audit = Audit(
-        user_id=user.id, subject_id=user.id,
+        user_id=current_user().id, subject_id=user.id,
         comment="ToU accepted", context='tou')
     tou_type = request.json.get('type') or 'website terms of use'
     if tou_type not in tou_types.enums:

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -2061,7 +2061,7 @@ def get_table_preferences(user_id, table_name):
     user = get_user(user_id, 'view')
     pref = TablePreference.query.filter_by(
         table_name=table_name, user_id=user.id).first()
-    # 404 case handled by current_user() or check_role above.  Return
+    # 404 case handled by get_user() above.  Return
     # empty list if no preferences yet exist.
     if not pref:
         return jsonify({})

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -43,7 +43,7 @@ from portal.models.questionnaire import Questionnaire
 from portal.models.relationship import add_static_relationships
 from portal.models.role import ROLE, Role, add_static_roles
 from portal.models.tou import ToU
-from portal.models.user import User, UserRoles, get_user
+from portal.models.user import User, UserRoles
 from portal.models.user_consent import (
     INCLUDE_IN_REPORTS_MASK,
     SEND_REMINDERS_MASK,
@@ -303,7 +303,7 @@ class TestCase(Base):
         """
         audit = Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID)
         for cc in CC.BIOPSY, CC.PCaDIAG, CC.PCaLocalized:
-            get_user(TEST_USER_ID).save_observation(
+            User.query.get(TEST_USER_ID).save_observation(
                 codeable_concept=cc, value_quantity=CC.TRUE_VALUE,
                 audit=audit, status='preliminary', issued=calc_date_params(
                     backdate=backdate, setdate=setdate))

--- a/tests/test_assessment_engine.py
+++ b/tests/test_assessment_engine.py
@@ -24,7 +24,7 @@ from portal.models.questionnaire_response import (
 )
 from portal.models.research_protocol import ResearchProtocol
 from portal.models.role import ROLE
-from portal.models.user import get_user
+from portal.models.user import User
 from portal.models.user_consent import UserConsent
 from portal.system_uri import (
     TRUENTH_STATUS_EXTENSION,
@@ -218,7 +218,7 @@ class TestAssessmentEngine(TestCase):
         qbq = QuestionnaireBankQuestionnaire(questionnaire=qn, rank=0)
         qb.questionnaires.append(qbq)
 
-        test_user = get_user(TEST_USER_ID)
+        test_user = User.query.get(TEST_USER_ID)
         test_user.organizations.append(org)
         authored = FHIR_datetime.parse(data['authored'])
         audit = Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID)
@@ -289,7 +289,7 @@ class TestAssessmentEngine(TestCase):
         qbq = QuestionnaireBankQuestionnaire(questionnaire=qn, rank=0)
         qb.questionnaires.append(qbq)
 
-        test_user = get_user(TEST_USER_ID)
+        test_user = User.query.get(TEST_USER_ID)
         test_user.organizations.append(org)
         authored = FHIR_datetime.parse(data['authored'])
         audit = Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID)
@@ -310,7 +310,7 @@ class TestAssessmentEngine(TestCase):
         response = self.client.post(
             '/api/patient/{}/assessment'.format(TEST_USER_ID), json=data)
         assert response.status_code == 200
-        test_user = get_user(TEST_USER_ID)
+        test_user = User.query.get(TEST_USER_ID)
         qb = db.session.merge(qb)
         assert test_user.questionnaire_responses.count() == 1
         assert (
@@ -349,7 +349,7 @@ class TestAssessmentEngine(TestCase):
         qbq = QuestionnaireBankQuestionnaire(questionnaire=qn, rank=0)
         qb.questionnaires.append(qbq)
 
-        test_user = get_user(TEST_USER_ID)
+        test_user = User.query.get(TEST_USER_ID)
         test_user.organizations.append(org)
         authored = FHIR_datetime.parse(data['authored'])
         audit = Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID)
@@ -370,7 +370,7 @@ class TestAssessmentEngine(TestCase):
         response = self.client.post(
             '/api/patient/{}/assessment'.format(TEST_USER_ID), json=data)
         assert response.status_code == 200
-        test_user = get_user(TEST_USER_ID)
+        test_user = User.query.get(TEST_USER_ID)
         assert test_user.questionnaire_responses.count() == 1
         assert (
             test_user.questionnaire_responses[0].questionnaire_bank_id

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -33,7 +33,7 @@ from portal.models.questionnaire_response import (
 from portal.models.recur import Recur
 from portal.models.research_protocol import ResearchProtocol
 from portal.models.role import ROLE
-from portal.models.user import get_user
+from portal.models.user import User
 from portal.system_uri import ICHOM
 from tests import TEST_USER_ID, TestCase, associative_backdate
 
@@ -70,7 +70,7 @@ def mock_qr(
         db.session.commit()
     enc = db.session.merge(enc)
     if not qb:
-        qstats = QB_Status(get_user(user_id), timestamp)
+        qstats = QB_Status(User.query.get(user_id), timestamp)
         qbd = qstats.current_qbd()
         qb, iteration = qbd.questionnaire_bank, qbd.iteration
 

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -15,7 +15,7 @@ from portal.models.intervention import INTERVENTION, UserIntervention
 from portal.models.message import EmailMessage
 from portal.models.organization import Organization
 from portal.models.role import ROLE
-from portal.models.user import User, get_user
+from portal.models.user import User
 from tests import OAUTH_INFO_PROVIDER_LOGIN, TEST_USER_ID, TestCase
 
 
@@ -270,7 +270,7 @@ class TestPortalEproms(TestCase):
         self.promote_user(role_name=ROLE.STAFF.value)
 
         org = Organization(name='test org')
-        user = get_user(TEST_USER_ID)
+        user = User.query.get(TEST_USER_ID)
         with SessionScope(db):
             db.session.add(org)
             user.organizations.append(org)

--- a/tests/test_site_persistence.py
+++ b/tests/test_site_persistence.py
@@ -28,7 +28,7 @@ from portal.models.questionnaire_bank import (
 from portal.models.recur import Recur
 from portal.models.research_protocol import ResearchProtocol
 from portal.models.role import ROLE
-from portal.models.user import get_user
+from portal.models.user import User
 from tests import TEST_USER_ID, TestCase
 
 
@@ -83,7 +83,7 @@ class TestSitePersistence(TestCase):
             db.session.commit()
         self.add_procedure(
             code='424313000', display='Started active surveillance')
-        get_user(TEST_USER_ID).save_observation(
+        User.query.get(TEST_USER_ID).save_observation(
             codeable_concept=CC.PCaLocalized, value_quantity=CC.TRUE_VALUE,
             audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID),
             status=None, issued=None)

--- a/tests/test_tou.py
+++ b/tests/test_tou.py
@@ -72,7 +72,8 @@ class TestTou(TestCase):
         assert response.status_code == 200
         tou = ToU.query.one()
         assert tou.agreement_url == tou_url
-        assert tou.audit.user_id == TEST_USER_ID
+        assert tou.audit.user_id == service_user.id
+        assert tou.audit.subject_id == TEST_USER_ID
 
     def test_get(self):
         audit = Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -39,7 +39,7 @@ from portal.models.user import (
     UserIndigenousStatusExtension,
     UserObservation,
     UserRelationship,
-    get_user_or_abort,
+    get_user,
     permanently_delete_user,
     user_extension_map,
 )
@@ -55,12 +55,12 @@ from tests import TEST_USER_ID, TEST_USERNAME, TestCase
 
 def test_null_id():
     with pytest.raises(BadRequest):
-        get_user_or_abort(None)
+        get_user(None, 'view')
 
 
 def test_empty_id():
     with pytest.raises(NotFound):
-        get_user_or_abort('')
+        get_user('', 'view')
 
 
 class TestUser(TestCase):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -391,6 +391,13 @@ class TestUser(TestCase):
         response = self.client.post('/api/user/{}/reactivate'.format(user_id))
         assert response.status_code == 400
 
+    def test_user_encounter(self):
+        self.login()
+        response = self.client.get(
+            '/api/user/{}/encounter'.format(TEST_USER_ID))
+        assert response.status_code == 200
+        assert response.json['auth_method'] == 'password_authenticated'
+
     def test_user_timezone(self):
         assert self.test_user.timezone == 'UTC'
         self.login()

--- a/tests/test_user_document.py
+++ b/tests/test_user_document.py
@@ -11,7 +11,7 @@ from portal.date_tools import FHIR_datetime
 from portal.extensions import db
 from portal.models.auth import create_service_token
 from portal.models.intervention import INTERVENTION
-from portal.models.user import get_user
+from portal.models.user import User
 from portal.models.user_document import UserDocument
 from tests import TEST_USER_ID, TestCase
 
@@ -52,7 +52,7 @@ class TestUserDocument(TestCase):
         # user doc file
         client = self.add_client()
         client.intervention = INTERVENTION.SEXUAL_RECOVERY
-        create_service_token(client=client, user=get_user(TEST_USER_ID))
+        create_service_token(client=client, user=User.query.get(TEST_USER_ID))
         self.login()
 
         test_contents = b"This is a test."


### PR DESCRIPTION
NB - to enable, set config value `ENABLE_URL_AUTHENTICATED` to a non false value.

- TN-2636: Add endpoint for front-end to acquire logged in user's current encounter.  The `auth_method` will define features that should be hidden from the user, such as making profile changes when `auth_method == 'url_authenticated'`
 
- TN-2635: Entry via /access/<token> now allows EPROMs users direct access, providing they've registered and finished initial queries.  The encounter will have the aforementioned `auth_method == 'url_authenticated'`

- TN-2647: Add css-class "portal-weak-auth-disabled" to the completed assessment tile, so the front end can disable or redirect to login, when the user's current encounter has `auth_method == 'url_authenticated'`

- TN-2648: Consider `url_authenticated` when evaluating authorization for all API endpoints