### PR TITLE
Bug fix for eproms staff resources page links

### DIFF
--- a/portal/eproms/templates/eproms/resources.html
+++ b/portal/eproms/templates/eproms/resources.html
@@ -24,9 +24,9 @@
                 <ul class="work-instruction-list">
                     {% for asset in results %}
                         {% if 'individual work instruction' in asset['tags'] %}
-                            <li class="work-instruction-item">
-                                <a href="{{url_for('.work_instruction', tag=asset['tags'][1])}}" class="first-letter">{{asset['title']}}</a>
-                            </li>
+                                    <li class="work-instruction-item">
+                                        <a href="{{url_for('.work_instruction', tag=asset['topics'][0])}}" class="first-letter">{{asset['title']}}</a>
+                                    </li>
                         {% endif %}
                     {% endfor %}
                 </ul>

--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -360,7 +360,7 @@ def resources():
         for asset in results:
             if 'demo' in asset['tags']:
                 demo_content.append(asset_by_uuid(asset['uuid']))
-            # topic tag for the work instruction
+            # filter for topic tag for the work instruction
             asset['topics'] = [tag for tag in asset['tags'] if tag not in (
                 asset_title, 'individual work instruction')]
 

--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -352,14 +352,17 @@ def resources():
     org = user.first_top_organization()
     if not org:
         abort(400, 'user must belong to an organization')
-    resources_data = get_any_tag_data(
-        '{} work instruction'.format(org.name.lower()))
+    asset_title = '{} work instruction'.format(org.name.lower())
+    resources_data = get_any_tag_data(asset_title)
     results = resources_data['results']
     if (len(results) > 0):
         demo_content = []
         for asset in results:
             if 'demo' in asset['tags']:
                 demo_content.append(asset_by_uuid(asset['uuid']))
+            # topic tag for the work instruction
+            asset['topics'] = [tag for tag in asset['tags'] if tag not in (
+                asset_title, 'individual work instruction')]
 
         return render_template('eproms/resources.html',
                                results=results, demo_content=demo_content)


### PR DESCRIPTION
address  https://jira.movember.com/browse/TN-2813
Links in EPROMS resources page link to incorrect LR content

Issue stems from code relying on getting the topic tag for the work instruction based on its index within the asset tags array - the index can change however, as tags in the array can change its order

Fix includes:
-  filter for only topic tag in the asset tags array so that the template can use the correct tag to build the url that displays the LR content