### PR TITLE
TN-2794 don't insert skipped visits if posted results tie user to older RP

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -534,6 +534,11 @@ def ordered_qbs(user, classification=None):
                 period_instruments = set(
                     [q.instrument for q in qnrs_for_period])
                 if not transition_now and period_instruments & cur_only:
+                    # Posted results tie user to the old RP; clear skipped
+                    # state as it's unavailable when results from the "next"
+                    # exist.
+                    rp_flyweight.skipped_nxt_start = None
+
                     # Don't transition yet, as definitive work on the old
                     # (current) RP has already been posted, UNLESS ...
                     if period_instruments & next_only:

--- a/portal/models/qbd.py
+++ b/portal/models/qbd.py
@@ -71,3 +71,12 @@ class QBD(object):
         results['iteration'] = self.iteration
         results['visit'] = visit_name(self)
         return results
+
+    def __repr__(self):
+        """Useful shortcut in debugging"""
+        results = self.as_json()
+        return "QBD(visit={visit}, start={rel_start}, qb={qb_name})".format(
+            visit=results['visit'],
+            rel_start=results['relative_start'],
+            qb_name=self._questionnaire_bank.name if self._questionnaire_bank else "",
+        )

--- a/portal/models/qbd.py
+++ b/portal/models/qbd.py
@@ -75,8 +75,10 @@ class QBD(object):
     def __repr__(self):
         """Useful shortcut in debugging"""
         results = self.as_json()
+        qb_name = (
+            self._questionnaire_bank.name if self._questionnaire_bank else "")
         return "QBD(visit={visit}, start={rel_start}, qb={qb_name})".format(
             visit=results['visit'],
             rel_start=results['relative_start'],
-            qb_name=self._questionnaire_bank.name if self._questionnaire_bank else "",
+            qb_name=qb_name,
         )

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -228,7 +228,10 @@ def overdue_dates(user, as_of):
         return na
 
     a_s = QB_Status(user, as_of_date=as_of)
-    assert a_s.overall_status == status
+    if a_s.overall_status != status:
+        current_app.logger.error(
+            "%s != %s for %s as of %s".format(
+            a_s.overall_status, status, user.id, as_of))
     if a_s.overdue_date is None:
         return na
 

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -231,7 +231,7 @@ def overdue_dates(user, as_of):
     if a_s.overall_status != status:
         current_app.logger.error(
             "%s != %s for %s as of %s".format(
-            a_s.overall_status, status, user.id, as_of))
+                a_s.overall_status, status, user.id, as_of))
     if a_s.overdue_date is None:
         return na
 


### PR DESCRIPTION
Complicated situation discovered thanks to an assertion in the reporting code.

If a user happens to have posted QNRs that deterministically tie them to the older RP (say they completed `ironmisc` on v3 versus `ironmisc_v5`) AND the timing is such that the older protocol (say v3) didn't include a visit (such as month 33), do NOT insert that skipped visit into their timeline, as we can't move back and forth between protocols. 