### PR TITLE
TN-2669 SDC Extraction Extension

### DIFF
--- a/portal/config/eproms/Questionnaire.json
+++ b/portal/config/eproms/Questionnaire.json
@@ -7696,6 +7696,12 @@
             }
           ]
         }
+      ],
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+          "valueBoolean": true
+        }
       ]
     }
   ],


### PR DESCRIPTION
TN-2669
Add extension for [SDC Observation-based extraction](http://build.fhir.org/ig/HL7/sdc/StructureDefinition-sdc-questionnaire-observationExtract.html) to Ironman substudy questionnaire

NB: This extension can be applied to individual `item`s (questions) if not all questions need extraction
