### PR TITLE
Substudy Docker Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+*.egg-info
+*.egg
+*.eggs
+*.env
+*.sqlite
+*.pyc
+*~
+*.swp
+application.cfg
+site.cfg
+celerybeat.pid
+celerybeat-schedule
+env
+lib
+local
+include
+man
+pip-selfcheck.json
+log
+portal/test_uploads
+docker/portal.env
+docker/docker-compose.dev.*.yaml
+
+geckodriver.log
+coverage.xml
+
+.coverage
+.idea
+.project
+.pydevproject
+.pytest_cache
+.settings
+.tox
+
+# compiled (binary) translation files
+*.mo
+
+# generated CSS files
+portal/static/css/*.css
+
+# nodeJS virtual environment and files
+node_env/
+portal/node_modules/
+portal/package-lock.json
+
+# auto-generated JS eslint config when linting JS files (via command eslint) at development
+portal/static/js/.eslintrc.js
+portal/eproms/static/js/.eslintrc.js
+
+# auto-generated folders housing files from the frontend build, i.e. substudy tailored content
+portal/static/templates
+portal/static/bundle
+portal/eproms_substudy_tailored_content/node_modules
+portal/eproms_substudy_tailored_content/dist

--- a/bin/docker-build.sh
+++ b/bin/docker-build.sh
@@ -21,31 +21,10 @@ USAGE
    exit 1
 }
 
-cleanup_generated_dockerignore() {
-    local file_copied="$1"
-    if [ -n "$file_copied" ]; then
-        rm "${repo_path}/.dockerignore"
-        echo "Deleted generated .dockerignore"
-    fi
-}
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     usage
 fi
-
-
-# Use .gitignore as .dockerignore during build only
-# not worth the effort to maintain both, for now
-copy_output="$(
-    cp \
-        --no-clobber \
-        --verbose \
-        "${repo_path}/.gitignore" \
-        "${repo_path}/.dockerignore"
-)"
-
-# "->" will appear in `cp` output if file is sucessfully copied
-file_copied="$(echo "$copy_output" | grep "\->" || true)"
 
 # docker-compose commands must be run in the same directory as docker-compose.yaml
 docker_compose_directory="${repo_path}/docker"
@@ -57,11 +36,5 @@ default_portal_env="${PORTAL_ENV_FILE:-portal.env}"
 # Create required env_file if it doesn't exist
 cp --no-clobber portal.env.default "$default_portal_env"
 
-
-# use trap to cleanup generated .dockerignore on early exit
-trap 'cleanup_generated_dockerignore "$file_copied"; exit' INT TERM EXIT
 echo "Building portal docker image..."
 docker-compose build web
-trap - INT TERM EXIT
-
-cleanup_generated_dockerignore "$file_copied"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,8 @@ WORKDIR "$HOME/portal"
 COPY . .
 
 # Copy substudy app files built in substudy_app stage
-COPY --from=substudy_app /tmp/substudy_app/dist/* /portal/portal/static/
+COPY --from=substudy_app /tmp/substudy_app/dist/bundle /portal/portal/static/bundle
+COPY --from=substudy_app /tmp/substudy_app/dist/templates /portal/portal/static/templates
 
 # Install build dependencies
 RUN \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR "$HOME/portal"
 COPY . .
 
 # Copy substudy app files built in substudy_app stage
-COPY --from=substudy_app /tmp/substudy_app/dist /portal/portal/static
+COPY --from=substudy_app /tmp/substudy_app/dist/* /portal/portal/static/
 
 # Install build dependencies
 RUN \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,17 @@
+FROM node:12 as substudy_app
+
+RUN mkdir /tmp/substudy_app
+WORKDIR /tmp/substudy_app
+
+# Copy required front-end files only
+COPY  portal/eproms_substudy_tailored_content/  ./
+
+RUN npm install
+
+RUN npm run build
+# -----------------------------------------------------------------------------
+
+
 FROM debian:buster as builder
 
 ENV \
@@ -18,6 +32,9 @@ WORKDIR "$HOME/portal"
 
 # Copy repo into image
 COPY . .
+
+# Copy substudy app files built in substudy_app stage
+COPY --from=substudy_app /tmp/substudy_app/dist /portal/portal/static
 
 # Install build dependencies
 RUN \

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,6 +91,7 @@ portal =
     static/js/dist/*.js
     static/css/*.css
     */static/css/*.css
+    static/*
 
 [tool:pytest]
 addopts = --color yes --verbose


### PR DESCRIPTION
Merges into #3713 

* Build substudy content as isolated docker stage
  * Use nodejs docker image as base
* Reduce scripting complexity, add `.dockerignore`