### PR TITLE
Substudy patient list updates

### DIFF
--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -2,7 +2,7 @@ import tnthAjax from "./modules/TnthAjax.js";
 import tnthDates from "./modules/TnthDate.js";
 import Utility from "./modules/Utility.js";
 import CurrentUser from "./mixins/CurrentUser.js";
-import {EPROMS_SUBSTUDY_ID} from "./data/common/consts.js";
+import {EPROMS_MAIN_STUDY_ID, EPROMS_SUBSTUDY_ID} from "./data/common/consts.js";
 
 (function () { /*global Vue DELAY_LOADING i18next $ */
     var DELAY_LOADING = true; //a workaround for hiding of loading indicator upon completion of loading of portal wrapper - loading indicator needs to continue displaying until patients list has finished loading
@@ -46,7 +46,9 @@ import {EPROMS_SUBSTUDY_ID} from "./data/common/consts.js";
                     self.setRowItemEvent();
                     self.handleAffiliatedUIVis();
                     self.addFilterPlaceHolders();
-                    self.setContainerVis();
+                    setTimeout(function() {
+                        self.setContainerVis();
+                    }, 350);
                 } else {
                     self.handleCurrentUser();
                 }
@@ -166,7 +168,8 @@ import {EPROMS_SUBSTUDY_ID} from "./data/common/consts.js";
             },
             getExportReportUrl: function(dataType) {
                 dataType = dataType||"json";
-                return `/api/report/questionnaire_status?format=${dataType}`;
+                let researchStudyID = $("#patientList").hasClass("substudy")?EPROMS_SUBSTUDY_ID: EPROMS_MAIN_STUDY_ID;
+                return `/api/report/questionnaire_status?research_study_id=${researchStudyID}&format=${dataType}`;
             },
             clearExportReportTimeoutID: function() {
                 if (!this.arrExportReportTimeoutID.length) {

--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -168,7 +168,7 @@ import {EPROMS_MAIN_STUDY_ID, EPROMS_SUBSTUDY_ID} from "./data/common/consts.js"
             },
             getExportReportUrl: function(dataType) {
                 dataType = dataType||"json";
-                let researchStudyID = $("#patientList").hasClass("substudy")?EPROMS_SUBSTUDY_ID: EPROMS_MAIN_STUDY_ID;
+                let researchStudyID = $("#patientList").hasClass("substudy") ? EPROMS_SUBSTUDY_ID: EPROMS_MAIN_STUDY_ID;
                 return `/api/report/questionnaire_status?research_study_id=${researchStudyID}&format=${dataType}`;
             },
             clearExportReportTimeoutID: function() {

--- a/portal/static/js/src/modules/OrgTool.js
+++ b/portal/static/js/src/modules/OrgTool.js
@@ -123,20 +123,26 @@ export default (function() { /*global i18next $ */
         if (!researchProtocols.length) return [];
         return researchProtocols[0].research_protocols;
     }
-    OrgTool.prototype.isSubStudyOrg = function(orgId) {
+    OrgTool.prototype.isSubStudyOrg = function(orgId, params) {
         if (!orgId) return false;
+        params = params || {};
         var orgsList = this.getOrgsList();
         if (!orgsList.hasOwnProperty(orgId)) return false;
         if (!this.getResearchProtocolsByOrgId(orgId).length) {
-            /*
-             * include flag for inherited attributes to find added inherited attributes that include research study
-             * information
-             */
-            tnthAjax.getOrg(orgId, {include_inherited_attributes: true, sync: true}, function(data) {
-                if (data && data.extension) {
-                    orgsList[orgId].extension = [...data.extension];
-                }
-            });
+            if (sessionStorage.getItem(`extension_${orgId}`)) {
+                orgsList[orgId].extension = [...JSON.parse(sessionStorage.getItem(`extension_${orgId}`))];
+            } else {
+                /*
+                * include flag for inherited attributes to find added inherited attributes that include research study
+                * information
+                */
+                tnthAjax.getOrg(orgId, {include_inherited_attributes: true, sync: params.async ? false : true}, function(data) {
+                    if (data && data.extension) {
+                        orgsList[orgId].extension = [...data.extension];
+                        sessionStorage.setItem(`extension_${orgId}`, JSON.stringify(data.extension));
+                    }
+                });
+            }
         }
         let researchProtocolSet = this.getResearchProtocolsByOrgId(orgId);
 

--- a/portal/templates/admin/patients_substudy.html
+++ b/portal/templates/admin/patients_substudy.html
@@ -62,14 +62,14 @@
                   <th data-field="lastname" data-sortable="true" data-class="lastname-field" data-filter-control="input">{{ _("Last Name") }}</th>
                   <th data-field="birthdate" data-sortable="true" data-class="birthdate-field" data-filter-control="input" data-visible="false">{{ _("Date of Birth") }}</th>
                   <th data-field="email" data-sortable="true" data-class="email-field" data-filter-control="input">{{ _("Email") }}</th>
-                  <th data-field="status" data-sortable="true" data-card-visible="false" data-searchable="true" data-width="5%" data-class="status-field" data-filter-control="select" data-filter-strict-search="true">{{ _("Clinician/Staff Questionnaire Status") }}</th>
+                  <th data-field="status" data-sortable="true" data-card-visible="false" data-searchable="true" data-width="5%" data-class="status-field" data-filter-control="select" data-filter-strict-search="true">{{_("Questionnaire Status")}}</th>
                   <th data-field="visit" data-sortable="true" data-card-visible="false" data-searchable="true" data-width="5%" data-class="visit-field" data-filter-control="input" data-visible="false">{{ _("Visit") }}</th>
                   <th data-field="study_id" data-sortable="true" data-searchable="true" data-class="study-id-field" data-filter-control="input" data-visible="false" data-sorter="tnthTables.alphanumericSorter" data-width="5%">{{ _("Study ID") }}</th>
                   <th data-field="consentdate" data-sortable="true" data-card-visible="false" data-sorter="tnthTables.dateSorter" data-searchable="true" data-visible="false" data-class="consentdate-field text-center" data-filter-control="input" data-visible="true">{{ app_text('consent date label') }} {{_("(GMT)")}}</th>
-                  <th data-field="organization" data-sortable="true" data-class="organization-field"  data-filter-control="select" data-visible="false">{{ _("Site(s)") }}</th>
+                  <th data-field="organization" data-sortable="true" data-class="organization-field"  data-filter-control="select" data-visible="true">{{ _("Site(s)") }}</th>
                   <!-- TODO fill in these two columns with data -->
                   <th data-field="clinician" data-sortable="true" data-class="clinician-field" data-filter-control="select">{{ _("Treating Clinician") }}</th>
-                  <th data-field="interventionActions" data-sortable="true" data-class="intervention-actions-field" data-filter-control="select">{{ _("Trigger Response") }}</th>
+                  <th data-field="interventionActions" data-sortable="true" data-class="intervention-actions-field" data-filter-control="select">{{ _("Response Status") }}</th>
               </tr>
           </thead>
           <tbody id="admin-table-body" class="data-link">


### PR DESCRIPTION
Address part of https://jira.movember.com/browse/TN-2771
Update column names for sub-study patient list based on latest specs.
In addition, fixes were made:

- fix export of report data on the sub-study patient list page, i.e. passed in research study ID so data by research study will be exported
- fix organization filter selector to sub-study organization(s) on the sub-study patient list
- fix patient list toggle UI so that clicking on the label will also be able to switch view