### PR TITLE
TN-2768 extend organization API for research study needs

### DIFF
--- a/portal/models/extension.py
+++ b/portal/models/extension.py
@@ -26,16 +26,22 @@ class CCExtension(Extension, metaclass=ABCMeta):
     def children(self):  # pragma: no cover
         pass
 
-    def as_fhir(self, include_empties=True):
+    def as_fhir(self, include_empties=True, include_inherited=False):
         if self.children.count():
             return {
                 'url': self.extension_url,
                 'valueCodeableConcept': {
                     'coding': [c.as_fhir() for c in self.children]}
             }
-        # Return valid empty if none are currently defined and requested
         if include_empties:
+            # Return valid empty if none are currently defined and requested
             return {'url': self.extension_url}
+
+        if include_inherited:
+            # TODO in the organization instance, need a `parent()`
+            #  implementation, and to climb tree till exhaused or value
+            return None
+
         return None
 
     def apply_fhir(self):
@@ -66,7 +72,9 @@ class TimezoneExtension(CCExtension):
     extension_url = \
         "http://hl7.org/fhir/StructureDefinition/user-timezone"
 
-    def as_fhir(self, include_empties=True):
+    def as_fhir(self, include_empties=True, include_inherited=False):
+        # Include inherited is NOP in this case, as self.source.timezone
+        # does its own inheritance lookup
         timezone = self.source.timezone
         if not timezone or timezone == 'None':
             timezone = 'UTC'

--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -187,6 +187,10 @@ def organization_get(id_or_code):
         description: Identifier system
         required: false
         type: string
+      - name: include_inherited_attributes
+        description: include attributes defined at a parent or higher level
+        required: false
+        type: string
     responses:
       200:
         description:
@@ -225,7 +229,10 @@ def organization_get(id_or_code):
                 400, "invalid input '{}' - expected integer without system "
                      "parameter".format(id_or_code))
 
-    return jsonify(org.as_fhir(include_empties=False))
+    include_inherited = request.args.get(
+        'included_inherited_attributes', 'false').lower() != 'false'
+    return jsonify(org.as_fhir(
+        include_empties=False, include_inherited=include_inherited))
 
 
 @org_api.route('/organization/<int:organization_id>', methods=('DELETE',))

--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -188,6 +188,7 @@ def organization_get(id_or_code):
         required: false
         type: string
       - name: include_inherited_attributes
+        in: query
         description: include attributes defined at a parent or higher level
         required: false
         type: string

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,9 +46,14 @@ from tests import TEST_USER_ID
 
 
 """ Include all fixtures found in nested fixtures dir as modules """
+# The double load attempt is necessary given different IDE/tox/CI envs
 pytest_plugins = [
     f"tests.{fixture.replace('/', '.')}"[:-3]
     for fixture in glob("fixtures/*.py")]
+if not pytest_plugins:
+    pytest_plugins = [
+        f"{fixture.replace('/', '.')}"[:-3]
+        for fixture in glob("tests/fixtures/*.py")]
 
 
 def pytest_addoption(parser):

--- a/tests/fixtures/organization.py
+++ b/tests/fixtures/organization.py
@@ -1,0 +1,25 @@
+import pytest
+from flask_webtest import SessionScope
+
+from portal.database import db
+from portal.models.organization import (
+    Organization,
+    OrganizationResearchProtocol,
+)
+
+
+@pytest.fixture
+def initialized_with_org(initialized_with_research_protocol):
+    org = Organization(name="test_org")
+    # Add the intermediary table type to include the
+    # retired_as_of value.  Magic of association proxy, bringing
+    # one to life commits, and trying to add directly will fail
+    orp = OrganizationResearchProtocol(
+        research_protocol=initialized_with_research_protocol,
+        organization=org,
+        retired_as_of=None)
+    with SessionScope(db):
+        db.session.add(org)
+        db.session.add(orp)
+        db.session.commit()
+    return db.session.merge(org)


### PR DESCRIPTION
The /api/organization/<org_id> endpoint now takes a query string parameter to include inherited information, such as a research protocol defined not at the requested org level, but somewhere up the org tree.

Research Protocols now include research_study_id in their serialized form.

Together, the front end can now call `/api/organization/<org_id>?include_inherited_attributes=true` to check for research study enrollment at any level.