### PR TITLE
TN-2628 followup fix - address issue where redirect url was truncated

### DIFF
--- a/portal/eproms/templates/eproms/base.html
+++ b/portal/eproms/templates/eproms/base.html
@@ -67,7 +67,7 @@
                     <h2 class="modal-title">{{ _("Limited Access") }}</h2>
                 </div>
                 <div class="modal-body">
-                    <p>{{_("If you want to access that, you'll need to log in with your username and password.")}}</p>
+                    <p>{{_("To access this information, you will need to log in with your username and password.")}}</p>
                     <br/>
                     <div class="buttons-container text-center">
                         <a type="button" class="btn btn-default btn-tnth-primary btn-lg" data-dismiss="modal">{{ _("Continue with limited access") }}</a>

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -15,6 +15,7 @@ from flask import (
 )
 from flask_babel import gettext as _
 from flask_user import roles_required
+from urllib.parse import quote
 import jsonschema
 import requests
 
@@ -1622,7 +1623,7 @@ def present_needed():
     encounter = current_user().current_encounter
     if encounter.auth_method == "url_authenticated":
         current_app.logger.debug('redirect to confirm identity')
-        return redirect('/confirm-identity?redirect_url={}'.format(url))
+        return redirect('/confirm-identity?redirect_url={}'.format(quote(url)))
 
     current_app.logger.debug('present assessment url, redirecting to: %s', url)
     return redirect(url, code=302)


### PR DESCRIPTION
A followup bug fix for this story: https://jira.movember.com/browse/TN-2628
**Issue**: Once a url-authenticated user has confirmed identity as survey taker, the ensuing URL the user was redirected was missing required parameters (e.g. resume instrument id, etc.)
**Fix**: to properly encode URL that is being passed as a query string to the confirm identity view

Also added text change per communication from Cam: https://jira.movember.com/browse/TN-2659