### PR TITLE
Latest updates to the patient home page for a sub-study subject

### DIFF
--- a/portal/eproms/templates/eproms/assessment_engine.html
+++ b/portal/eproms/templates/eproms/assessment_engine.html
@@ -1,25 +1,21 @@
-<div class="portal-body">
-    <div class="portal-item">
-        {% if assessment_status.overall_status in (OverallStatus.due, OverallStatus.overdue, OverallStatus.in_progress) %}
-            <!-- patient has pending work in base study -->
-            {% include "eproms/assessment_engine/ae_due.html" with context %}
-        {% elif (unstarted_indefinite_instruments or unfinished_indefinite_instruments) and assessment_status.overall_status != OverallStatus.withdrawn %}
-            <!-- patient completed base study, but has outstanding indefinite work-->
-            {% include "eproms/assessment_engine/ae_indefinite_due.html" with context %}
-        {% elif assessment_status.overall_status == OverallStatus.completed %}
-            <!-- patient completed both base and indefinite or withdrew -->
-            {% include "eproms/assessment_engine/ae_complete.html" with context %}
-        {% elif assessment_status.overall_status == OverallStatus.withdrawn %}
-            <!-- patient withdrawn, show questionnaire unavailable anymore? -->
-            {% include "eproms/assessment_engine/ae_not_available.html" with context %}
-        {% else %}
-            <!--If the user was enrolled in indefinite work and lands
-                here, they should see the thank you text. -->
-            {% if enrolled_in_indefinite %}
-                {% include "eproms/assessment_engine/ae_thankyou.html" with context %}
-            {% else %}
-                {% include "eproms/assessment_engine/ae_not_available.html" with context %}
-            {% endif %}
-        {% endif %}
-    </div>
-</div>
+{% if assessment_status.overall_status in (OverallStatus.due, OverallStatus.overdue, OverallStatus.in_progress) %}
+    <!-- patient has pending work in base study -->
+    {% include "eproms/assessment_engine/ae_due.html" with context %}
+{% elif (unstarted_indefinite_instruments or unfinished_indefinite_instruments) and assessment_status.overall_status != OverallStatus.withdrawn %}
+    <!-- patient completed base study, but has outstanding indefinite work-->
+    {% include "eproms/assessment_engine/ae_indefinite_due.html" with context %}
+{% elif assessment_status.overall_status == OverallStatus.completed %}
+    <!-- patient completed both base and indefinite or withdrew -->
+    {% include "eproms/assessment_engine/ae_complete.html" with context %}
+{% elif assessment_status.overall_status == OverallStatus.withdrawn %}
+    <!-- patient withdrawn, show questionnaire unavailable anymore? -->
+    {% include "eproms/assessment_engine/ae_not_available.html" with context %}
+{% else %}
+    <!--If the user was enrolled in indefinite work and lands
+        here, they should see the thank you text. -->
+    {% if enrolled_in_indefinite %}
+        {% include "eproms/assessment_engine/ae_thankyou.html" with context %}
+    {% else %}
+        {% include "eproms/assessment_engine/ae_not_available.html" with context %}
+    {% endif %}
+{% endif %}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_complete.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_complete.html
@@ -21,17 +21,15 @@
     <!-- tile title change for subjects enrolled in substudy -->
     {% set title_text = _("%(assigning_authority)s Questionnaire", assigning_authority=_(assessment_status.assigning_authority))
                         if enrolled_in_substudy else _("Open Questionnaire") %}
-    {%- call render_card_content(
-        title_text=title_text,
-        card_class="portal-completed-container") -%}
-        <div class="text-content">{{_("No questionnaire is due.")}}</div>
-        {{render_call_to_button(button_label=_("View previous questionnaire"), button_url=url_for("portal.profile", _anchor="proAssessmentsLoc"))}}
-    {%- endcall -%}
-
     {% set completed_title_text = _("%(assigning_authority)s Questionnaire", 
                                 assigning_authority=_(assessment_status.assigning_authority)) if enrolled_in_substudy else  _("Completed Questionnaires") %}
 
     {%- if enrolled_in_substudy -%}
+        {%- call render_card_content(
+            title_text=title_text,
+            card_class="portal-completed-container") -%}
+            <div class="text-content">{{_("No questionnaire is due.")}}</div>
+        {%- endcall -%}
         <!-- main study questionnaire is completed, but sub-study questionnaire could still be due -->
         <!-- substudy due card -->
         {{empro_due(
@@ -43,9 +41,9 @@
             enrolled_in_substudy=enrolled_in_substudy
         )}}
         <div class="portal-skyscraper-container">
-            <!-- main study completed card -->
             <div class="top">
                 <h2 class="section-title">{{_("Completed Questionnaires")}}</h2>
+                <!-- main study completed card -->
                 {{completed_card(
                     assessment_status=assessment_status,
                     OverallStatus=OverallStatus,
@@ -66,6 +64,12 @@
         </div>
     {%- else -%}
         <!-- main study ONLY -->
+        {%- call render_card_content(
+            title_text=title_text,
+            card_class="portal-completed-container") -%}
+            <div class="text-content">{{_("No questionnaire is due.")}}</div>
+            {{render_call_to_button(button_label=_("View previous questionnaire"), button_url=url_for("portal.profile", _anchor="proAssessmentsLoc"))}}
+        {%- endcall -%}
         <!-- main study completed card -->
         {{completed_card(
             assessment_status=assessment_status,

--- a/portal/eproms/templates/eproms/assessment_engine/ae_complete.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_complete.html
@@ -1,16 +1,20 @@
-{%- from "eproms/assessment_engine/ae_macros.html" import render_header, render_card_content, render_call_to_button, completed_card, thankyou_card, empro_due, empro_completed -%}
+{%- from "eproms/assessment_engine/ae_macros.html" import render_header, render_card_content, render_call_to_button, completed_card, thankyou_card, empro_thankyou_card, empro_due, empro_completed -%}
 {% extends "eproms/assessment_engine/ae_base.html" %}
 <!-- User completed both baseline and indefinite -->
 {% block head %}
     <!-- if main study is completed but still work in sub-study display header accordingly -->
-    {%- if substudy_assessment_is_due-%}
+    {%- if substudy_assessment_is_due -%}
         {% call render_header(title_text=greeting) %}
             {{_("Please complete your questionnaire as soon as possible. It is due on %(substudy_due_date)s.",
                 substudy_due_date=substudy_due_date
             )}}
         {% endcall %}
     {%- else -%}
-        {{thankyou_card(full_name=full_name, registry=_(assessment_status.assigning_authority))}}
+        {%- if enrolled_in_substudy -%}
+            {{empro_thankyou_card(full_name=full_name)}}
+        {%- else -%}
+            {{thankyou_card(full_name=full_name, registry=_(assessment_status.assigning_authority))}}
+        {%- endif -%}
     {%- endif -%}
 {% endblock %}
 {% block body %}
@@ -23,30 +27,50 @@
         <div class="text-content">{{_("No questionnaire is due.")}}</div>
         {{render_call_to_button(button_label=_("View previous questionnaire"), button_url=url_for("portal.profile", _anchor="proAssessmentsLoc"))}}
     {%- endcall -%}
-    <!-- main study questionnaire is completed, but sub-study questionnaire could still be due -->
-    <!-- substudy due card -->
-    {{empro_due(
-        substudy_assessment_is_due=substudy_assessment_is_due,
-        assessment_status=assessment_status,
-        OverallStatus=OverallStatus,
-        substudy_assessment_status=substudy_assessment_status,
-        substudy_due_date=substudy_due_date,
-        enrolled_in_substudy=enrolled_in_substudy
-    )}}
 
-    {% set completed_title_text = _("Completed Questionnaires") %}
-    <!-- main study completed card -->
-    {{completed_card(
-        assessment_status=assessment_status,
-        OverallStatus=OverallStatus,
-        comp_date=comp_date,
-        title_text=completed_title_text)}}
-    <!-- substudy completed card -->
-    {{empro_completed(
-        user=user,
-        OverallStatus=OverallStatus,
-        substudy_assessment_status=substudy_assessment_status,
-        substudy_comp_date=substudy_comp_date,
-        enrolled_in_substudy=enrolled_in_substudy
-    )}}
+    {% set completed_title_text = _("%(assigning_authority)s Questionnaire", 
+                                assigning_authority=_(assessment_status.assigning_authority)) if enrolled_in_substudy else  _("Completed Questionnaires") %}
+
+    {%- if enrolled_in_substudy -%}
+        <!-- main study questionnaire is completed, but sub-study questionnaire could still be due -->
+        <!-- substudy due card -->
+        {{empro_due(
+            substudy_assessment_is_due=substudy_assessment_is_due,
+            assessment_status=assessment_status,
+            OverallStatus=OverallStatus,
+            substudy_assessment_status=substudy_assessment_status,
+            substudy_due_date=substudy_due_date,
+            enrolled_in_substudy=enrolled_in_substudy
+        )}}
+        <div class="portal-skyscraper-container">
+            <!-- main study completed card -->
+            <div class="top">
+                <h2 class="section-title">{{_("Completed Questionnaires")}}</h2>
+                {{completed_card(
+                    assessment_status=assessment_status,
+                    OverallStatus=OverallStatus,
+                    comp_date=comp_date,
+                    title_text=completed_title_text)}}
+            </div>
+            <div class="bottom">
+                <!-- substudy completed card -->
+                {{empro_completed(
+                    user=user,
+                    OverallStatus=OverallStatus,
+                    substudy_assessment_status=substudy_assessment_status,
+                    substudy_comp_date=substudy_comp_date,
+                    enrolled_in_substudy=enrolled_in_substudy,
+                    card_class="disabled" if substudy_assessment_is_due else ""
+                )}}
+            </div>
+        </div>
+    {%- else -%}
+        <!-- main study ONLY -->
+        <!-- main study completed card -->
+        {{completed_card(
+            assessment_status=assessment_status,
+            OverallStatus=OverallStatus,
+            comp_date=comp_date,
+            title_text=completed_title_text)}}
+    {%- endif -%}
 {% endblock %}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_due.html
@@ -22,9 +22,9 @@
 {% block body %}
     {% set button_label =  _('Continue questionnaire') if assessment_status.overall_status == OverallStatus.in_progress else _('Go to questionnaire')
     %}
-    <!-- tile title change for subjects enrolled in substudy -->
+    <!-- tile title change for sub-study questionnaire is due.  NOTE: sub-study tile is not available when main study questionnaire is not completed yet -->
     {% set title_text = _("%(assigning_authority)s Questionnaire", assigning_authority=_(assessment_status.assigning_authority))
-                        if enrolled_in_substudy else _("Open Questionnaire") %}
+                        if substudy_assessment_is_due and substudy_assessment_is_due else _("Open Questionnaire") %}
     <!-- main study due card -->
     {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=title_text)}}
     <!-- substudy due card -->

--- a/portal/eproms/templates/eproms/assessment_engine/ae_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_due.html
@@ -29,20 +29,30 @@
     {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=title_text)}}
     <!-- substudy due card -->
     {%- if enrolled_in_substudy -%}
-        {{empro_due(
-            substudy_assessment_is_due=substudy_assessment_is_due,
-            assessment_status=assessment_status,
-            OverallStatus=OverallStatus,
-            substudy_assessment_status=substudy_assessment_status,
-            substudy_due_date=substudy_due_date,
-            enrolled_in_substudy=enrolled_in_substudy
-        )}}
+        {%- if substudy_assessment_is_due -%}
+            {{empro_due(
+                substudy_assessment_is_due=substudy_assessment_is_due,
+                assessment_status=assessment_status,
+                OverallStatus=OverallStatus,
+                substudy_assessment_status=substudy_assessment_status,
+                substudy_due_date=substudy_due_date,
+                enrolled_in_substudy=enrolled_in_substudy
+            )}}
+        {%- else -%}
+            {{completed_card(
+                assessment_status=assessment_status,
+                OverallStatus=OverallStatus,
+                comp_date=comp_date,
+                title_text=title_text)
+            }}
+        {%- endif -%}
     {%- else -%}
+        <!-- main study completed tile -->
         {{completed_card(
             assessment_status=assessment_status,
             OverallStatus=OverallStatus,
             comp_date=comp_date,
-            title_text=title_text)
+            title_text=_("Completed Questionnaires"))
         }}
     {%- endif -%}
 {% endblock %}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
@@ -9,9 +9,9 @@
 {% endblock %}
 {% block body %}
     {%- set button_label = _("Continue questionnaire") if unfinished_indefinite_instruments else _("Go to questionnaire") -%}
-    <!-- tile title change for subjects enrolled in substudy -->
+    <!-- tile title change for sub-study questionnaire is due.  NOTE: sub-study tile is not available when main study questionnaire is not completed yet -->
     {% set title_text = _("%(assigning_authority)s Questionnaire", assigning_authority=_(assessment_status.assigning_authority))
-                        if enrolled_in_substudy else _("Open Questionnaire") %}
+                        if substudy_assessment_is_due else _("Open Questionnaire") %}
     <!-- main study due card -->
     {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=title_text)}}
     {%- if enrolled_in_substudy -%}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
@@ -15,16 +15,21 @@
     <!-- main study due card -->
     {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=title_text)}}
     {%- if enrolled_in_substudy -%}
-        <!-- substudy due card -->
-        {{empro_due(
-            substudy_assessment_is_due=substudy_assessment_is_due,
-            assessment_status=assessment_status,
-            OverallStatus=OverallStatus,
-            substudy_assessment_status=substudy_assessment_status,
-            substudy_due_date=substudy_due_date,
-            enrolled_in_substudy=enrolled_in_substudy
-        )}}
+        {%- if substudy_assessment_is_due -%}
+            <!-- substudy due card -->
+            {{empro_due(
+                substudy_assessment_is_due=substudy_assessment_is_due,
+                assessment_status=assessment_status,
+                OverallStatus=OverallStatus,
+                substudy_assessment_status=substudy_assessment_status,
+                substudy_due_date=substudy_due_date,
+                enrolled_in_substudy=enrolled_in_substudy
+            )}}
+        {%- else -%}
+            {{completed_card(assessment_status=assessment_status, OverallStatus=OverallStatus, comp_date=comp_date)}}
+        {%- endif -%}
     {%- else -%}
-        {{completed_card(assessment_status=assessment_status, OverallStatus=OverallStatus, comp_date=comp_date)}}
+        <!-- main study completed tile -->
+        {{completed_card(assessment_status=assessment_status, OverallStatus=OverallStatus, comp_date=comp_date, title=_("Completed Questionnaires"))}}
     {%- endif -%}
 {% endblock %}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
@@ -30,6 +30,6 @@
         {%- endif -%}
     {%- else -%}
         <!-- main study completed tile -->
-        {{completed_card(assessment_status=assessment_status, OverallStatus=OverallStatus, comp_date=comp_date, title=_("Completed Questionnaires"))}}
+        {{completed_card(assessment_status=assessment_status, OverallStatus=OverallStatus, comp_date=comp_date, title_text=_("Completed Questionnaires"))}}
     {%- endif -%}
 {% endblock %}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
@@ -127,7 +127,7 @@
 {%- endmacro -%}
 {%- macro empro_thankyou_card(full_name="") -%}
     {% call render_header(title_text=_("Hi, %(full_name)s.", full_name=full_name if full_name else '')) %}
-        <p>{{_("None of your questionnaires are due.  You can view your completed questionnaires below:")}}</p>
+        <p>{{_("None of your questionnaires are due. You can view your completed questionnaires below:")}}</p>
     {% endcall %}
 {%- endmacro -%}
 {%- macro empro_modal_default_supportTeam_block(organization="") -%}
@@ -148,14 +148,14 @@
         <p><b>{{_("To help address these, we've informed your care team and they'll be in contact with you soon.")}}</b></p>
         <br/>
         {% if user and user.organizations %}
-            <p>{{_("In the meantime, if you have any questions or need assistance, please contact your team at %(organization) directly.  They're happy to help.", organization=organization)}}</p>
+            <p>{{_("In the meantime, if you have any questions or need assistance, please contact your team at %(organization) directly. They're happy to help.", organization=organization)}}</p>
         {% endif %}
     </div>
 {%- endmacro -%}
 {%- macro empro_modal_default_report_block() -%}
     <div class="item">
         <h4>{{_("Your Report")}}</h4>
-        <p>{{_("Here’s where you'll find an ongoing summary of your responses, each time you complete a questionnaire.")}}</p>
+        <p>{{_("Here's where you'll find an ongoing summary of your responses, each time you complete a questionnaire.")}}</p>
         <div class="buttons-container">
             <!-- TODO point to longitudinal report -->
             <a class="btn btn-empro-primary">{{_("My Report")}}</a>

--- a/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
@@ -39,9 +39,9 @@
         {{render_call_to_button(button_label=button_label, button_url=url_for('assessment_engine_api.present_needed'))}}
     {%- endcall -%}
 {%- endmacro -%}
-{%- macro completed_card(assessment_status={}, OverallStatus={}, comp_date="", title_text=_("Completed Questionnaires")) -%}
+{%- macro completed_card(assessment_status={}, OverallStatus={}, comp_date="", title_text=_("Completed Questionnaires"), card_class="") -%}
     {%- if assessment_status.overall_status == OverallStatus.completed -%}
-        {% call render_card_content(title_text=title_text) %}
+        {% call render_card_content(title_text=title_text, card_class=card_class) %}
             <div class="text-content">
                 <a class="portal-weak-auth-disabled" href='{{url_for("portal.profile", _anchor="proAssessmentsLoc")}}'>
                     {{_("View questionnaire completed on %(comp_date)s", comp_date=comp_date)}}
@@ -101,15 +101,16 @@
     OverallStatus={},
     substudy_assessment_status={},
     substudy_comp_date="",
-    enrolled_in_substudy=false)
+    enrolled_in_substudy=false,
+    card_class="")
 -%}
     <!-- subject is in the sub-study and the sub-study questionnaire has been completed -->
     {%- if enrolled_in_substudy and 
         substudy_assessment_status.overall_status == OverallStatus.completed -%}
         {%- set substudy_title = "EMPRO" -%}
         {%- call render_card_content(
-            title_text=_("%(substudy_title)s: Get help with your specific issues", substudy_title=substudy_title),
-            card_class="portal-description-complete") -%}
+            title_text = _("%(substudy_title)s: Get help with your specific issues", substudy_title=substudy_title),
+            card_class = card_class if card_class else "portal-description-complete") -%}
             <div class="text-content">
                 <!-- this is an anchor link to open thank you modal -->
                 <a data-toggle="modal" data-target="#emproModal">{{_("Learn about your specific issues based on your last questionnaire submitted on %(substudy_comp_date)s", substudy_comp_date=substudy_comp_date)}}</a>
@@ -117,79 +118,103 @@
         {%- endcall -%}
         <!-- TODO link to longitudinal report page -->
         {%- call render_card_content(
-            title_text=_("%(substudy_title)s: View how you are doing over time", substudy_title=substudy_title),
-            card_class="portal-description-complete") -%}
+            title_text = _("%(substudy_title)s: View how you are doing over time", substudy_title=substudy_title),
+            card_class = card_class if card_class else "portal-description-complete") -%}
             <p>{{_("View your longitudinal charts and discuss with your care provider")}}</p>
         {%- endcall -%}
         {{empro_thankyou_modal(user)}}
     {%- endif -%}
+{%- endmacro -%}
+{%- macro empro_thankyou_card(full_name="") -%}
+    {% call render_header(title_text=_("Hi, %(full_name)s.", full_name=full_name if full_name else '')) %}
+        <p>{{_("None of your questionnaires are due.  You can view your completed questionnaires below:")}}</p>
+    {% endcall %}
+{%- endmacro -%}
+{%- macro empro_modal_default_supportTeam_block(organization="") -%}
+    <div class="item">
+        <h4>{{_("Your Support Team")}}</h4>
+        <p>{{_("If you have any questions or need assistance, please contact your team at %(organization)s directly. They're happy to help.", organization=organization)}}</p>
+      
+    </div>
+{%- endmacro -%}
+{%- macro empro_modal_hardTrigger_supportTeam_block(organization="") -%}
+    <div class="item">
+        <h4>{{_("Your Support Team")}}</h4>
+        <p>{{_("You reported having some particular challenges with: ")}}</p>
+        <ul class="triggersDisplayList">
+           <!-- dynamically populated based on user trigger domain(s) -->
+        </ul>
+        <br/>
+        <p><b>{{_("To help address these, we've informed your care team and they'll be in contact with you soon.")}}</b></p>
+        <br/>
+        {% if user and user.organizations %}
+            <p>{{_("In the meantime, if you have any questions or need assistance, please contact your team at %(organization) directly.  They're happy to help.", organization=organization)}}</p>
+        {% endif %}
+    </div>
+{%- endmacro -%}
+{%- macro empro_modal_default_report_block() -%}
+    <div class="item">
+        <h4>{{_("Your Report")}}</h4>
+        <p>{{_("Here’s where you'll find an ongoing summary of your responses, each time you complete a questionnaire.")}}</p>
+        <div class="buttons-container">
+            <!-- TODO point to longitudinal report -->
+            <a class="btn btn-empro-primary">{{_("My Report")}}</a>
+        </div>
+    </div>
+{%- endmacro -%}
+{%- macro empro_modal_triggered_healthTip_block() -%}
+    <div class="item">
+        <h4>{{_("Your Health Tips")}}</h4>
+        <p>{{_("Based on your questionnaire responses, we've gathered tips and resources on managing the topic(s) below:")}}</p>
+        <div class="triggersButtonsContainer buttons-container">
+            <!--dynamically populated based on user trigger domain(s) -->
+        </div>
+    </div>
+{%- endmacro -%}
+{%- macro empro_modal_default_healthTip_block() -%}
+    <div class="item">
+        <h4>{{_("Your Health Tips")}}</h4>
+        <p>{{_("Explore ways to manage common prostate cancer challenges. Here you'll find plenty of helpful information and resources.")}}</p>
+        <div class="buttons-container">
+            <a class="btn btn-empro-primary" href="{{url_for('portal.substudy_tailored_content')}}" target="_blank">{{_("Explore Our Resources")}}</a>
+        </div>
+    </div>
 {%- endmacro -%}
 <!--sub-study macro -->
 {%- macro empro_thankyou_modal(user) -%}
     <!-- sub-study modal for display domain topic(s), resources link and summary report link to the user -->
     <div class="modal fade" tabindex="-1" role="dialog" id="emproModal">
         <div class="modal-dialog">
-        <div class="modal-content">
-            <button type="button" class="close" data-dismiss="modal" aria-label="{{_('Close')}}"><span aria-hidden="true">&times;</span></button>
-            <div class="modal-body">
-                <div class="header-section">
-                    <h2 class="title">{{_("Thank you for completing the IRONMAN EMPRO questionnaire.")}}</h2>
-                    <p class="subtitle-text">{{_("We appreciate you sharing your experience and truly value your time.")}}</p>
-                </div>
-                <div class="items-section">
-                    <!-- TODO show this section only if there is hard trigger -->
-                    <!-- hard trigger items are hidden by default -->
-                    <div class="item hard-trigger-item">
-                        <!-- TODO dynamic populate domain topics from call to API !?! -->
-                        <p>{{_("You reported having some particular challenges with: ")}}</p>
-                        <ul id="hardTriggerDisplayList">
-                            <!-- TODO this is the subject's domain topic(s)-->
-                            <!--<li>{{_("insomnia")}}</li>-->
-                        </ul>
-                        <br/>
-                        <p><b>{{_("To help address these, we've informed your care team and they'll be in contact with you soon.")}}</b></p>
-                        <br/>
-                        {% if user and user.organizations %}
-                            <p>{{_("In the meantime, if you have any questions or need assistance, please contact your team directly at")}}</p>
-                            <p><b>{{user.organizations[0].name}}</b></p>
-                        {% endif %}
+            <div class="modal-content">
+                <button type="button" class="close" data-dismiss="modal" aria-label="{{_('Close')}}">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <div class="modal-body">
+                    <div class="header-section">
+                        <h2 class="title">
+                            {{_("Thank you for being part of the IRONMAN EMPRO study.")}}
+                            <br/>
+                            {{_("We truly value your time and participation.")}}
+                        </h2>
+                        <p>{{_("Find your latest tips and tools below.")}}</p>
                     </div>
-                    <!-- TODO show this section only if there is hard trigger -->
-                    <!-- TODO show this section only if there is soft trigger -->
-                    <div class="item hard-trigger-item">
-                        <p>{{_("Based on your questionnaire responses, we've also gathered information and resources you may find helpful.")}}</p>
-                        <div id="hardTriggerButtonsContainer" class="buttons-container">
-                            <!--TODO this should be dynamically populated based on the domain topics available to the user-->
-                            <!--<button class="btn btn-empro-primary">{{_("insomnia")}}</button>-->
-                        </div>
+                    <div class="items-section no-trigger">
+                        {{empro_modal_default_report_block()}}
+                        {{empro_modal_default_healthTip_block()}}
+                        {{empro_modal_default_supportTeam_block(organization=user.organizations[0].name if user else "")}}
                     </div>
-                    <!-- always show -->
-                    <div class="item default">
-                        <p class="hard-trigger-item">{{_("Our goal is to guide you through managing each challenge with key information and support. To view a full summary of your responses, use the link below.")}}</p>
-                        <p class="soft-trigger-item no-trigger-item">{{_("View a full summary of your responses.")}}</p>
-                        <!-- TODO point to longitudinal report-->
-                        <div class="buttons-container">
-                            <button class="btn btn-empro-primary">{{_("View Report")}}</button>
-                        </div>
+                    <div class="items-section hard-trigger">
+                        {{empro_modal_hardTrigger_supportTeam_block(organization=user.organizations[0].name if user else "")}}
+                        {{empro_modal_triggered_healthTip_block()}}
+                        {{empro_modal_default_report_block()}}
                     </div>
-                    <div class="item soft-trigger-item no-trigger-item">
-                        <p>{{_("We've gathered more information and resources you may find helpful.")}}</p>
-                        <div class="buttons-container">
-                            <!-- TODO self management pointing to self management landing page -->
-                            <a class="btn btn-empro-primary" href="/substudy_tailored_content">{{_("Explore Our Resources")}}</a>
-                        </div>
-                    </div>
-                    <div class="item soft-trigger-item no-trigger-item">
-                        <p>{{_("If you have any questions or need assistance, please contact your team directly.")}}</p>
-                        <br/>
-                        {% if user and user.organizations %}
-                            <p>{{_("If you have any questions or need assistance, please contact your team directly at")}}</p>
-                            <p><b>{{user.organizations[0].name}}</b></p>
-                        {% endif %}
+                    <div class="items-section soft-trigger">
+                        {{empro_modal_triggered_healthTip_block()}}
+                        {{empro_modal_default_report_block()}}
+                        {{empro_modal_default_supportTeam_block(organization=user.organizations[0].name if user else "")}}
                     </div>
                 </div>
             </div>
-        </div>
         </div>
     </div>
     {{empro_script()}}

--- a/portal/static/js/src/empro.js
+++ b/portal/static/js/src/empro.js
@@ -30,7 +30,7 @@ emproObj.prototype.initTriggerItemsVis = function() {
     if (this.hasHardTrigger) {
         $("#emproModal .hard-trigger").addClass("active");
         $("#emproModal .no-trigger").hide();
-         //present thank you modal
+         //present thank you modal if hard trigger present
         $("#emproModal").modal("show");
         return;
     }
@@ -64,7 +64,13 @@ emproObj.prototype.initTriggerDomains = function() {
                 let entry = Object.entries(item);
                 return entry[0] && entry[0][1] && entry[0][1].indexOf("soft") !== -1;
             }).length;
+            /*
+             * display user domain topic(s)
+             */
             self.populateDomainDisplay();
+            /*
+             * show/hide sections based on triggers
+             */
             self.initTriggerItemsVis();
            //console.log("self.domains? ", self.domains);
            //console.log("has hard triggers ", self.hasHardTrigger);
@@ -77,5 +83,4 @@ $(document).ready(function() {
     let EmproObj = new emproObj();
     EmproObj.initTriggerDomains();
     EmproObj.initThankyouModal();
-   
 });

--- a/portal/static/js/src/empro.js
+++ b/portal/static/js/src/empro.js
@@ -66,9 +66,9 @@ emproObj.prototype.initTriggerDomains = function() {
             }).length;
             self.populateDomainDisplay();
             self.initTriggerItemsVis();
-           console.log("self.domains? ", self.domains);
-           console.log("has hard triggers ", self.hasHardTrigger);
-           console.log("has soft triggers ", self.hasSoftTrigger);
+           //console.log("self.domains? ", self.domains);
+           //console.log("has hard triggers ", self.hasHardTrigger);
+           //console.log("has soft triggers ", self.hasSoftTrigger);
         });
     });
 }
@@ -79,4 +79,3 @@ $(document).ready(function() {
     EmproObj.initThankyouModal();
    
 });
-

--- a/portal/static/js/src/empro.js
+++ b/portal/static/js/src/empro.js
@@ -8,22 +8,45 @@ var emproObj = function() {
     this.userId = 0;
 };
 emproObj.prototype.populateDomainDisplay = function() {
-    if (!$("#hardTriggerDisplayList").length) return;
     this.domains.forEach(domain => {
-        $("#hardTriggerDisplayList").append(`<li>${domain}</li>`);
-        $("#hardTriggerButtonsContainer").append(
-            `<a class="btn btn-empro-primary" href="/substudy-tailored-content#/${domain}">${domain.replace(/_/g, " ")}</a>`
+        $("#emproModal .triggersDisplayList").append(`<li>${domain}</li>`);
+        $("#emproModal .triggersButtonsContainer").append(
+            `<a class="btn btn-empro-primary" href="/substudy-tailored-content#/${domain}" target="_blank">${domain.replace(/_/g, " ")}</a>`
         );
     });
+};
+emproObj.prototype.initThankyouModal = function() {
+    if (!$("#emproModal").length) {
+        return;
+    }
+    $("#emproModal").modal({
+        show: false
+    });
+};
+emproObj.prototype.initTriggerItemsVis = function() {
+    if (!$("#emproModal").length) {
+        return;
+    }
+    if (this.hasHardTrigger) {
+        $("#emproModal .hard-trigger").addClass("active");
+        $("#emproModal .no-trigger").hide();
+         //present thank you modal
+        $("#emproModal").modal("show");
+        return;
+    }
+    if (this.hasSoftTrigger) {
+        $("#emproModal .soft-trigger").addClass("active");
+        $("#emproModal .no-trigger").hide();
+        return;
+    }
+   
 };
 emproObj.prototype.initTriggerDomains = function() {
     var self = this;
     tnthAjax.getCurrentUser((data) => {
         if (!data || !data.id) return;
         this.userId = data.id;
-        //console.log("user id? ", this.userId)
         tnthAjax.getSubStudyTriggers(this.userId, false, function(data) {
-            //console.log("data? ", data)
             if (!data || !data.triggers || !data.triggers.domain) {
                 return false;
             }
@@ -42,24 +65,18 @@ emproObj.prototype.initTriggerDomains = function() {
                 return entry[0] && entry[0][1] && entry[0][1].indexOf("soft") !== -1;
             }).length;
             self.populateDomainDisplay();
-            if (self.hasHardTrigger) {
-                $("#emproModal .hard-trigger-item").show();
-                $("#emproModal .soft-trigger-item").hide();
-                $("#emproModal .no-trigger-item").hide();
-                //present thank you modal
-                $("#emproModal").modal("show");
-            }
-       //     console.log("self.domains? ", self.domains);
-       //     console.log("has hard triggers ", self.hasHardTrigger);
-       //     console.log("has soft triggers ", self.hasSoftTrigger);
+            self.initTriggerItemsVis();
+           console.log("self.domains? ", self.domains);
+           console.log("has hard triggers ", self.hasHardTrigger);
+           console.log("has soft triggers ", self.hasSoftTrigger);
         });
     });
 }
 
 $(document).ready(function() {
-    (new emproObj()).initTriggerDomains();
-    $("#emproModal").modal({
-        show: false
-    });
+    let EmproObj = new emproObj();
+    EmproObj.initTriggerDomains();
+    EmproObj.initThankyouModal();
+   
 });
 

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -1100,8 +1100,8 @@ select:not([multiple]) {
   z-index: 20;
   position: relative;
   visibility: hidden;
-  -webkit-transition: visibility 350ms ease;
-  transition: visibility 350ms ease;
+  -webkit-transition: visibility 350ms ease 150ms;
+  transition: visibility 350ms ease 150ms;
 }
 #iqFooterWrapper {
   display: none;

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -1100,8 +1100,8 @@ select:not([multiple]) {
   z-index: 20;
   position: relative;
   visibility: hidden;
-  -webkit-transition: visibility 350ms ease 150ms;
-  transition: visibility 350ms ease 150ms;
+  -webkit-transition: visibility 350ms ease 350ms;
+  transition: visibility 350ms ease 350ms;
 }
 #iqFooterWrapper {
   display: none;
@@ -2817,7 +2817,7 @@ body.portal .copyright-container  {
 }
 .portal-header-container {
   color: #FFF;
-  width: 90%;
+  width: 87.5%;
   margin: 1em auto 2em auto;
   font-size: @subheadSize;
   max-width: 100%;
@@ -2895,7 +2895,7 @@ body.portal .copyright-container  {
 .portal-description {
   background: #3d4750;
   color: #FFF;
-  padding: 0.5em 2em 2.5em;
+  padding: 0.5em 1.5em 2.5em;
   position: relative;
   width: 440px;
   max-width: 100%;

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -2817,7 +2817,7 @@ body.portal .copyright-container  {
 }
 .portal-header-container {
   color: #FFF;
-  width: 85%;
+  width: 90%;
   margin: 1em auto 2em auto;
   font-size: @subheadSize;
   max-width: 100%;
@@ -2907,7 +2907,22 @@ body.portal .copyright-container  {
     text-overflow: ellipsis;
   }
   &.disabled {
-    opacity: @disabledOpacity;
+    position: relative;
+    a:hover {
+      text-decoration: none;
+    }
+    &:after {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      display: block;
+      content: "";
+      background:@muterColor;
+      opacity: 0.1;
+      z-index: 1;
+    }
   }
   & .title {
     font-size: @subSmallHeadSize;
@@ -2951,11 +2966,7 @@ body.portal .copyright-container  {
     width: 42.5%;
   }
 }
-@media (min-width: 1200px) {
-  .portal-description {
-    width: 40%;
-  }
-}
+
 .portal-no-description-container {
   position: relative;
   font-size: @subheadSize;
@@ -3043,6 +3054,27 @@ body.portal .copyright-container  {
   padding: 2em;
 }
 
+.portal-skyscraper-container {
+  margin-top: 40px;
+  .section-title {
+    color: #FFF;
+    margin-bottom: 16px;
+    font-size: @lgFontSize;
+  }
+  .top {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+  }
+  .bottom {
+    display: flex;
+    justify-content: center;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+}
+
 #emproModal {
   .modal-dialog {
     width: 100%;
@@ -3057,12 +3089,13 @@ body.portal .copyright-container  {
     position: relative;
     .close {
       position: absolute;
-      right: 24px;
-      top: 16px;
+      right: 16px;
+      top: 8px;
       font-size: 24px;
       display: block;
       font-weight: 400;
       color: @mutedColor;
+      opacity: 1;
       z-index: 10;
     }
     p {
@@ -3072,7 +3105,7 @@ body.portal .copyright-container  {
   .title {
     margin-bottom: 16px;
     width: 100%;
-    line-height: 1.5;
+    line-height: 1.4;
     padding-right: 32px;
   }
   .header-section {
@@ -3090,15 +3123,22 @@ body.portal .copyright-container  {
     flex-wrap: wrap;
     justify-content: space-evenly;
     margin-bottom: 24px;
+    &.hard-trigger,
+    &.soft-trigger {
+      display: none;
+    }
+    &.active {
+      display: flex;
+    }
     .item {
-      padding: 24px 8px;
+      padding: 16px 8px 24px;
       width: 100%;
       border-bottom: 1px solid @HRColor;
       &:last-of-type {
         border-bottom: 0;
       }
-      &.hard-trigger-item {
-        display: none;
+      li:not(:last-of-type) {
+        margin-bottom: 8px;
       }
     }
     .buttons-container {
@@ -3109,7 +3149,7 @@ body.portal .copyright-container  {
       color: #FFF;
       display: block;
       width: 100%;
-      max-width: 320px;
+      max-width: 100%;
       white-space: normal;
       margin: 8px auto;
     }
@@ -3117,19 +3157,15 @@ body.portal .copyright-container  {
 }
 @media (min-width: 768px) {
   #emproModal {
-    .title {
-      width: 480px;
-    }
     .items-section {
       .item {
-        padding: 24px 24px;
+        padding: 16px 24px 24px;
         width: 33.33333333%;
         min-height: 424px;
         flex-wrap: nowrap;
         flex: 1;
         border-bottom: 0;
-        &:first-of-type,
-        &.default:first-child{
+        &:first-of-type {
           padding-left: 0;
         }
         &:not(:last-of-type) {
@@ -3145,7 +3181,7 @@ body.portal .copyright-container  {
 @media (min-width: 1200px) {
   #emproModal {
     .modal-dialog {
-      width: 75%;
+      width: 70%;
       margin: auto;
     }
   }
@@ -3153,7 +3189,7 @@ body.portal .copyright-container  {
 @media (min-width: 1400px) {
   #emproModal {
     .modal-dialog {
-      width: 70%;
+      width: 67.5%;
     }
   }
 }

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -2895,7 +2895,7 @@ body.portal .copyright-container  {
 .portal-description {
   background: #3d4750;
   color: #FFF;
-  padding: 0.5em 1.5em 2.5em;
+  padding: 0.5em 1.75em 2.5em;
   position: relative;
   width: 440px;
   max-width: 100%;
@@ -2956,7 +2956,7 @@ body.portal .copyright-container  {
 @media (min-width: 992px) {
   .portal-description {
     margin: 1em;
-    width: 42.5%;
+    width: 40%;
     &.full-width {
       width: 96%;
       min-height: 200px;
@@ -3037,7 +3037,7 @@ body.portal .copyright-container  {
   text-align: center;
   font-size: @baseFontSize;
   line-height: 1.5;
-  margin-bottom: 12px;
+  margin-bottom: 16px;
 }
 
 @media (min-width: 699px) {


### PR DESCRIPTION
Addresses: 
https://jira.movember.com/browse/TN-2786
https://jira.movember.com/browse/TN-2644
update patient home page for a sub-study subject based on latest content and design changes

Changes include:

- Verbiage updates to sub-study tiles
- update layout for when both main study and sub-study questionnaires are completed
- update sub-study thank you modal based on latest design and content changes
- fix tile text for when **both** sub-study and main-study tiles are present
- put back text for the main study questionnaire completed tile
- remove un-needed extra HTML tags from assessment_engine.html

