### PR TITLE
TN-2541-empro-qb-for-patient-temp

### DIFF
--- a/portal/config/eproms/QuestionnaireBank.json
+++ b/portal/config/eproms/QuestionnaireBank.json
@@ -720,6 +720,29 @@
     },
     {
       "resourceType": "QuestionnaireBank",
+      "classification": "baseline",
+      "name": "ironman_ss_baseline",
+      "start": "{\"days\": 0}",
+      "due": "{\"days\": 0}",
+      "overdue": "{\"days\": 15}",
+      "expired": "{\"months\": 1, \"days\": -1}",
+      "recurs": [],
+      "research_protocol": {
+        "display": "EMPRO v1",
+        "reference": "api/research_protocol/EMPRO v1"
+      },
+      "questionnaires": [
+        {
+          "questionnaire": {
+            "display": "ironman_ss",
+            "reference": "api/questionnaire/ironman_ss?system=http://us.truenth.org/questionnaire"
+          },
+          "rank": 0
+        }
+      ]
+    },
+    {
+      "resourceType": "QuestionnaireBank",
       "classification": "recurring",
       "name": "ironman_ss_recurring_monthly_pattern",
       "start": "{\"days\": 0}",
@@ -729,7 +752,7 @@
       "recurs": [
         {
           "cycle_length": "{\"months\": 1}",
-          "start": "{\"days\": 0}",
+          "start": "{\"months\": 1}",
           "termination": "{\"months\": 12}"
         }
       ],

--- a/portal/config/eproms/QuestionnaireBank.json
+++ b/portal/config/eproms/QuestionnaireBank.json
@@ -717,6 +717,35 @@
       },
       "resourceType": "QuestionnaireBank",
       "start": "{\"days\": 0}"
+    },
+    {
+      "resourceType": "QuestionnaireBank",
+      "classification": "recurring",
+      "name": "ironman_ss_recurring_monthly_pattern",
+      "start": "{\"days\": 0}",
+      "due": "{\"days\": 0}",
+      "overdue": "{\"days\": 15}",
+      "expired": "{\"months\": 1, \"days\": -1}",
+      "recurs": [
+        {
+          "cycle_length": "{\"months\": 1}",
+          "start": "{\"days\": 0}",
+          "termination": "{\"months\": 12}"
+        }
+      ],
+      "research_protocol": {
+        "display": "EMPRO v1",
+        "reference": "api/research_protocol/EMPRO v1"
+      },
+      "questionnaires": [
+        {
+          "questionnaire": {
+            "display": "ironman_ss",
+            "reference": "api/questionnaire/ironman_ss?system=http://us.truenth.org/questionnaire"
+          },
+          "rank": 0
+        }
+      ]
     }
   ],
   "id": "SitePersistence v0.2",

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -38,10 +38,12 @@ class QB_Status(object):
 
         # Every QB should have "due" - filter by to get one per QB
         users_qbs = QBT.query.filter(QBT.user_id == self.user.id).filter(
+            QBT.research_study_id == self.research_study_id).filter(
             QBT.status == OverallStatus.due).order_by(QBT.at.asc())
 
         # Obtain withdrawal date if applicable
         withdrawn = QBT.query.filter(QBT.user_id == self.user.id).filter(
+            QBT.research_study_id == self.research_study_id).filter(
             QBT.status == OverallStatus.withdrawn).first()
         self._withdrawal_date = withdrawn.at if withdrawn else None
 

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -23,7 +23,6 @@ class QB_Status(object):
         self.user = user
         self.as_of_date = as_of_date
         self.research_study_id = research_study_id
-        assert self.research_study_id is not None
         for state in OverallStatus:
             setattr(self, "_{}_date".format(state.name), None)
         self._overall_status = None

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -23,6 +23,7 @@ class QB_Status(object):
         self.user = user
         self.as_of_date = as_of_date
         self.research_study_id = research_study_id
+        assert self.research_study_id is not None
         for state in OverallStatus:
             setattr(self, "_{}_date".format(state.name), None)
         self._overall_status = None

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -678,7 +678,8 @@ def update_users_QBT(user_id, research_study_id, invalidate_existing=False):
                     QBT.research_study_id == research_study_id).delete()
 
             # if any rows are found, assume this user/study is current
-            if QBT.query.filter(QBT.user_id == user_id).count():
+            if QBT.query.filter(QBT.user_id == user_id).filter(
+                    QBT.research_study_id == research_study_id).count():
                 trace(
                     "found QBT rows, returning cached for {}:{}".format(
                         user_id, research_study_id))

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -96,6 +96,10 @@ class QuestionnaireBank(db.Model):
     @property
     def research_study_id(self):
         """A questionnaire bank w/ a research protocol has a research study"""
+        # intervention linked qbs hardcoded to use study id 0
+        if self.intervention_id is not None:
+            return 0
+
         if self.research_protocol_id is None:
             return
 

--- a/portal/models/research_study.py
+++ b/portal/models/research_study.py
@@ -64,6 +64,8 @@ class ResearchStudy(db.Model):
             if latest_consent(user, rs_id) and rs_id not in results:
                 results.append(rs_id)
         results.sort()
+        if len(results):
+            assert None not in results
         return results
 
 

--- a/portal/models/research_study.py
+++ b/portal/models/research_study.py
@@ -64,8 +64,6 @@ class ResearchStudy(db.Model):
             if latest_consent(user, rs_id) and rs_id not in results:
                 results.append(rs_id)
         results.sort()
-        if len(results):
-            assert None not in results
         return results
 
 


### PR DESCRIPTION
Since this QB is blocking the ability to administer the empro patient questionnaire and thus test things like trigger evaluation, our temporary approach for this story is to make the empro patient QB contingent on the empro consent date only (removing the complex requirement to also factor in the state of the ironman global QB).