### PR TITLE
Bugfix/url authenticated modal display

### DIFF
--- a/portal/eproms/templates/eproms/base.html
+++ b/portal/eproms/templates/eproms/base.html
@@ -59,27 +59,6 @@
             {%- endblock -%}
           </div> {# <!-- <div id="mainDiv"> --> #}
         </div> {# <!-- <div id="mainHolder"> --> #}
-        <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
-                    <h2 class="modal-title">{{ _("Limited Access") }}</h2>
-                </div>
-                <div class="modal-body">
-                    <p>{{_("To access this information, you will need to log in with your username and password.")}}</p>
-                    <br/>
-                    <div class="buttons-container text-center">
-                        <a type="button" class="btn btn-default btn-tnth-primary btn-lg" data-dismiss="modal">{{ _("Continue with limited access") }}</a>
-                        <a id="btnUrlAuthenticatedContinue" type="button" class="btn btn-default btn-tnth-primary btn-lg" data-dismiss="modal">{{ _("Log in to see more") }}</a>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">{{ _("Close") }}</button>
-                </div>
-                </div>
-            </div>
-        </div>
         {# One-time system messages called Flash messages #}
         {% block flash_messages %}
             {%- with messages = get_flashed_messages(with_categories=true) -%}

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -1,6 +1,4 @@
 var URLAuthenticatedModalObj = function() {
-    this.URL_AUTH_METHOD_IDENTIFIER = "url_authenticated";
-    this.PROMOTE_ENCOUNTER_URL = "/promote-encounter";
     /*
      * initialized modal
      */
@@ -19,7 +17,8 @@ var URLAuthenticatedModalObj = function() {
         if (!data || !data.id) {
             return;
         }
-        var self = this;
+        var URL_AUTH_METHOD_IDENTIFIER = "url_authenticated";
+        var PROMOTE_ENCOUNTER_URL = "/promote-encounter";
         //call to check if the current user is authenticated via url authenticated method
         $.ajax({
             type: "GET",
@@ -28,13 +27,13 @@ var URLAuthenticatedModalObj = function() {
             if (!data || !data.auth_method) {
                 return;
             }
-            if (String(data.auth_method).toLowerCase() === self.URL_AUTH_METHOD_IDENTIFIER) {
+            if (String(data.auth_method).toLowerCase() === URL_AUTH_METHOD_IDENTIFIER) {
                 //links needing to redirect to login page 
                 $(".portal-weak-auth-disabled").each(function() {
                     $(this).on("click", function(e) {
                         e.preventDefault();
                         var originalHref = $(this).attr("href");
-                        var redirectHref = self.PROMOTE_ENCOUNTER_URL+"?next="+originalHref;
+                        var redirectHref = PROMOTE_ENCOUNTER_URL+"?next="+originalHref;
                         $(this).attr("href", redirectHref);
                         $("#btnUrlAuthenticatedContinue").attr("href", redirectHref);
                         $("#urlAuthenticatedModal").modal("show");

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -44,7 +44,8 @@ URLAuthenticatedModalObj.prototype.setURLAuthenticatedUI = function() {
         //call to check if the current user is authenticated via url authenticated method
         $.ajax({
             type: "GET",
-            url: self.getPortalBaseURL() + "/api/user/" + data.id + "/encounter"
+            url: self.getPortalBaseURL() + "/api/user/" + data.id + "/encounter",
+            crossDomain: true
         }).done(function(data) {
             if (!data || !data.auth_method) {
                 return;
@@ -84,7 +85,8 @@ URLAuthenticatedModalObj.prototype.getCurrentUser = function(callback) {
     }
     $.ajax({
         type: "GET",
-        url: this.getPortalBaseURL() + "/api/me"
+        url: this.getPortalBaseURL() + "/api/me",
+        crossDomain: true
     }).done(function(data) {
         if (!data || !data.id) {
             callback({error: true});

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -1,0 +1,69 @@
+var URLAuthenticatedModalObj = function() {
+    this.URL_AUTH_METHOD_IDENTIFIER = "url_authenticated";
+    this.PROMOTE_ENCOUNTER_URL = "/promote-encounter";
+    /*
+     * initialized modal
+     */
+    this.initURLAuthenticatedModal = function() {
+        $("#urlAuthenticatedModal").modal({
+            "show":false,
+            "backdrop": "static",
+            "focus": true,
+            "keyboard": false
+        });
+    }
+    /*
+     * set UI element with matching CSS class identifier to trigger modal
+     */
+    this.setURLAuthenticatedUI = function(data) {
+        if (!data || !data.id) {
+            return;
+        }
+        var self = this;
+        //call to check if the current user is authenticated via url authenticated method
+        $.ajax({
+            type: "GET",
+            url: "/api/user/" + data.id + "/encounter"
+        }).done(function(data) {
+            if (!data || !data.auth_method) {
+                return;
+            }
+            if (String(data.auth_method).toLowerCase() === self.URL_AUTH_METHOD_IDENTIFIER) {
+                //links needing to redirect to login page 
+                $(".portal-weak-auth-disabled").each(function() {
+                    $(this).on("click", function(e) {
+                        e.preventDefault();
+                        var originalHref = $(this).attr("href");
+                        var redirectHref = self.PROMOTE_ENCOUNTER_URL+"?next="+originalHref;
+                        $(this).attr("href", redirectHref);
+                        $("#btnUrlAuthenticatedContinue").attr("href", redirectHref);
+                        $("#urlAuthenticatedModal").modal("show");
+                    });
+                });
+                //elements needing to be hidden
+                $(".portal-weak-auth-hide").each(function() {
+                    $(this).hide();
+                });
+            }
+        });
+    };
+    this.getCurrentUser = function (callback) {
+        callback = callback || function() {};
+        $.ajax({
+            type: "GET",
+            url: "/api/me"
+        }).done(function(data) {
+            if (!data || !data.id) {
+                callback({error: true});
+                return;
+            }
+            callback(data);
+        }).fail(function() {
+            callback({error: true});
+        });
+    };
+    this.init = function() {
+        this.initURLAuthenticatedModal();
+        this.getCurrentUser(this.setURLAuthenticatedUI);
+    };
+};

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -77,7 +77,6 @@ URLAuthenticatedModalObj.prototype.setURLAuthenticatedUI = function() {
  */
 URLAuthenticatedModalObj.prototype.getCurrentUser = function(callback) {
     callback = callback || function() {};
-    console.log("PORTAL BASE ? ", this.getPortalBaseURL())
     $.ajax({
         type: "GET",
         url: this.getPortalBaseURL() + "/api/me"

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -1,24 +1,33 @@
-var URLAuthenticatedModalObj = function() {
-    /*
-     * initialized modal
-     */
-    this.initURLAuthenticatedModal = function() {
-        $("#urlAuthenticatedModal").modal({
-            "show":false,
-            "backdrop": "static",
-            "focus": true,
-            "keyboard": false
-        });
-    }
-    /*
-     * set UI element with matching CSS class identifier to trigger modal
-     */
-    this.setURLAuthenticatedUI = function(data) {
+/* 
+ * see urlAuthenticatedLoginModal macro in /templates/flask_user/_macros for modal HTML
+ */
+function URLAuthenticatedModalObj() {
+    this.URL_AUTH_METHOD_IDENTIFIER = "url_authenticated";
+    this.PROMOTE_ENCOUNTER_URL = "/promote-encounter";
+    this.MODAL_ELEMENT_IDENTIFIER = "urlAuthenticatedModal";
+};
+
+/*
+ * initialized login prompt modal
+ */
+URLAuthenticatedModalObj.prototype.initURLAuthenticatedModal = function() {
+    $("#"+this.MODAL_ELEMENT_IDENTIFIER).modal({
+        "show":false,
+        "backdrop": "static",
+        "focus": true,
+        "keyboard": false
+    });
+};
+
+/*
+ * set UI element with matching CSS class identifier to trigger the login modal
+ */
+URLAuthenticatedModalObj.prototype.setURLAuthenticatedUI = function() {
+    var self = this;
+    this.getCurrentUser(function(data) {
         if (!data || !data.id) {
             return;
         }
-        var URL_AUTH_METHOD_IDENTIFIER = "url_authenticated";
-        var PROMOTE_ENCOUNTER_URL = "/promote-encounter";
         //call to check if the current user is authenticated via url authenticated method
         $.ajax({
             type: "GET",
@@ -27,42 +36,54 @@ var URLAuthenticatedModalObj = function() {
             if (!data || !data.auth_method) {
                 return;
             }
-            if (String(data.auth_method).toLowerCase() === URL_AUTH_METHOD_IDENTIFIER) {
-                //links needing to redirect to login page 
-                $(".portal-weak-auth-disabled").each(function() {
-                    $(this).on("click", function(e) {
-                        e.preventDefault();
-                        var originalHref = $(this).attr("href");
-                        var redirectHref = PROMOTE_ENCOUNTER_URL+"?next="+originalHref;
-                        $(this).attr("href", redirectHref);
-                        $("#btnUrlAuthenticatedContinue").attr("href", redirectHref);
-                        $("#urlAuthenticatedModal").modal("show");
-                    });
-                });
+            if (String(data.auth_method).toLowerCase() === self.URL_AUTH_METHOD_IDENTIFIER) {
+                //links needing to redirect to login page
+                $("body").delegate(".portal-weak-auth-disabled", "click", function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    var originalHref = $(this).attr("href");
+                    var redirectHref = self.PROMOTE_ENCOUNTER_URL+"?next="+originalHref;
+                    $(this).attr("href", redirectHref);
+                    $("#btnUrlAuthenticatedContinue").attr("href", redirectHref);
+                    $("#"+self.MODAL_ELEMENT_IDENTIFIER).modal("show");
+                })
                 //elements needing to be hidden
-                $(".portal-weak-auth-hide").each(function() {
-                    $(this).hide();
-                });
+                $(".portal-weak-auth-hide").each(
+                    function() {
+                        $(this).hide();
+                    }
+                );
             }
         });
-    };
-    this.getCurrentUser = function (callback) {
-        callback = callback || function() {};
-        $.ajax({
-            type: "GET",
-            url: "/api/me"
-        }).done(function(data) {
-            if (!data || !data.id) {
-                callback({error: true});
-                return;
-            }
-            callback(data);
-        }).fail(function() {
+    });
+};
+
+/*
+ * get current user information
+ * @param callback function to execute when data is returned from API
+ */
+URLAuthenticatedModalObj.prototype.getCurrentUser = function(callback) {
+    callback = callback || function() {};
+    callback.bind(this);
+    $.ajax({
+        type: "GET",
+        url: "/api/me"
+    }).done(function(data) {
+        if (!data || !data.id) {
             callback({error: true});
-        });
-    };
-    this.init = function() {
-        this.initURLAuthenticatedModal();
-        this.getCurrentUser(this.setURLAuthenticatedUI);
-    };
+            return;
+        }
+        callback(data);
+    }).fail(function() {
+        callback({error: true});
+    });
+};
+
+/*
+ * initializing object
+ * this will initialize the login modal and set UI states/events appropiately
+ */
+URLAuthenticatedModalObj.prototype.init = function() {
+    this.initURLAuthenticatedModal();
+    this.setURLAuthenticatedUI();
 };

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -5,6 +5,7 @@ function URLAuthenticatedModalObj() {
     this.URL_AUTH_METHOD_IDENTIFIER = "url_authenticated";
     this.PROMOTE_ENCOUNTER_URL = "/promote-encounter";
     this.MODAL_ELEMENT_IDENTIFIER = "urlAuthenticatedModal";
+    this.PORTAL_BASE_URL = window.location.protocol + "//" + window.location.host;
 };
 
 /*
@@ -31,7 +32,7 @@ URLAuthenticatedModalObj.prototype.setURLAuthenticatedUI = function() {
         //call to check if the current user is authenticated via url authenticated method
         $.ajax({
             type: "GET",
-            url: "/api/user/" + data.id + "/encounter"
+            url: this.PORTAL_BASE_URL + "/api/user/" + data.id + "/encounter"
         }).done(function(data) {
             if (!data || !data.auth_method) {
                 return;
@@ -67,7 +68,7 @@ URLAuthenticatedModalObj.prototype.getCurrentUser = function(callback) {
     callback.bind(this);
     $.ajax({
         type: "GET",
-        url: "/api/me"
+        url: this.PORTAL_BASE_URL + "/api/me"
     }).done(function(data) {
         if (!data || !data.id) {
             callback({error: true});

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -3,10 +3,22 @@
  */
 function URLAuthenticatedModalObj() {
     this.URL_AUTH_METHOD_IDENTIFIER = "url_authenticated";
-    this.PROMOTE_ENCOUNTER_URL = "/promote-encounter";
     this.MODAL_ELEMENT_IDENTIFIER = "urlAuthenticatedModal";
-    this.PORTAL_BASE_URL = window.location.protocol + "//" + window.location.host;
 };
+
+/*
+ * return Portal base URL, important to affix when calling api from intervention
+ */
+URLAuthenticatedModalObj.prototype.getPortalBaseURL = function() {
+    return $("#"+this.MODAL_ELEMENT_IDENTIFIER).attr("data-ref-url") || (window.location.protocol + "//" + window.location.host);
+}
+
+/*
+ * return URL for promoting encounter
+ */
+URLAuthenticatedModalObj.prototype.getPromoteEncounterURL = function() {
+    return this.getPortalBaseURL() + "/promote-encounter";
+}
 
 /*
  * initialized login prompt modal
@@ -32,7 +44,7 @@ URLAuthenticatedModalObj.prototype.setURLAuthenticatedUI = function() {
         //call to check if the current user is authenticated via url authenticated method
         $.ajax({
             type: "GET",
-            url: self.PORTAL_BASE_URL + "/api/user/" + data.id + "/encounter"
+            url: self.getPortalBaseURL() + "/api/user/" + data.id + "/encounter"
         }).done(function(data) {
             if (!data || !data.auth_method) {
                 return;
@@ -43,7 +55,7 @@ URLAuthenticatedModalObj.prototype.setURLAuthenticatedUI = function() {
                     e.preventDefault();
                     e.stopPropagation();
                     var originalHref = $(this).attr("href");
-                    var redirectHref = self.PROMOTE_ENCOUNTER_URL+"?next="+originalHref;
+                    var redirectHref = self.getPromoteEncounterURL()+"?next="+originalHref;
                     $(this).attr("href", redirectHref);
                     $("#btnUrlAuthenticatedContinue").attr("href", redirectHref);
                     $("#"+self.MODAL_ELEMENT_IDENTIFIER).modal("show");
@@ -65,10 +77,10 @@ URLAuthenticatedModalObj.prototype.setURLAuthenticatedUI = function() {
  */
 URLAuthenticatedModalObj.prototype.getCurrentUser = function(callback) {
     callback = callback || function() {};
-    console.log("PORTAL BASE ? ", this.PORTAL_BASE_URL)
+    console.log("PORTAL BASE ? ", this.getPortalBaseURL())
     $.ajax({
         type: "GET",
-        url: this.PORTAL_BASE_URL + "/api/me"
+        url: this.getPortalBaseURL() + "/api/me"
     }).done(function(data) {
         if (!data || !data.id) {
             callback({error: true});

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -77,6 +77,11 @@ URLAuthenticatedModalObj.prototype.setURLAuthenticatedUI = function() {
  */
 URLAuthenticatedModalObj.prototype.getCurrentUser = function(callback) {
     callback = callback || function() {};
+    var presetUserId = $("#"+this.MODAL_ELEMENT_IDENTIFIER).attr("data-user-id");
+    if (presetUserId) {
+        callback({"id": presetUserId});
+        return;
+    }
     $.ajax({
         type: "GET",
         url: this.getPortalBaseURL() + "/api/me"

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -32,7 +32,7 @@ URLAuthenticatedModalObj.prototype.setURLAuthenticatedUI = function() {
         //call to check if the current user is authenticated via url authenticated method
         $.ajax({
             type: "GET",
-            url: this.PORTAL_BASE_URL + "/api/user/" + data.id + "/encounter"
+            url: self.PORTAL_BASE_URL + "/api/user/" + data.id + "/encounter"
         }).done(function(data) {
             if (!data || !data.auth_method) {
                 return;
@@ -65,7 +65,7 @@ URLAuthenticatedModalObj.prototype.setURLAuthenticatedUI = function() {
  */
 URLAuthenticatedModalObj.prototype.getCurrentUser = function(callback) {
     callback = callback || function() {};
-    callback.bind(this);
+    console.log("PORTAL BASE ? ", this.PORTAL_BASE_URL)
     $.ajax({
         type: "GET",
         url: this.PORTAL_BASE_URL + "/api/me"

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -39,6 +39,9 @@ URLAuthenticatedModalObj.prototype.getProvidedAuthMethod = function() {
     return $("#"+this.MODAL_ELEMENT_IDENTIFIER).attr("data-auth-method");
 };
 
+/*
+ * update UI state and attribute, e.g. href, when encounter auth method is url-authenticated
+ */
 URLAuthenticatedModalObj.prototype.setUI = function() {
     var self = this;
     //links needing to redirect to login page

--- a/portal/static/js/src/modules/Global.js
+++ b/portal/static/js/src/modules/Global.js
@@ -78,49 +78,6 @@ export default { /*global $ i18next */ /*initializing functions performed only o
 
         return cachedCurrentUserId;
     },
-    "checkURLAuthenticated": function() {
-        $("#urlAuthenticatedModal").modal({
-            "show":false,
-            "backdrop": "static",
-            "focus": true,
-            "keyboard": false
-        });
-        this.getCurrentUser(
-            function(userId) {
-                if (!userId) {
-                    return;
-                }
-                const url_auth_method = "url_authenticated";
-                //call to check if the current user is authenticated via url authenticated method
-                $.ajax({
-                    type: "GET",
-                    url: `/api/user/${userId}/encounter`
-                }).done(function(data) {
-                    if (!data || !data.auth_method) {
-                        return;
-                    }
-                    if (String(data.auth_method).toLowerCase() === url_auth_method) {
-                        const loginPath = "/user/sign-in";
-                        //links needing to redirect to login page 
-                        $(".portal-weak-auth-disabled").each(function() {
-                            $(this).on("click", function(e) {
-                                e.preventDefault();
-                                let originalHref = $(this).attr("href");
-                                let redirectHref = `/promote-encounter?next=${originalHref}`;
-                                $(this).attr("href", redirectHref);
-                                $("#btnUrlAuthenticatedContinue").attr("href", redirectHref);
-                                $("#urlAuthenticatedModal").modal("show");
-                            });
-                        });
-                        //elements needing to be hidden
-                        $(".portal-weak-auth-hide").each(function() {
-                            $(this).hide();
-                        });
-                    }
-                });
-            }
-        );
-    },
     "prePopulateEmail": function() {
         var requestEmail =  Utility.getUrlParameter("email"), emailField = document.querySelector("#email");
         if (requestEmail && emailField) { /*global Utility getUrlParameter */
@@ -176,7 +133,6 @@ export default { /*global $ i18next */ /*initializing functions performed only o
                     self.handleLogout();
                 });
                 self.handleDisableLinks();
-                self.checkURLAuthenticated();
             }, 350);
             self.getNotification(function(data) { //ajax to get notifications information
                 self.notifications(data);

--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -111,6 +111,7 @@
     <script src="{{ url_for('static', filename='js/flask_user/PasswordPopover.js') }}"></script>
 {%- endmacro %}
 {% macro urlAuthenticatedLoginModal() -%}
+    <!-- reusable component login modal that prompts user to login when accessing protected link-->
     <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -136,7 +137,7 @@
         (function() {
             var d=document, g=d.createElement("script"), s=d.getElementsByTagName("head")[0];
             g.type="text/javascript"; g.async=true; g.defer=true; g.src='{{PORTAL}}{{ url_for("static", filename="js/flask_user/urlAuthenticatedModal.js") }}';
-            //inserting script in HEAD element
+            //inserting script in HEAD element, NOTE, this will prevent browser from wiping out SCRIPT tag that includes a static file
             s.appendChild(g);
             function initURLAuthenticatedModal() {
                 setTimeout(function() {

--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -110,3 +110,45 @@
     </div>
     <script src="{{ url_for('static', filename='js/flask_user/PasswordPopover.js') }}"></script>
 {%- endmacro %}
+{% macro urlAuthenticatedLoginModal() -%}
+    <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal">
+        <div class="modal-dialog">
+            <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="{{ _('Close') }}"><span aria-hidden="true">&times;</span></button>
+                <h2 class="modal-title">{{ _("Limited Access") }}</h2>
+            </div>
+            <div class="modal-body">
+                <p>{{_("To access this information, you will need to log in with your username and password.")}}</p>
+                <br/>
+                <div class="buttons-container text-center">
+                    <a type="button" class="btn btn-default btn-tnth-primary btn-lg" data-dismiss="modal">{{ _("Continue with limited access") }}</a>
+                    <a id="btnUrlAuthenticatedContinue" type="button" class="btn btn-default btn-tnth-primary btn-lg" >{{ _("Log in to see more") }}</a>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">{{ _("Close") }}</button>
+            </div>
+            </div>
+        </div>
+    </div>
+    <script type="text/javascript">
+        (function() {
+            var d=document, g=d.createElement("script"), s=d.getElementsByTagName("head")[0];
+            g.type="text/javascript"; g.async=true; g.defer=true; g.src='{{PORTAL}}{{ url_for("static", filename="js/flask_user/urlAuthenticatedModal.js") }}';
+            //inserting script in HEAD element
+            s.appendChild(g);
+            function initURLAuthenticatedModal() {
+                setTimeout(function() {
+                    (new URLAuthenticatedModalObj()).init();
+                }, 150);
+            }
+            g.onreadystatechange= function () { //IE
+                if (this.readyState === "complete") {
+                    initURLAuthenticatedModal();
+                }
+            }
+            g.onload = initURLAuthenticatedModal; //other browsers
+        })();
+    </script>
+{%- endmacro %}

--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -110,9 +110,9 @@
     </div>
     <script src="{{ url_for('static', filename='js/flask_user/PasswordPopover.js') }}"></script>
 {%- endmacro %}
-{% macro urlAuthenticatedLoginModal(PORTAL_BASE_URL="", user_id="") -%}
+{% macro urlAuthenticatedLoginModal(PORTAL_BASE_URL="", auth_method="") -%}
     <!-- reusable login modal component that prompts user to login when accessing protected link-->
-    <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal" data-user-id="{{user_id}}" data-ref-url="{{PORTAL_BASE_URL}}">
+    <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal" data-auth-method="{{auth_method}}" data-ref-url="{{PORTAL_BASE_URL}}">
         <div class="modal-dialog">
             <div class="modal-content">
             <div class="modal-header">

--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -110,7 +110,7 @@
     </div>
     <script src="{{ url_for('static', filename='js/flask_user/PasswordPopover.js') }}"></script>
 {%- endmacro %}
-{% macro urlAuthenticatedLoginModal() -%}
+{% macro urlAuthenticatedLoginModal(PORTAL_BASE_URL="") -%}
     <!-- reusable component login modal that prompts user to login when accessing protected link-->
     <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal">
         <div class="modal-dialog">
@@ -136,7 +136,7 @@
     <script type="text/javascript">
         (function() {
             var d=document, g=d.createElement("script"), s=d.getElementsByTagName("head")[0];
-            g.type="text/javascript"; g.async=true; g.defer=true; g.src='{{PORTAL}}{{ url_for("static", filename="js/flask_user/urlAuthenticatedModal.js") }}';
+            g.type="text/javascript"; g.src='{{PORTAL_BASE_URL}}{{ url_for("static", filename="js/flask_user/urlAuthenticatedModal.js") }}';
             //inserting script in HEAD element, NOTE, this will prevent browser from wiping out SCRIPT tag that includes a static file
             s.appendChild(g);
             function initURLAuthenticatedModal() {

--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -112,7 +112,7 @@
 {%- endmacro %}
 {% macro urlAuthenticatedLoginModal(PORTAL_BASE_URL="") -%}
     <!-- reusable login modal component that prompts user to login when accessing protected link-->
-    <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal">
+    <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal" data-ref-url="{{PORTAL_BASE_URL}}">
         <div class="modal-dialog">
             <div class="modal-content">
             <div class="modal-header">

--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -110,9 +110,9 @@
     </div>
     <script src="{{ url_for('static', filename='js/flask_user/PasswordPopover.js') }}"></script>
 {%- endmacro %}
-{% macro urlAuthenticatedLoginModal(PORTAL_BASE_URL="") -%}
+{% macro urlAuthenticatedLoginModal(PORTAL_BASE_URL="", user_id="") -%}
     <!-- reusable login modal component that prompts user to login when accessing protected link-->
-    <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal" data-ref-url="{{PORTAL_BASE_URL}}">
+    <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal" data-user-id="{{user_id}}" data-ref-url="{{PORTAL_BASE_URL}}">
         <div class="modal-dialog">
             <div class="modal-content">
             <div class="modal-header">

--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -111,7 +111,7 @@
     <script src="{{ url_for('static', filename='js/flask_user/PasswordPopover.js') }}"></script>
 {%- endmacro %}
 {% macro urlAuthenticatedLoginModal(PORTAL_BASE_URL="") -%}
-    <!-- reusable component login modal that prompts user to login when accessing protected link-->
+    <!-- reusable login modal component that prompts user to login when accessing protected link-->
     <div class="modal fade" tabindex="-1" role="dialog" id="urlAuthenticatedModal">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -135,9 +135,9 @@
     </div>
     <script type="text/javascript">
         (function() {
-            var d=document, g=d.createElement("script"), s=d.getElementsByTagName("head")[0];
-            g.type="text/javascript"; g.src='{{PORTAL_BASE_URL}}{{ url_for("static", filename="js/flask_user/urlAuthenticatedModal.js") }}';
-            //inserting script in HEAD element, NOTE, this will prevent browser from wiping out SCRIPT tag that includes a static file
+            var d=document, g=d.createElement("script"), s=d.getElementsByTagName("body")[0];
+            g.type="text/javascript"; g.src='{{PORTAL_BASE_URL}}{{url_for("static", filename="js/flask_user/urlAuthenticatedModal.js")}}';
+            //inserting script in BODY element, NOTE, this will prevent browser from removing SCRIPT tag that references a static file
             s.appendChild(g);
             function initURLAuthenticatedModal() {
                 setTimeout(function() {

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -154,7 +154,7 @@
     The modal will be triggered when user who is URL-authenticated attempts to access a protected link, e.g. profile
     The modal includes content that prompts the user to either login to access the protected link or continue with limited access
 -->
-{% if user and user.current_encounter().auth_method == 'url_authenticated'%}{{urlAuthenticatedLoginModal(PORTAL)}}{% endif %}
+{% if user and user.current_encounter().auth_method == 'url_authenticated'%}{{urlAuthenticatedLoginModal(PORTAL_BASE_URL=PORTAL, user_id=user.id)}}{% endif %}
 <input type="hidden" id="sessionMonitorProps" data-baseurl="{{PORTAL}}" data-crsftoken="{{csrf_token()}}" data-expires-in="{{expires_in}}"/>
 <div id="session-warning-modal" class="modal fade" tabindex="-1" role="dialog" style="display: none">
   <div class="modal-dialog" role="document">

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -154,7 +154,8 @@
     The modal will be triggered when user who is URL-authenticated attempts to access a protected link, e.g. profile
     The modal includes content that prompts the user to either login to access the protected link or continue with limited access
 -->
-{% if user and user.current_encounter().auth_method == 'url_authenticated'%}{{urlAuthenticatedLoginModal(PORTAL_BASE_URL=PORTAL, user_id=user.id)}}{% endif %}
+{% set user_auth_method = user.current_encounter().auth_method if user else '' %}
+{% if user_auth_method == 'url_authenticated'%}{{urlAuthenticatedLoginModal(PORTAL_BASE_URL=PORTAL, auth_method=user_auth_method)}}{% endif %}
 <input type="hidden" id="sessionMonitorProps" data-baseurl="{{PORTAL}}" data-crsftoken="{{csrf_token()}}" data-expires-in="{{expires_in}}"/>
 <div id="session-warning-modal" class="modal fade" tabindex="-1" role="dialog" style="display: none">
   <div class="modal-dialog" role="document">

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -154,9 +154,7 @@
     The modal will be triggered when user who is URL-authenticated attempts to access a protected link, e.g. profile
     The modal will prompt user to either login to access the protected link or continue with limited access
 -->
-{% if user %}
-    {{urlAuthenticatedLoginModal()}}
-{% endif %}
+{% if user %}{{urlAuthenticatedLoginModal(PORTAL)}}{% endif %}
 <input type="hidden" id="sessionMonitorProps" data-baseurl="{{PORTAL}}" data-crsftoken="{{csrf_token()}}" data-expires-in="{{expires_in}}"/>
 <div id="session-warning-modal" class="modal fade" tabindex="-1" role="dialog" style="display: none">
   <div class="modal-dialog" role="document">

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -95,7 +95,7 @@
                          <button id="tnthUserBtn" type="button" class="tnth-nav-btn tnth-white tnth-dropdown-toggle" data-toggle="tnth-dropdown">
                             {% if enable_links %}&nbsp;&nbsp; {{ _("MENU") }} <i class="fa fa-bars"></i>{% endif %}
                             <img class="profile-img" src="{{movember_profile}}" width="50" height="50" alt="{{_('Profile image')}}"/>
-                            {% if user.current_encounter.auth_method != 'url_authenticated' %}
+                            {% if user.current_encounter().auth_method != 'url_authenticated' %}
                                 <span class="welcome-text portal-weak-auth-hide"><em>{{ _("Welcome") }}</em>{% if user.display_name != "Anonymous" %}, {{ user.display_name }}{% endif %}</span>
                             {% endif %}
                             {% if config.DEBUG_TIMEOUTS %}({{ expires_in }} seconds remaining){% endif %}

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -152,9 +152,9 @@
 <!-- URL authenticated login modal-->
 <!-- 
     The modal will be triggered when user who is URL-authenticated attempts to access a protected link, e.g. profile
-    The modal will prompt user to either login to access the protected link or continue with limited access
+    The modal includes content that prompts the user to either login to access the protected link or continue with limited access
 -->
-{% if user %}{{urlAuthenticatedLoginModal(PORTAL)}}{% endif %}
+{% if user and user.current_encounter.auth_method == 'url_authenticated'%}{{urlAuthenticatedLoginModal(PORTAL)}}{% endif %}
 <input type="hidden" id="sessionMonitorProps" data-baseurl="{{PORTAL}}" data-crsftoken="{{csrf_token()}}" data-expires-in="{{expires_in}}"/>
 <div id="session-warning-modal" class="modal fade" tabindex="-1" role="dialog" style="display: none">
   <div class="modal-dialog" role="document">

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -46,10 +46,7 @@
         <span class="close" title="{{_('dismiss')}}">X</span>
     </div>
 {% endif %}
-{# for an user that is url-authenticated, accessing the profile link requires that the user signs in first #}
-{% 
-    set profile_link = '/profile' if user and user.current_encounter.auth_method != 'url_authenticated' else '/user/sign-in?next=/profile'
-%}
+{% from "flask_user/_macros.html" import urlAuthenticatedLoginModal %}
 <div id="tnthNavWrapper">
     <div id="tnthNavMain">
         <div id="tnthNavMainContainer">
@@ -68,7 +65,7 @@
                         <ul class="tnth-dropdown-menu" style="list-style-type:none">
                             <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
                             {% if 'login_as_id' in session or (user and user.is_registered()) %}
-                            <li><a href="{{PORTAL}}{{profile_link}}">{{ _("My TrueNTH Profile") }}</a></li>
+                            <li><a href="{{PORTAL}}/profile" class="portal-weak-auth-disabled">{{ _("My TrueNTH Profile") }}</a></li>
                             {% endif %}
                             <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>
                             {% if user and user.has_role(ROLE.APPLICATION_DEVELOPER.value) %}
@@ -126,7 +123,7 @@
                 <ul class="tnth-navbar-xs" style="list-style-type:none">
                     {% if login_url %}<li><a href="{{ login_url }}">{{ _("Log In to TrueNTH") }}</a></li>{% endif %}
                     <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
-                    {% if 'login_as_id' in session or (user and user.is_registered()) %}<li><a href="{{PORTAL}}{{profile_link}}">{{ _("My TrueNTH Profile") }}</a></li>{% endif %}
+                    {% if 'login_as_id' in session or (user and user.is_registered()) %}<li><a href="{{PORTAL}}/profile" class="portal-weak-auth-disabled">{{ _("My TrueNTH Profile") }}</a></li>{% endif %}
                     <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>
                     {% if user and user.has_role(ROLE.APPLICATION_DEVELOPER.value) %}<li><a href="{{PORTAL}}/clients">{{ _("Client Applications") }}</a></li>{% endif %}
                     {% if user and user.has_role(ROLE.STAFF.value, ROLE.INTERVENTION_STAFF.value) %}<li><a href="{{PORTAL}}/patients/">{{ _("Patients") }}</a></li>{% endif %}
@@ -152,6 +149,14 @@
         </div>
     </div>
 </div>
+<!-- URL authenticated login modal-->
+<!-- 
+    The modal will be triggered when user is URL-authenticated and attempting to access a protected link, e.g. profile
+    The modal will prompt user to either login to access the protected link or continue with limited access
+-->
+{% if user %}
+    {{urlAuthenticatedLoginModal()}}
+{% endif %}
 <input type="hidden" id="sessionMonitorProps" data-baseurl="{{PORTAL}}" data-crsftoken="{{csrf_token()}}" data-expires-in="{{expires_in}}"/>
 <div id="session-warning-modal" class="modal fade" tabindex="-1" role="dialog" style="display: none">
   <div class="modal-dialog" role="document">

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -154,7 +154,7 @@
     The modal will be triggered when user who is URL-authenticated attempts to access a protected link, e.g. profile
     The modal includes content that prompts the user to either login to access the protected link or continue with limited access
 -->
-{% if user and user.current_encounter.auth_method == 'url_authenticated'%}{{urlAuthenticatedLoginModal(PORTAL)}}{% endif %}
+{% if user and user.current_encounter().auth_method == 'url_authenticated'%}{{urlAuthenticatedLoginModal(PORTAL)}}{% endif %}
 <input type="hidden" id="sessionMonitorProps" data-baseurl="{{PORTAL}}" data-crsftoken="{{csrf_token()}}" data-expires-in="{{expires_in}}"/>
 <div id="session-warning-modal" class="modal fade" tabindex="-1" role="dialog" style="display: none">
   <div class="modal-dialog" role="document">

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -151,7 +151,7 @@
 </div>
 <!-- URL authenticated login modal-->
 <!-- 
-    The modal will be triggered when user is URL-authenticated and attempting to access a protected link, e.g. profile
+    The modal will be triggered when user who is URL-authenticated attempts to access a protected link, e.g. profile
     The modal will prompt user to either login to access the protected link or continue with limited access
 -->
 {% if user %}

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -943,7 +943,7 @@ def delete_user_consents(user_id):
     return jsonify(message="ok")
 
 
-@user_api.route('/user/<int:user_id>/encounter', methods=('GET', 'OPTIONS'))
+@user_api.route('/user/<int:user_id>/encounter', methods=('GET',))
 @crossdomain()
 @oauth.require_oauth()
 def current_encounter(user_id):

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -943,7 +943,7 @@ def delete_user_consents(user_id):
     return jsonify(message="ok")
 
 
-@user_api.route('/user/<int:user_id>/encounter', methods=('GET',))
+@user_api.route('/user/<int:user_id>/encounter', methods=('GET', 'OPTIONS'))
 @crossdomain()
 @oauth.require_oauth()
 def current_encounter(user_id):


### PR DESCRIPTION
Address **https://jira.movember.com/browse/TN-2645**
My last fix here: https://github.com/uwcirg/truenth-portal/commit/011da9426e8d30358c34031fc3e4e5fd1891499c has changed/broken the desired UI behavior. Sorry, I had forgotten what the desired UI behavior was when I made the fix.
The desired UI behavior **should be**, per story: When a URL authenticated user attempts to access a protected link, a login modal will be triggered that prompts the user to either login or continue with limited access.

Fixes include:
- moving any code associated with the login modal to a re-usable standalone macro that can be included anywhere
- including the modal macro in portal wrapper so that accessing the profile link will trigger the modal, this allows the modal to display in portal and Assessment Engine as well