### PR TITLE
EPROMS patient home exception fix

### DIFF
--- a/portal/eproms/templates/eproms/portal.html
+++ b/portal/eproms/templates/eproms/portal.html
@@ -14,14 +14,8 @@
         {%- if display.access -%}
             <div class="portal-item">
                 {%- if intervention.name == "assessment_engine" %}
-                    {%- if display.card_html -%}
-                        {%  set ae_html = assessment_engine_view(user) %}
-                        {{ ae_html | safe }}
-                        <input type="hidden" class="link-label" value="{{display.link_label}}" />
-                        <input type="hidden" class="link-url" value="{{display.link_url}}" />
-                    {%- else -%}
-                        {{render_card_content(intervention, display, class='portal-description-incomplete portal-no-description-container')}}
-                    {%- endif %}
+                    {%  set ae_html = assessment_engine_view(user) %}
+                    {{ ae_html | safe }}
                 {%- else -%}
                     {% call render_card_content(intervention, display) %}
                         <div class="portal-description-body">


### PR DESCRIPTION
Address recent exceptions triggered when accessing patient home page

Fix includes

- remove check for intervention.card_html for assessment engine intervention as it is now being rendered via a dedicated view, `assessment_engine_view`

Sample exception seen in EPROMS Test:

`Exception on /home [GET]
Traceback (most recent call last):
 File "/opt/venvs/portal/lib/python3.7/site-packages/flask/app.py", line 2311, in wsgi_app
   response = self.full_dispatch_request()
 File "/opt/venvs/portal/lib/python3.7/site-packages/flask/app.py", line 1834, in full_dispatch_request
   rv = self.handle_user_exception(e)
 File "/opt/venvs/portal/lib/python3.7/site-packages/flask/app.py", line 1737, in handle_user_exception
   reraise(exc_type, exc_value, tb)
 File "/opt/venvs/portal/lib/python3.7/site-packages/flask/_compat.py", line 36, in reraise
   raise value
 File "/opt/venvs/portal/lib/python3.7/site-packages/flask/app.py", line 1832, in full_dispatch_request
   rv = self.dispatch_request()
 File "/opt/venvs/portal/lib/python3.7/site-packages/flask/app.py", line 1818, in dispatch_request
   return self.view_functions[rule.endpoint](**req.view_args)
 File "/opt/venvs/portal/lib/python3.7/site-packages/portal/eproms/views.py", line 196, in home
   consent_agreements=consent_agreements)
 File "/opt/venvs/portal/lib/python3.7/site-packages/flask/templating.py", line 135, in render_template
   context, ctx.app)
 File "/opt/venvs/portal/lib/python3.7/site-packages/flask/templating.py", line 117, in _render
   rv = template.render(context)
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/asyncsupport.py", line 76, in render
   return original_render(self, *args, **kwargs)
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/environment.py", line 1008, in render
   return self.environment.handle_exception(exc_info, True)
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/environment.py", line 780, in handle_exception
   reraise(exc_type, exc_value, tb)
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/_compat.py", line 37, in reraise
   raise value.with_traceback(tb)
 File "/opt/venvs/portal/lib/python3.7/site-packages/portal/eproms/templates/eproms/portal.html", line 53, in top-level template code
   <a class="btn-lg btn-tnth-primary" href="{{ display.link_url }}">{{display.link_label or _("Go to link")}}</a>
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/environment.py", line 1005, in render
   return concat(self.root_render_func(self.new_context(vars)))
 File "/opt/venvs/portal/lib/python3.7/site-packages/portal/eproms/templates/eproms/portal.html", line 71, in root
 File "/opt/venvs/portal/lib/python3.7/site-packages/portal/eproms/templates/eproms/base.html", line 40, in root
   <div id="mainDiv">
 File "/opt/venvs/portal/lib/python3.7/site-packages/portal/eproms/templates/eproms/base.html", line 112, in block_body
   {% if config["SYSTEM_TYPE"].lower() != "production" %}
 File "/opt/venvs/portal/lib/python3.7/site-packages/portal/eproms/templates/eproms/portal.html", line 113, in block_main
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/runtime.py", line 262, in call
   return __obj(*args, **kwargs)
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/runtime.py", line 570, in __call__
   return self._invoke(arguments, autoescape)
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/asyncsupport.py", line 110, in _invoke
   return original_invoke(self, arguments, autoescape)
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/runtime.py", line 574, in _invoke
   rv = self._func(*arguments)
 File "/opt/venvs/portal/lib/python3.7/site-packages/portal/eproms/templates/eproms/portal.html", line 45, in macro
   {%- if intervention.description -%}<h2 class="tnth-subhead title">{{ intervention.description }}</h2>{% endif %}
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/runtime.py", line 262, in call
   return __obj(*args, **kwargs)
 File "/opt/venvs/portal/lib/python3.7/site-packages/jinja2/runtime.py", line 630, in _fail_with_undefined_error
   raise self._undefined_exception(hint)
jinja2.exceptions.UndefinedError: No caller defined`