### PR TITLE
TN-2786 follow-up bug fixes for EMPRO patient home page

### DIFF
--- a/portal/eproms/templates/eproms/assessment_engine/ae_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_due.html
@@ -1,4 +1,4 @@
-{%- from "eproms/assessment_engine/ae_macros.html" import render_header, render_greeting, render_card_content, render_call_to_button, due_card, completed_card, empro_due -%}
+{%- from "eproms/assessment_engine/ae_macros.html" import render_header, render_greeting, render_card_content, render_call_to_button, due_card, completed_card, empro_due, empro_completed -%}
 {% extends "eproms/assessment_engine/ae_base.html" %}
 <!-- baseline due -->
 {% block head %}
@@ -22,11 +22,15 @@
 {% block body %}
     {% set button_label =  _('Continue questionnaire') if assessment_status.overall_status == OverallStatus.in_progress else _('Go to questionnaire')
     %}
-    <!-- tile title change for sub-study questionnaire is due.  NOTE: sub-study tile is not available when main study questionnaire is not completed yet -->
-    {% set title_text = _("%(assigning_authority)s Questionnaire", assigning_authority=_(assessment_status.assigning_authority))
-                        if substudy_assessment_is_due else _("Open Questionnaire") %}
+    <!-- tile title change for sub-study questionnaire is due.  NOTE: sub-study DUE tile is not available when main study questionnaire is not completed yet -->
+    {% set due_title_text = _("%(assigning_authority)s Questionnaire", assigning_authority=_(assessment_status.assigning_authority))
+                            if enrolled_in_substudy else _("Open Questionnaire") %}
+    <!-- tile title for completed card, NOTE:  need to differentiate between main and sub-study -->
+    {% set completed_title_text = _("%(assigning_authority)s Questionnaire", 
+                            assigning_authority=_(assessment_status.assigning_authority))
+                            if enrolled_in_substudy else _("Completed Questionnaire") %}
     <!-- main study due card -->
-    {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=title_text)}}
+    {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=due_title_text)}}
     <!-- substudy due card -->
     {%- if enrolled_in_substudy -%}
         {%- if substudy_assessment_is_due -%}
@@ -43,16 +47,24 @@
                 assessment_status=assessment_status,
                 OverallStatus=OverallStatus,
                 comp_date=comp_date,
-                title_text=_("Completed Questionnaires"))
+                title_text=completed_title_text)
             }}
         {%- endif -%}
+         <!-- it is possible that user has completed empro at this point, so need to show -->
+        {{empro_completed(
+            user=user,
+            OverallStatus=OverallStatus,
+            substudy_assessment_status=substudy_assessment_status,
+            substudy_comp_date=substudy_comp_date,
+            enrolled_in_substudy=enrolled_in_substudy
+        )}}
     {%- else -%}
         <!-- main study completed tile -->
         {{completed_card(
             assessment_status=assessment_status,
             OverallStatus=OverallStatus,
             comp_date=comp_date,
-            title_text=_("Completed Questionnaires"))
+            title_text=completed_title_text)
         }}
     {%- endif -%}
 {% endblock %}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
@@ -1,4 +1,4 @@
-{%- from "eproms/assessment_engine/ae_macros.html" import render_header, render_greeting, render_card_content, render_call_to_button, due_card, completed_card, empro_due -%}
+{%- from "eproms/assessment_engine/ae_macros.html" import render_header, render_greeting, render_card_content, render_call_to_button, due_card, completed_card, empro_due, empro_completed -%}
 {% extends "eproms/assessment_engine/ae_base.html" %}
 <!-- User completed baseline, but has outstanding indefinite work -->
 {% block head %}
@@ -9,11 +9,14 @@
 {% endblock %}
 {% block body %}
     {%- set button_label = _("Continue questionnaire") if unfinished_indefinite_instruments else _("Go to questionnaire") -%}
-    <!-- tile title change for sub-study questionnaire is due.  NOTE: sub-study tile is not available when main study questionnaire is not completed yet -->
-    {% set title_text = _("%(assigning_authority)s Questionnaire", assigning_authority=_(assessment_status.assigning_authority))
-                        if substudy_assessment_is_due else _("Open Questionnaire") %}
+    <!-- tile title change for sub-study questionnaire is due.  NOTE: sub-study DUE tile is not available when main study questionnaire is not completed yet -->
+    {% set due_title_text = _("%(assigning_authority)s Questionnaire", assigning_authority=_(assessment_status.assigning_authority))
+        if enrolled_in_substudy else _("Open Questionnaire") %}
+    <!-- tile title for completed card, NOTE:  need to differentiate between main and sub-study -->
+    {% set completed_title_text = _("%(assigning_authority)s Questionnaire", assigning_authority=_(assessment_status.assigning_authority))
+        if enrolled_in_substudy else _("Completed Questionnaire") %}
     <!-- main study due card -->
-    {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=title_text)}}
+    {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=due_title_text)}}
     {%- if enrolled_in_substudy -%}
         {%- if substudy_assessment_is_due -%}
             <!-- substudy due card -->
@@ -26,10 +29,22 @@
                 enrolled_in_substudy=enrolled_in_substudy
             )}}
         {%- else -%}
-            {{completed_card(assessment_status=assessment_status, OverallStatus=OverallStatus, comp_date=comp_date)}}
+            {{completed_card(
+                assessment_status=assessment_status,
+                OverallStatus=OverallStatus,
+                comp_date=comp_date,
+                title_text=completed_title_text)}}
         {%- endif -%}
+        <!-- it is possible that user has completed empro at this point, so need to show -->
+        {{empro_completed(
+            user=user,
+            OverallStatus=OverallStatus,
+            substudy_assessment_status=substudy_assessment_status,
+            substudy_comp_date=substudy_comp_date,
+            enrolled_in_substudy=enrolled_in_substudy
+        )}}
     {%- else -%}
         <!-- main study completed tile -->
-        {{completed_card(assessment_status=assessment_status, OverallStatus=OverallStatus, comp_date=comp_date, title_text=_("Completed Questionnaires"))}}
+        {{completed_card(assessment_status=assessment_status, OverallStatus=OverallStatus, comp_date=comp_date, title_text=completed_title_text)}}
     {%- endif -%}
 {% endblock %}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
@@ -120,7 +120,7 @@
         {%- call render_card_content(
             title_text = _("%(substudy_title)s: View how you are doing over time", substudy_title=substudy_title),
             card_class = card_class if card_class else "portal-description-complete") -%}
-            <p><a class="longitudinal-report-link">{{_("View your longitudinal charts and discuss with your care provider")}}</a></p>
+            <p>{{_("View your longitudinal charts and discuss with your care provider")}}</p>
         {%- endcall -%}
         {{empro_thankyou_modal(user)}}
     {%- endif -%}
@@ -158,7 +158,7 @@
         <p>{{_("Here's where you'll find an ongoing summary of your responses, each time you complete a questionnaire.")}}</p>
         <div class="buttons-container">
             <!-- TODO point to longitudinal report -->
-            <a class="btn btn-empro-primary btn-report longitudinal-report-link">{{_("My Report")}}</a>
+            <a class="btn btn-empro-primary">{{_("My Report")}}</a>
         </div>
     </div>
 {%- endmacro -%}
@@ -176,7 +176,7 @@
         <h4>{{_("Your Health Tips")}}</h4>
         <p>{{_("Explore ways to manage common prostate cancer challenges. Here you'll find plenty of helpful information and resources.")}}</p>
         <div class="buttons-container">
-            <a class="btn btn-empro-primary" href="{{url_for('portal.substudy_tailored_content')}}" target="_blank">{{_("Explore Our Resources")}}</a>
+            <a class="btn btn-empro-primary" href="{{url_for('portal.substudy_tailored_content')}}">{{_("Explore Our Resources")}}</a>
         </div>
     </div>
 {%- endmacro -%}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
@@ -116,11 +116,10 @@
                 <a data-toggle="modal" data-target="#emproModal">{{_("Learn about your specific issues based on your last questionnaire submitted on %(substudy_comp_date)s", substudy_comp_date=substudy_comp_date)}}</a>
             </div>
         {%- endcall -%}
-        <!-- TODO link to longitudinal report page -->
         {%- call render_card_content(
             title_text = _("%(substudy_title)s: View how you are doing over time", substudy_title=substudy_title),
             card_class = card_class if card_class else "portal-description-complete") -%}
-            <p>{{_("View your longitudinal charts and discuss with your care provider")}}</p>
+            <p><a class="longitudinal-report-link">{{_("View your longitudinal charts and discuss with your care provider")}}</a></p>
         {%- endcall -%}
         {{empro_thankyou_modal(user)}}
     {%- endif -%}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
@@ -156,8 +156,7 @@
         <h4>{{_("Your Report")}}</h4>
         <p>{{_("Here's where you'll find an ongoing summary of your responses, each time you complete a questionnaire.")}}</p>
         <div class="buttons-container">
-            <!-- TODO point to longitudinal report -->
-            <a class="btn btn-empro-primary">{{_("My Report")}}</a>
+            <a class="btn btn-empro-primary btn-report longitudinal-report-link">{{_("My Report")}}</a>
         </div>
     </div>
 {%- endmacro -%}

--- a/portal/static/js/src/empro.js
+++ b/portal/static/js/src/empro.js
@@ -13,7 +13,7 @@ var emproObj = function() {
 emproObj.prototype.populateDomainDisplay = function() {
     this.domains.forEach(domain => {
         $("#emproModal .triggersButtonsContainer").append(
-            `<a class="btn btn-empro-primary" href="/substudy-tailored-content#/${domain}" target="_blank">${domain.replace(/_/g, " ")}</a>`
+            `<a class="btn btn-empro-primary" href="/substudy-tailored-content#/${domain}">${domain.replace(/_/g, " ")}</a>`
         );
     });
     this.hardTriggerDomains.forEach(domain => {

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -24,7 +24,7 @@
 @headlineSize:    1.60em;
 @subheadSize:     1.30em;
 @subSmallHeadSize: 1.1em;
-@lgFontSize:      1.5em;
+@lgFontSize:      1.475em;
 @lgHeadlineSize:  1.35em;
 @lgsubheadSize:   1.25em;
 @splashFontSize:  1.05em;
@@ -2823,10 +2823,20 @@ body.portal .copyright-container  {
 .portal-header-container {
   color: #FFF;
   width: 87.5%;
-  margin: 1em auto 2em auto;
+  margin: 1em auto 32px auto;
   font-size: @subheadSize;
   max-width: 100%;
   text-align: center;
+}
+@media (min-width: 768px) {
+  .portal-header-container {
+    margin: 3.5em auto 32px auto;
+  }
+}
+@media (min-width: 992px) {
+  .portal-header-container {
+    margin: 32px auto 32px auto;
+  }
 }
 .button-callout {
   position: relative;
@@ -2858,7 +2868,7 @@ body.portal .copyright-container  {
 }
 .portal-header,
 .portal-intro-text {
-  font-size: @baseFontSize;
+  font-size: @subSmallHeadSize*0.96;
   letter-spacing: 1px;
   p {
     margin: 0 0 8px;
@@ -2908,6 +2918,7 @@ body.portal .copyright-container  {
   margin: 1em auto;
   min-height: 250px;
   overflow: hidden;
+  line-height: 1.5;
   p {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -3023,7 +3034,7 @@ body.portal .copyright-container  {
 .portal-description .button-container {
   position: relative;
   margin-bottom: 0;
-  margin-top: 24px;
+  margin-top: 32px;
 }
 
 .portal-flex-container {
@@ -3061,11 +3072,13 @@ body.portal .copyright-container  {
 }
 
 .portal-skyscraper-container {
-  margin-top: 40px;
+  margin-top: 16px;
   .section-title {
     color: #FFF;
     margin-bottom: 16px;
-    font-size: @lgFontSize;
+    font-size: 20px;
+    font-weight: 400;
+    letter-spacing: 1px;
   }
   .top {
     display: flex;
@@ -3080,7 +3093,13 @@ body.portal .copyright-container  {
     flex-wrap: wrap;
   }
 }
-
+@media (min-width: 699px) {
+  .portal-skyscraper-container {
+    .section-title {
+      font-size: 1.4em;
+    }
+  }
+}
 section.header {
   margin-top: 16px;
   display: flex;


### PR DESCRIPTION
Issues found while testing  https://jira.movember.com/browse/TN-2786

Fixes include:

- Title update for **completed** PROM tiles - needing to differentiate between main and sub-study tiles, i.e. IRONMAN Questionnaire vs EMPRO Questionnaire
- Display completed EMPRO tiles where possible, e.g. main study has pending work, but subject could have completed EMPRO Questionnaire
- minor styling updates per specs
- link to sub-study tailored content page should open in the same browser tab
