### PR TITLE
Reuse valid encounters during login flow, if found

### DIFF
--- a/portal/extensions.py
+++ b/portal/extensions.py
@@ -16,7 +16,7 @@ from functools import wraps
 # ReCaptcha is used for form verification
 # Flask-Session provides server side sessions
 # Flask-User
-from flask import abort, current_app, request
+from flask import abort, request
 from flask_babel import Babel
 from flask_mail import Mail
 from flask_oauthlib.provider import OAuth2Provider

--- a/portal/extensions.py
+++ b/portal/extensions.py
@@ -16,7 +16,7 @@ from functools import wraps
 # ReCaptcha is used for form verification
 # Flask-Session provides server side sessions
 # Flask-User
-from flask import abort, request
+from flask import abort, current_app, request
 from flask_babel import Babel
 from flask_mail import Mail
 from flask_oauthlib.provider import OAuth2Provider
@@ -50,7 +50,7 @@ class OAuthOrAlternateAuth(OAuth2Provider):
 
         2. if the user appears to be locally logged in (i.e. browser
            session cookie with a valid user.id),
-           return the effecively undecorated function.
+           return the effectively undecorated function.
 
         """
 
@@ -80,7 +80,7 @@ class OAuthOrAlternateAuth(OAuth2Provider):
                 if hasattr(request, 'oauth') and request.oauth:
                     # Start MOD
                     # Need to log oauth user in for flask-user roles, etc.
-                    login_user(request.oauth.user, 'password_authenticated')
+                    login_user(request.oauth.user)
                     # End MOD
                     return eff(*args, **kwargs)
 
@@ -96,7 +96,7 @@ class OAuthOrAlternateAuth(OAuth2Provider):
                 request.oauth = req
                 # Start MOD
                 # Need to log oauth user in for flask-user roles, etc.
-                login_user(request.oauth.user, 'password_authenticated')
+                login_user(request.oauth.user)
                 # End MOD
                 return eff(*args, **kwargs)
 

--- a/portal/models/encounter.py
+++ b/portal/models/encounter.py
@@ -172,6 +172,10 @@ def initiate_encounter(user, auth_method):
     if user.has_role(ROLE.SERVICE.value):
         auth_method = 'service_token_authenticated'
 
+    # If the auth_method is unknown, fall back to failsafe
+    if auth_method is None:
+        auth_method = 'failsafe'
+
     # Initiate new as directed
     encounter = Encounter(
         status='in-progress', auth_method=auth_method,

--- a/portal/models/login.py
+++ b/portal/models/login.py
@@ -28,14 +28,13 @@ def login_user(user, auth_method=None):
         generate_failsafe_if_missing=False)
     if not active_encounter:
         current_app.logger.debug(
-            "No current encounter found for user {}, initiate as {}".format(
-                user.id, auth_method))
+            "No current encounter found for user %d, initiate as %s", user.id,
+            auth_method)
         initiate_encounter(user, auth_method)
     elif auth_method and active_encounter.auth_method != auth_method:
         current_app.logger.debug(
-            "Active encounter has different auth_method: {}; "
-            "Starting new with {}".format(
-                active_encounter.auth_method, auth_method))
+            "Active encounter has different auth_method: %s; "
+            "Starting new with %s", active_encounter.auth_method, auth_method)
         initiate_encounter(user, auth_method)
 
     # remove session var used to capture locale_code prior to login, now

--- a/portal/models/login.py
+++ b/portal/models/login.py
@@ -30,7 +30,7 @@ def login_user(user, auth_method=None):
             "No current encounter found for user {}, initiate as {}".format(
                 user.id, auth_method))
         initiate_encounter(user, auth_method)
-    if auth_method and active_encounter.auth_method != auth_method:
+    elif auth_method and active_encounter.auth_method != auth_method:
         current_app.logger.debug(
             "Active encounter has different auth_method: {}; "
             "Starting new with {}".format(

--- a/portal/models/login.py
+++ b/portal/models/login.py
@@ -1,6 +1,6 @@
 """Module for common login hook"""
 
-from flask import session
+from flask import current_app, session
 from flask_login import (
     current_user as flask_login_current_user,
     login_user as flask_user_login,
@@ -10,8 +10,11 @@ from flask_user import _call_or_get
 from .encounter import initiate_encounter
 
 
-def login_user(user, auth_method):
+def login_user(user, auth_method=None):
     """Common entry point for all login flows - direct here for bookkeeping
+
+    :param user: The user to log in
+    :param auth_method: If known, the method used to log in.
 
     Logs user into flask_user system and generates the encounter used to track
     authentication method.
@@ -19,7 +22,21 @@ def login_user(user, auth_method):
     """
     if not _call_or_get(flask_login_current_user.is_authenticated):
         flask_user_login(user)
-    initiate_encounter(user, auth_method)
+
+    # Reuse active encounter if available, and a new auth_method wasn't provided
+    active_encounter = user.current_encounter(generate_failsafe_if_missing=False)
+    if not active_encounter:
+        current_app.logger.debug(
+            "No current encounter found for user {}, initiate as {}".format(
+                user.id, auth_method))
+        initiate_encounter(user, auth_method)
+    if auth_method and active_encounter.auth_method != auth_method:
+        current_app.logger.debug(
+            "Active encounter has different auth_method: {}; "
+            "Starting new with {}".format(
+                active_encounter.auth_method, auth_method))
+        initiate_encounter(user, auth_method)
+
     # remove session var used to capture locale_code prior to login, now
     # that we have a user.
     if 'locale_code' in session:

--- a/portal/models/login.py
+++ b/portal/models/login.py
@@ -23,8 +23,9 @@ def login_user(user, auth_method=None):
     if not _call_or_get(flask_login_current_user.is_authenticated):
         flask_user_login(user)
 
-    # Reuse active encounter if available, and a new auth_method wasn't provided
-    active_encounter = user.current_encounter(generate_failsafe_if_missing=False)
+    # Reuse active encounter if available
+    active_encounter = user.current_encounter(
+        generate_failsafe_if_missing=False)
     if not active_encounter:
         current_app.logger.debug(
             "No current encounter found for user {}, initiate as {}".format(

--- a/portal/models/procedure.py
+++ b/portal/models/procedure.py
@@ -76,7 +76,7 @@ class Procedure(db.Model):
         if 'encounter' in data:
             p.encounter = Encounter.from_fhir(data['encounter'])
         else:
-            p.encounter = User.query.get(audit.user_id).current_encounter
+            p.encounter = User.query.get(audit.user_id).current_encounter()
         p.user_id = Reference.parse(data['subject']).id
         if 'performedDateTime' in data:
             p.start_time = FHIR_datetime.parse(

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -439,8 +439,8 @@ class User(db.Model, UserMixin):
             if not generate_failsafe_if_missing:
                 return None
             current_app.logger.error(
-                "Failed to locate in-progress encounter for {}"
-                "; generate failsafe".format(self))
+                "Failed to locate in-progress encounter for %s"
+                "; generate failsafe", self.id)
             return initiate_encounter(self, auth_method='failsafe')
         if query.count() != 1:
             # Not good - we should only have one `active` encounter for

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -439,7 +439,7 @@ class User(db.Model, UserMixin):
             if not generate_failsafe_if_missing:
                 return None
             current_app.logger.error(
-                "Failed to locate in-progress encounter for %s"
+                "Failed to locate in-progress encounter for %d"
                 "; generate failsafe", self.id)
             return initiate_encounter(self, auth_method='failsafe')
         if query.count() != 1:

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1540,7 +1540,7 @@ def assessment_add(patient_id):
         'valid': True,
     })
 
-    encounter = current_user().current_encounter
+    encounter = current_user().current_encounter()
     if 'entry_method' in request.args:
         encounter_type = getattr(
             EC, request.args['entry_method'].upper()).codings[0]
@@ -1621,8 +1621,7 @@ def present_needed():
 
     url = url_for('.present_assessment', **args)
 
-    encounter = current_user().current_encounter
-    if encounter.auth_method == "url_authenticated":
+    if current_user().current_encounter().auth_method == "url_authenticated":
         current_app.logger.debug('redirect to confirm identity')
         return redirect('/confirm-identity?redirect_url={}'.format(quote(url)))
 

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1491,7 +1491,8 @@ def assessment_add(patient_id):
             message='Requires resourceType of "QuestionnaireResponse"'), 400
 
     # Verify the current user has permission to edit given patient
-    patient = get_user(patient_id, 'edit')
+    patient = get_user(
+        patient_id, 'edit', allow_on_url_authenticated_encounters=True)
 
     response = {
         'ok': False,

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -595,7 +595,8 @@ def assessment(patient_id, instrument_id):
       - ServiceToken: []
 
     """
-    patient = get_user(patient_id, 'view')
+    patient = get_user(
+        patient_id, 'view', allow_on_url_authenticated_encounters=True)
     questionnaire_responses = QuestionnaireResponse.query.filter_by(
         subject_id=patient.id).order_by(QuestionnaireResponse.authored.desc())
 

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -388,9 +388,11 @@ def flask_user_login_event(app, user, **extra):
     auditable_event("local user login", user_id=user.id, subject_id=user.id,
                     context='login')
 
-    # After a successfull login make sure lockout is reset
+    # After a successful login make sure lockout is reset
     user.reset_lockout()
 
+    current_app.logger.debug(
+        "captured flask_user_login_event, login w/ 'password_authenticated'")
     login_user(user, 'password_authenticated')
 
 

--- a/portal/views/clinical.py
+++ b/portal/views/clinical.py
@@ -360,7 +360,8 @@ def clinical(patient_id):
       - ServiceToken: []
 
     """
-    patient = get_user(patient_id, 'view')
+    patient = get_user(
+        patient_id, 'view', allow_on_url_authenticated_encounters=True)
     patch_dstu2 = request.args.get('patch_dstu2', False)
     return jsonify(patient.clinical_history(
         requestURL=request.url, patch_dstu2=patch_dstu2))

--- a/portal/views/demographics.py
+++ b/portal/views/demographics.py
@@ -70,7 +70,8 @@ def demographics(patient_id):
     """
     if patient_id is None:
         patient_id = current_user().id
-    patient = get_user(patient_id, 'view')
+    patient = get_user(
+        patient_id, 'view', allow_on_url_authenticated_encounters=True)
     return jsonify(patient.as_fhir(include_empties=False))
 
 

--- a/portal/views/intervention.py
+++ b/portal/views/intervention.py
@@ -107,7 +107,7 @@ def user_intervention_get(intervention_name, user_id):
     intervention = getattr(INTERVENTION, intervention_name)
     if not intervention:
         abort(404, 'no such intervention {}'.format(intervention_name))
-    get_user(user_id, 'edit')
+    get_user(user_id, 'edit', allow_on_url_authenticated_encounters=True)
 
     ui = UserIntervention.query.filter_by(
         user_id=user_id, intervention_id=intervention.id).first()

--- a/portal/views/notification.py
+++ b/portal/views/notification.py
@@ -76,7 +76,7 @@ def get_user_notification(user_id):
       - ServiceToken: []
 
     """
-    user = get_user(user_id, 'edit')
+    user = get_user(user_id, 'edit', allow_on_url_authenticated_encounters=True)
     notifs = [notif.as_json() for notif in user.notifications]
 
     return jsonify(notifications=notifs)

--- a/portal/views/notification.py
+++ b/portal/views/notification.py
@@ -76,7 +76,8 @@ def get_user_notification(user_id):
       - ServiceToken: []
 
     """
-    user = get_user(user_id, 'edit', allow_on_url_authenticated_encounters=True)
+    user = get_user(
+        user_id, 'edit', allow_on_url_authenticated_encounters=True)
     notifs = [notif.as_json() for notif in user.notifications]
 
     return jsonify(notifications=notifs)

--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -482,7 +482,8 @@ def user_organizations(user_id):
 
     """
     # Return user's current organizations
-    user = get_user(user_id, 'view')
+    user = get_user(
+        user_id, 'view', allow_on_url_authenticated_encounters=True)
     return jsonify(organizations=[
         Reference.organization(org.id).as_fhir()
         for org in user.organizations])

--- a/portal/views/procedure.py
+++ b/portal/views/procedure.py
@@ -56,7 +56,8 @@ def procedure(patient_id):
       - ServiceToken: []
 
     """
-    patient = get_user(patient_id, 'view')
+    patient = get_user(
+        patient_id, 'view', allow_on_url_authenticated_encounters=True)
     return jsonify(patient.procedure_history(requestURL=request.url))
 
 

--- a/portal/views/role.py
+++ b/portal/views/role.py
@@ -97,7 +97,8 @@ def roles(user_id):
       - ServiceToken: []
 
     """
-    user = get_user(user_id, 'view', allow_on_url_authenticated_encounters=True)
+    user = get_user(
+        user_id, 'view', allow_on_url_authenticated_encounters=True)
     return jsonify(roles=[r.as_json() for r in user.roles])
 
 

--- a/portal/views/role.py
+++ b/portal/views/role.py
@@ -97,7 +97,7 @@ def roles(user_id):
       - ServiceToken: []
 
     """
-    user = get_user(user_id, 'view')
+    user = get_user(user_id, 'view', allow_on_url_authenticated_encounters=True)
     return jsonify(roles=[r.as_json() for r in user.roles])
 
 

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -96,7 +96,7 @@ def me():
 
     """
     user = current_user()
-    if user.current_encounter.auth_method == 'url_authenticated':
+    if user.current_encounter().auth_method == 'url_authenticated':
         return jsonify(id=user.id)
     return jsonify(
         id=user.id, username=user.username, email=user.email)
@@ -1023,7 +1023,7 @@ def current_encounter(user_id):
     user = current_user()
     if user_id != user.id:
         abort(400, "Only current_user's encounter accessible")
-    return jsonify(user.current_encounter.as_fhir())
+    return jsonify(user.current_encounter().as_fhir())
 
 
 @user_api.route('/user/<int:user_id>/groups')

--- a/tests/test_encounter.py
+++ b/tests/test_encounter.py
@@ -43,7 +43,7 @@ class TestEncounter(TestCase):
     def test_encounter_on_login(self):
         self.login()
         assert len(self.test_user.encounters) == 1
-        assert (self.test_user.current_encounter.auth_method
+        assert (self.test_user.current_encounter().auth_method
                 == 'password_authenticated')
 
     def test_encounter_after_logout(self):
@@ -54,12 +54,12 @@ class TestEncounter(TestCase):
         assert len(self.test_user.encounters) > 1
         assert all(e.status == 'finished' for e in self.test_user.encounters)
         # as we generate failsafe on missing, confirm that's the type returned
-        assert self.test_user.current_encounter.auth_method == 'failsafe'
+        assert self.test_user.current_encounter().auth_method == 'failsafe'
 
     def test_service_encounter_on_login(self):
         service_user = self.add_service_user()
         self.login(user_id=service_user.id)
-        assert (service_user.current_encounter.auth_method
+        assert (service_user.current_encounter().auth_method
                 == 'service_token_authenticated')
 
     def test_login_as(self):
@@ -72,13 +72,13 @@ class TestEncounter(TestCase):
         self.promote_user(user=staff_user, role_name=ROLE.STAFF.value)
         staff_user = db.session.merge(staff_user)
         self.login(user_id=staff_user.id)
-        assert staff_user.current_encounter
+        assert staff_user.current_encounter(generate_failsafe_if_missing=False)
 
         # Switch to test_user using login_as, test the encounter
         self.test_user = db.session.merge(self.test_user)
         response = self.client.get('/login-as/{}'.format(TEST_USER_ID))
         assert response.status_code == 302  # sent to next_after_login
-        assert (self.test_user.current_encounter.auth_method
+        assert (self.test_user.current_encounter().auth_method
                 == 'staff_authenticated')
         assert self.test_user._email.startswith(INVITE_PREFIX)
 
@@ -93,15 +93,15 @@ class TestEncounter(TestCase):
         self.promote_user(user=staff_user, role_name=ROLE.STAFF.value)
         staff_user = db.session.merge(staff_user)
         self.login(user_id=staff_user.id)
-        assert staff_user.current_encounter
+        assert staff_user.current_encounter(generate_failsafe_if_missing=False)
 
         # Switch to test_user using login_as, test the encounter
         self.test_user = db.session.merge(self.test_user)
         response = self.client.get('/login-as/{}'.format(TEST_USER_ID))
         # should return 401 as test user isn't a patient or partner
         assert response.status_code == 401
-        assert self.test_user.current_encounter.auth_method == 'failsafe'
-        assert staff_user.current_encounter
+        assert self.test_user.current_encounter().auth_method == 'failsafe'
+        assert staff_user.current_encounter(generate_failsafe_if_missing=False)
 
     def test_failsafe(self):
         self.bless_with_basics()
@@ -113,13 +113,13 @@ class TestEncounter(TestCase):
         self.promote_user(user=staff_user, role_name=ROLE.STAFF.value)
         staff_user = db.session.merge(staff_user)
         self.login(user_id=staff_user.id)
-        assert staff_user.current_encounter
+        assert staff_user.current_encounter(generate_failsafe_if_missing=False)
 
         # Switch to test_user using login_as, test the encounter
         self.test_user = db.session.merge(self.test_user)
         response = self.client.get('/login-as/{}'.format(TEST_USER_ID))
         assert response.status_code == 302  # sent to next_after_login
-        assert (self.test_user.current_encounter.auth_method
+        assert (self.test_user.current_encounter().auth_method
                 == 'staff_authenticated')
         assert self.test_user._email.startswith(INVITE_PREFIX)
 
@@ -129,6 +129,6 @@ class TestEncounter(TestCase):
         db.session.delete(e)
 
         self.test_user = db.session.merge(self.test_user)
-        encounter = self.test_user.current_encounter
+        encounter = self.test_user.current_encounter()
         assert encounter.auth_method == 'failsafe'
         assert encounter.status == 'in-progress'

--- a/tests/test_encounter.py
+++ b/tests/test_encounter.py
@@ -49,9 +49,9 @@ class TestEncounter(TestCase):
     def test_encounter_after_logout(self):
         self.login()
         time.sleep(0.1)
-        self.login()  # generate a second encounter - should logout the first
+        self.login()  # generate a second encounter - should reuse the first
         self.client.get('/logout', follow_redirects=True)
-        assert len(self.test_user.encounters) > 1
+        assert len(self.test_user.encounters) == 1
         assert all(e.status == 'finished' for e in self.test_user.encounters)
         # as we generate failsafe on missing, confirm that's the type returned
         assert self.test_user.current_encounter().auth_method == 'failsafe'

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -122,7 +122,7 @@ class TestFHIR(TestCase):
             subject_id=TEST_USER_ID,
             status='in-progress',
             authored=datetime.utcnow(),
-            encounter=self.test_user.current_encounter
+            encounter=self.test_user.current_encounter()
         )
         db.session.add(qr)
         db.session.commit()


### PR DESCRIPTION
Due to oauth initiation happening via API invocation, many of the fail safe calls to `login()` needlessly generate a new encounter, and previously occasionally included the incorrect assumption on `auth_method`.

Now reusing the current_encounter for a user on a call to login, if it's found to be valid and of the requested auth_method.

Should also resolve a bug in the `url_authenticated` flow, where any oauth protected API call from an external intervention (i.e. the AssessmentEngine) incorrectly promoted the auth_method. 