### PR TITLE
looking up research_protocol must often be limited by research_study

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -286,20 +286,21 @@ def second_null_safe_datetime(x):
 RPD = namedtuple("RPD", ['rp', 'retired', 'qbds'])
 
 
-def cur_next_rp_gen(user, classification, trigger_date):
+def cur_next_rp_gen(user, research_study_id, classification, trigger_date):
     """Generator to manage transitions through research protocols
 
     Returns a *pair* of research protocol data (RPD) namedtuples,
     one for current (active) RP data, one for the "next".
 
     :param user: applicable patient
+    :param research_study_id: study being processed
     :param classification: None or 'indefinite' for special handling
     :param trigger_date: patient's initial trigger date
 
     :yields: cur_RPD, next_RPD
 
     """
-    rps = ResearchProtocol.assigned_to(user)
+    rps = ResearchProtocol.assigned_to(user, research_study_id)
     sorted_rps = sorted(
         list(rps), key=second_null_safe_datetime, reverse=True)
 
@@ -361,7 +362,9 @@ class RP_flyweight(object):
         self.research_study_id = research_study_id
         self.classification = classification
         self.rp_walker = cur_next_rp_gen(
-            user=self.user, trigger_date=self.td,
+            user=self.user,
+            research_study_id=self.research_study_id,
+            trigger_date=self.td,
             classification=self.classification)
         self.cur_rpd, self.nxt_rpd = next(self.rp_walker, (None, None))
         self.skipped_nxt_start = None

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -378,7 +378,7 @@ def trigger_date(user, research_study_id, qb=None):
     # the intervention method.  (Yes, it's possible the user has neither
     # intervention nor RP, but the intervention method is too expensive
     # for a simple trigger date lookup - will be caught in qb_timeline)
-    if ResearchProtocol.assigned_to(user):
+    if ResearchProtocol.assigned_to(user, research_study_id):
         return consent_date(user, research_study_id=research_study_id)
     else:
         return intervention_trigger(user)

--- a/portal/models/research_protocol.py
+++ b/portal/models/research_protocol.py
@@ -48,10 +48,11 @@ class ResearchProtocol(db.Model):
         return ' '.join([n.title() for n in word_list])
 
     @staticmethod
-    def assigned_to(user):
+    def assigned_to(user, research_study_id):
         """Returns set of tuples (ResearchProtocol, retired) for user"""
         rps = set()
         for org in user.organizations:
-            for r in org.rps_w_retired(consider_parents=True):
+            for r in org.rps_w_retired(
+                    research_study_id, consider_parents=True):
                 rps.add(r)
         return rps

--- a/portal/models/research_study.py
+++ b/portal/models/research_study.py
@@ -55,7 +55,8 @@ class ResearchStudy(db.Model):
         if iqbs:
             results.append(base_study)  # Use dummy till system need arises
 
-        for rp, _ in ResearchProtocol.assigned_to(user):
+        for rp, _ in ResearchProtocol.assigned_to(
+                user, research_study_id='all'):
             rs_id = rp.research_study_id
             if rs_id is None:
                 continue

--- a/tests/test_model_persistence.py
+++ b/tests/test_model_persistence.py
@@ -312,5 +312,7 @@ class TestModelPersistence(TestCase):
         # Make sure retired_as_of was set properly on old
         rp1, rp2 = map(db.session.merge, (rp1, rp2))
         expected = [(rp2, None), (rp1, now)]
-        results = [(rp, retired) for rp, retired in org.rps_w_retired()]
+        results = [
+            (rp, retired) for rp, retired in
+            org.rps_w_retired(research_study_id=0)]
         assert results == expected

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -191,7 +191,9 @@ def test_multiple_rps_in_fhir():
     assert len(rps[0]['research_protocols']) == 3
 
     # confirm the order is descending in the custom accessor method
-    results = [(rp, retired) for rp, retired in org.rps_w_retired()]
+    results = [
+        (rp, retired) for rp, retired in
+        org.rps_w_retired(research_study_id=rs_id)]
     assert [(rp1, None), (rp2, yesterday), (rp3, lastyear)] == results
 
 
@@ -496,7 +498,8 @@ def test_organization_extension_update(
     assert org.default_locale == 'en_AU'
     assert org.locales.count() == 0
     assert org.timezone == 'US/Pacific'
-    assert org.research_protocol(as_of_date=datetime.utcnow()).id == rp_id
+    assert org.research_protocol(
+        research_study_id=0, as_of_date=datetime.utcnow()).id == rp_id
 
     # Confirm empty extension isn't included in result
     results = response.json

--- a/tests/test_research_protocol.py
+++ b/tests/test_research_protocol.py
@@ -59,5 +59,5 @@ def test_rp_inheritance(initialized_with_research_protocol):
     assert parent.research_protocols[0].id == rp.id
     assert parent.research_protocols[0].research_study_id == 0
     assert len(child.research_protocols) == 0
-    assert (child.research_protocol(as_of_date=datetime.utcnow()).id
-            == rp.id)
+    assert (child.research_protocol(
+        research_study_id=0, as_of_date=datetime.utcnow()).id == rp.id)


### PR DESCRIPTION
TN-2769 Oversight from #3771 - need to filter on research_study_id when looking up research_protocols in many cases.