### PR TITLE
Log details of the failing message, not the class!

### DIFF
--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -180,7 +180,7 @@ class EmailMessage(db.Model):
         else:
             # This should never happen, alert if it does
             current_app.logger.error(
-                "Unable to generate audit log for email: %s", str(Message))
+                "Unable to generate audit log for email: %s", str(message))
         # If an exception was raised when attempting the send, re-raise now
         # for clients to manage
         if exc:


### PR DESCRIPTION
Correct typo in word `message` - lower, not upper case.

This will provide what we want, in place of current emails such as:

```
TrueNTH <noreply@us.truenth.org> | TrueNTH <noreply@us.truenth.org> | Aug 1, 2020, 8:37 AM (2 days ago)
-- | -- | --
TrueNTH <noreply@us.truenth.org>

Unable to generate audit log for email: <class 'flask_mail.Message'>```
