### PR TITLE
Allow sending substudy welcome email from patient profile page

### DIFF
--- a/portal/config/eproms/AppText.json
+++ b/portal/config/eproms/AppText.json
@@ -152,7 +152,7 @@
     },
     {
       "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=01fbb874-b7cb-21b5-625c-8221e10cec6b",
-      "name": "patient welcome email IRONMAN EMPRO Study",
+      "name": "patient invite email IRONMAN EMPRO Study",
       "resourceType": "AppText"
     },
     {

--- a/portal/config/eproms/AppText.json
+++ b/portal/config/eproms/AppText.json
@@ -151,6 +151,11 @@
       "resourceType": "AppText"
     },
     {
+      "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=01fbb874-b7cb-21b5-625c-8221e10cec6b",
+      "name": "patient welcome email IRONMAN EMPRO Study",
+      "resourceType": "AppText"
+    },
+    {
       "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=605ac1fe-8217-55c8-f5b6-8db73b8959ea",
       "name": "patient reminder email TrueNTH Global Registry",
       "resourceType": "AppText"

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -280,16 +280,12 @@ class UserReminderEmail_ATMA(AppTextModelAdapter):
     @staticmethod
     def name_key(**kwargs):
         """Generate AppText name key for User Reminder Email Content
-
         Some organizations supply customized content - which is indexed
         by adding the org name to the end of the app_text pattern
         `patient reminder email`
-
         :param org: Typically top level org name - used to look for
         customized content.
-
         :returns: string for AppText.name field
-
         """
         default = "patient reminder email"
         # See if content is available with the given org as the suffix
@@ -299,6 +295,38 @@ class UserReminderEmail_ATMA(AppTextModelAdapter):
             if query.count() == 1:
                 return specialized
         return default
+
+
+class UserWelcomeEmail_ATMA(AppTextModelAdapter):
+    """AppTextModelAdapter for User Welcome Email Content for a research study"""
+    @staticmethod
+    def name_key(**kwargs):
+        """Generate AppText name key for Welcome Email Content
+
+        Some organizations supply customized content - which is indexed
+        by adding the research study name to the end of the app_text pattern
+        `patient welcome email`
+
+        :param research_study: name of the research study - used to look for
+        customized content.
+
+        :returns: string for AppText.name field
+
+        """
+       
+        default = "patient welcome email"
+        research_study = kwargs.get('research_study')
+
+        # See if content is available with the given research study title as the suffix
+        if research_study:
+            specialized = " ".join((default, research_study))
+            print("specialized name {}".format(specialized))
+            query = AppText.query.filter_by(name=specialized)
+            if query.count() == 1:
+                return specialized
+    
+        return default
+
 
 
 class SiteSummaryEmail_ATMA(AppTextModelAdapter):

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -280,12 +280,16 @@ class UserReminderEmail_ATMA(AppTextModelAdapter):
     @staticmethod
     def name_key(**kwargs):
         """Generate AppText name key for User Reminder Email Content
+
         Some organizations supply customized content - which is indexed
         by adding the org name to the end of the app_text pattern
         `patient reminder email`
+
         :param org: Typically top level org name - used to look for
         customized content.
+
         :returns: string for AppText.name field
+        
         """
         default = "patient reminder email"
         # See if content is available with the given org as the suffix

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -254,17 +254,30 @@ class UserInviteEmail_ATMA(AppTextModelAdapter):
     def name_key(**kwargs):
         """Generate AppText name key for User Invite Email Content
 
-        Some organizations supply customized content - which is indexed
-        by adding the org name to the end of the app_text pattern
+        Some organizations and research studies supply customized content,
+        which is indexed by adding the org or study name to the end of the
+        app_text pattern.
         `patient invite email`
 
         :param org: Typically top level org name - used to look for
-        customized content.
+         customized content.
+        :param research_study_id: Optionally included for studies with
+         tailored content.  If provided, the study is consulted FIRST.
 
         :returns: string for AppText.name field
 
         """
+        from .research_study import ResearchStudy
         default = "patient invite email"
+        # First try the study (if provided)
+        if kwargs.get('research_study_id'):
+            study_title = ResearchStudy.query.get(
+                kwargs.get('research_study_id')).title
+            specialized = " ".join((default, study_title))
+            query = AppText.query.filter_by(name=specialized)
+            if query.count() == 1:
+                return specialized
+
         # See if content is available with the given org as the suffix
         if kwargs.get('org'):
             specialized = " ".join((default, kwargs.get('org')))
@@ -299,39 +312,6 @@ class UserReminderEmail_ATMA(AppTextModelAdapter):
             if query.count() == 1:
                 return specialized
         return default
-
-
-class UserWelcomeEmail_ATMA(AppTextModelAdapter):
-    """AppTextModelAdapter for User Welcome Email Content"""
-    @staticmethod
-    def name_key(**kwargs):
-        """Generate AppText name key for Welcome Email Content
-
-        Some organizations supply customized content - which is indexed
-        by adding the research study name to the end of the app_text pattern
-        `patient welcome email`
-
-        :param research_study: name of the research study - used to look for
-        customized content.
-
-        :returns: string for AppText.name field
-
-        """
-
-        default = "patient welcome email"
-        research_study = kwargs.get('research_study')
-
-        # See if content is available with the given research study title
-        # as the suffix
-        if research_study:
-            specialized = " ".join((default, research_study))
-            print("specialized name {}".format(specialized))
-            query = AppText.query.filter_by(name=specialized)
-            if query.count() == 1:
-                return specialized
-        
-        return default
-
 
 
 class SiteSummaryEmail_ATMA(AppTextModelAdapter):

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -329,7 +329,7 @@ class UserWelcomeEmail_ATMA(AppTextModelAdapter):
             query = AppText.query.filter_by(name=specialized)
             if query.count() == 1:
                 return specialized
-                
+        
         return default
 
 

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -289,7 +289,7 @@ class UserReminderEmail_ATMA(AppTextModelAdapter):
         customized content.
 
         :returns: string for AppText.name field
-        
+
         """
         default = "patient reminder email"
         # See if content is available with the given org as the suffix
@@ -302,7 +302,7 @@ class UserReminderEmail_ATMA(AppTextModelAdapter):
 
 
 class UserWelcomeEmail_ATMA(AppTextModelAdapter):
-    """AppTextModelAdapter for User Welcome Email Content for a research study"""
+    """AppTextModelAdapter for User Welcome Email Content"""
     @staticmethod
     def name_key(**kwargs):
         """Generate AppText name key for Welcome Email Content
@@ -317,18 +317,19 @@ class UserWelcomeEmail_ATMA(AppTextModelAdapter):
         :returns: string for AppText.name field
 
         """
-       
+
         default = "patient welcome email"
         research_study = kwargs.get('research_study')
 
-        # See if content is available with the given research study title as the suffix
+        # See if content is available with the given research study title
+        # as the suffix
         if research_study:
             specialized = " ".join((default, research_study))
             print("specialized name {}".format(specialized))
             query = AppText.query.filter_by(name=specialized)
             if query.count() == 1:
                 return specialized
-    
+                
         return default
 
 

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -94,12 +94,14 @@ export default { /*global $ */
         this.reportError(userId ? userId : "Not available", url, errorMessage, true);
     },
     "reportError": function(userId, page_url, message, sync) {
+        let MAX_MESSAGE_LENGTH = 1900;
         //params need to contain the following: subject_id: User on which action is being attempted message: Details of the error event page_url: The page requested resulting in the error
         var params = {};
         page_url = page_url || window.location.href;
         params.subject_id = userId || 0;
         params.page_url = page_url;
         params.message = "Error generated in JS - " + (message ? message.replace(/["']/g, "") : "no detail available"); //don't think we want to translate message sent back to the server here
+        params.message = params.message.substring(0, MAX_MESSAGE_LENGTH)
         console.log("Errors occurred....."); /*eslint no-console: off */
         console.log(params); /*global console*/
         $.ajax({
@@ -320,7 +322,9 @@ export default { /*global $ */
             callback({error: i18next.t("User id is required.")});
             return false;
         }
-        this.sendRequest(`/api/user/${userId}/triggers`, "GET", userId, params, function(data) {
+        //substudy_test_triggers_new
+        this.sendRequest(`/static/files/substudy_test_triggers_new.json`, "GET", userId, params, function(data) {
+        //this.sendRequest(`/api/user/${userId}/triggers`, "GET", userId, params, function(data) {
             if (data) {
                 if (!data.error) {
                     callback(data);

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -322,8 +322,6 @@ export default { /*global $ */
             callback({error: i18next.t("User id is required.")});
             return false;
         }
-        //substudy_test_triggers_new
-        //this.sendRequest(`/static/files/substudy_test_triggers_new.json`, "GET", userId, params, function(data) {
         this.sendRequest(`/api/user/${userId}/triggers`, "GET", userId, params, function(data) {
             if (data) {
                 if (!data.error) {

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -323,8 +323,8 @@ export default { /*global $ */
             return false;
         }
         //substudy_test_triggers_new
-        this.sendRequest(`/static/files/substudy_test_triggers_new.json`, "GET", userId, params, function(data) {
-        //this.sendRequest(`/api/user/${userId}/triggers`, "GET", userId, params, function(data) {
+        //this.sendRequest(`/static/files/substudy_test_triggers_new.json`, "GET", userId, params, function(data) {
+        this.sendRequest(`/api/user/${userId}/triggers`, "GET", userId, params, function(data) {
             if (data) {
                 if (!data.error) {
                     callback(data);

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -219,6 +219,17 @@ export default (function() {
                 get: function() {
                     return this.manualEntry.message;
                 }
+            },
+            computedIsSubStudyPatient: function() {
+                //will re-compute when the dependent prop, this.subjectReseachStudies, updates
+                return this.subjectReseachStudies.indexOf(EPROMS_SUBSTUDY_ID) !== -1;
+            },
+            computedUserEmail: function() {
+                //will re-compute when email updates
+                return this.demo.data.email;
+            },
+            computedTreatingClinician: function() {
+                return this.demo.data.clinician && Object.keys(this.demo.data.clinician).length;
             }
         },
         methods: {
@@ -303,7 +314,7 @@ export default (function() {
                 });
             },
             userHasNoEmail: function() {
-                return !this.demo.data.email;
+                return !this.computedUserEmail;
             },
             isUserEmailReady: function() {
                 return this.userEmailReady;
@@ -573,7 +584,7 @@ export default (function() {
                 }).length;
             },
             isSubStudyPatient: function() {
-                return this.subjectReseachStudies.indexOf(EPROMS_SUBSTUDY_ID) !== -1;
+                return this.computedIsSubStudyPatient;
             },
             isStaffAdmin: function() {
                 return this.currentUserRoles.indexOf("staff_admin") !== -1;
@@ -1119,6 +1130,9 @@ export default (function() {
                     self.updateIdentifierData(this);
                 });
             },
+            hasTreatingClinician: function() {
+                return this.computedTreatingClinician;
+            },
             initTreatingClinicianSection: function() {
                 let self = this;
                 this.modules.tnthAjax.getCliniciansList(this.subjectOrgs, function(data) {
@@ -1299,6 +1313,10 @@ export default (function() {
                 $("#profileEmailLogTable a.item-link").on("click", function() {
                     self.getEmailContent($(this).attr("data-user-id"), $(this).attr("data-item-id"));
                 });
+            },
+            allowSubStudyWelcomeEmail: function() {
+                //TODO check to see if sub-study questionnaire is DUE?
+                return this.isSubStudyPatient() && !this.userHasNoEmail() && this.hasTreatingClinician();
             },
             initPatientEmailFormSection: function() {
                 var self = this;
@@ -2527,6 +2545,7 @@ export default (function() {
                     setTimeout(function() { // Set a one second delay before getting updated list. Mostly to give user sense of progress/make it
                         self.modules.tnthAjax.getConsent(userId || self.subjectId, {sync: true}, function(data) {
                             self.getConsentList(data);
+                            self.setSubjectResearchStudies();
                         });
                     }, 1500);
                 });

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1078,7 +1078,8 @@ export default (function() {
                     e.stopPropagation();
                     $("#erroremail").html("");
                 });
-                $("#profileForm").on("postEventUpdate", "#email", function(e) {
+            
+                $("#profileForm").on("change, postEventUpdate", "#email", function(e) {
                     if (self.updateEmailVis()) { //should only update email if there is no validation error
                         self.postDemoData($(this), self.getTelecomData());
                     }

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1316,7 +1316,11 @@ export default (function() {
                 });
             },
             allowSubStudyWelcomeEmail: function() {
-                //TODO check to see if sub-study questionnaire is DUE?
+                /*
+                 *  to allow option for sub-study welcome email in the dropdown
+                 *  the subject needs to have consented to the sub-study, have a valid email and an
+                 *  assigned treating clinician
+                 */
                 return this.isSubStudyPatient() && !this.userHasNoEmail() && this.hasTreatingClinician();
             },
             initPatientEmailFormSection: function() {

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -3012,8 +3012,8 @@ body.portal .copyright-container  {
   flex-direction: column;
   .text-content {
     flex: 1;
-    padding-left: 16px;
-    padding-right: 16px;
+    padding-left: 8px;
+    padding-right: 8px;
   }
 }
 .portal-flex-container .button-container,
@@ -3072,7 +3072,7 @@ body.portal .copyright-container  {
 }
 
 .portal-skyscraper-container {
-  margin-top: 16px;
+  margin-top: 24px;
   .section-title {
     color: #FFF;
     margin-bottom: 16px;
@@ -3109,6 +3109,8 @@ section.header {
   border-bottom: 1px solid @muterColor;
   .header__div--title {
     margin-right: 16px;
+    width: 60%;
+    max-width: 100%;
   }
   .icon {
     padding: 12px;
@@ -3200,7 +3202,7 @@ section.header {
     border-radius: 20px;
     background: @muterColor;
     display: inline-block;
-    padding: 8px 12px;
+    padding: 8px 16px;
     min-width: 132px;
     text-align: center;
     &.darker {

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -1203,7 +1203,7 @@ select:not([multiple]) {
     }
   }
   .detail-title {
-    margin-bottom: 0.25em;
+    margin-bottom: 16px;
   }
  .detail-title {
     color: #ebefeb;

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -3702,7 +3702,7 @@ section.header {
   top: 0;
   left: 0;
   background: @profileItemBgColor;
-  min-height: 4em;
+  min-height: 80px;
   width: 100%;
 }
 #profileEmailMessage {

--- a/portal/templates/profile/patient_profile.html
+++ b/portal/templates/profile/patient_profile.html
@@ -18,7 +18,7 @@
 {% endblock %}
 {% block profile_content %}
   {% if config.CUSTOM_PATIENT_DETAIL and current_user and current_user.has_role(ROLE.STAFF.value, ROLE.STAFF_ADMIN.value) -%}
-    {{ profile_macro.profileCustomDetail(user) }}
+    {{ profile_macro.profileCustomDetail(person=user, substudy_assessment_is_ready=substudy_assessment_is_ready) }}
     <div class="row">
       <div class="col-md-12 col-xs-12">
         <h4 class="profile-item-title detail-title">{{_("Patient Details")}}</h4>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -313,7 +313,7 @@
         {{emailReadyMessage()}}
     </div>
 {%- endmacro %}
-{% macro profileSendEmail(person) -%}
+{% macro profileSendEmail(person, substudy_assessment_is_ready=false) -%}
     {%- if person -%}
         <div class="email-form-container">
             {% call profileEmailForm(person) %}
@@ -321,8 +321,10 @@
                     <option value="invite" data-url="{{url_for('portal.patient_invite_email', user_id=person.id)}}">{{_("TrueNTH Invite")}}</option>
                 {%endif %}
                 <option value="reminder" data-url="{{url_for('portal.patient_reminder_email', user_id=person.id)}}">{{_("TrueNTH Reminder")}}</option>
-                <!-- reactive option, will only show when user is in sub-study and email is available -->
-                <option value="welcome" data-url="{{url_for('portal.patient_invite_email', user_id=person.id, research_study_id=1)}}"  :hidden="!allowSubStudyWelcomeEmail()" :disabled="!allowSubStudyWelcomeEmail()">{{_("TrueNTH Sub-Study Welcome")}}</option>
+                {% if substudy_assessment_is_ready %}
+                    <!-- reactive option, will only show when user is in sub-study and email is available -->
+                    <option value="welcome" data-url="{{url_for('portal.patient_invite_email', user_id=person.id, research_study_id=1)}}"  :hidden="!allowSubStudyWelcomeEmail()" :disabled="!allowSubStudyWelcomeEmail()">{{_("TrueNTH Sub-Study Welcome")}}</option>
+                {% endif %}
             {% endcall %}
             <!--
                 set P3P invite/reminder tile visibility based on whether user's org matches config variable, ACCEPT_TERMS_ON_NEXT_ORG - this is the case of MUSIC patient
@@ -1057,7 +1059,7 @@
         <div id="errorprofileSiteId" class="error-message"></div>
     </div>
 {%- endmacro %}
-{% macro profileCustomDetail(person) -%}
+{% macro profileCustomDetail(person, substudy_assessment_is_ready=false) -%}
      <div class="row" data-profile-section-id="custompatientdetail">
         <div class="col-md-12 col-xs-12">
             <h4 class="profile-item-title detail-title">{{_("Three ways to complete questionnaire")}}</h4>
@@ -1067,7 +1069,7 @@
                     <h4 id="customSendEmailLoc" class="profile-item-title index-item">{{_("Send email")}}</h4>
                     <br/>
                     <div class="text-muted custom-container-content">{{_("Invite or remind patient over email to complete their questionnaire")}}</div>
-                    <div>{{profileSendEmail(person)}}</div>
+                    <div>{{profileSendEmail(person, substudy_assessment_is_ready)}}</div>
                 </div>
                 <div class="profile-item-container custom-container-item-right">
                     <h4 id="customLoginAsLoc" class="profile-item-title index-item">{{_("Log in as patient")}}</h4>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -321,6 +321,8 @@
                     <option value="invite" data-url="{{url_for('portal.patient_invite_email', user_id=person.id)}}">{{_("TrueNTH Invite")}}</option>
                 {%endif %}
                 <option value="reminder" data-url="{{url_for('portal.patient_reminder_email', user_id=person.id)}}">{{_("TrueNTH Reminder")}}</option>
+                <!-- reactive option, will only show when user is in sub-study and email is available -->
+                <option value="welcome" data-url="{{url_for('portal.patient_welcome_email', user_id=person.id, research_study_id=1)}}" v-show="allowSubStudyWelcomeEmail()">{{_("TrueNTH Sub-Study Welcome")}}</option>
             {% endcall %}
             <!--
                 set P3P invite/reminder tile visibility based on whether user's org matches config variable, ACCEPT_TERMS_ON_NEXT_ORG - this is the case of MUSIC patient

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -322,7 +322,7 @@
                 {%endif %}
                 <option value="reminder" data-url="{{url_for('portal.patient_reminder_email', user_id=person.id)}}">{{_("TrueNTH Reminder")}}</option>
                 <!-- reactive option, will only show when user is in sub-study and email is available -->
-                <option value="welcome" data-url="{{url_for('portal.patient_invite_email', user_id=person.id, research_study_id=1)}}" v-show="allowSubStudyWelcomeEmail()" :disabled="!allowSubStudyWelcomeEmail()">{{_("TrueNTH Sub-Study Welcome")}}</option>
+                <option value="welcome" data-url="{{url_for('portal.patient_invite_email', user_id=person.id, research_study_id=1)}}"  :hidden="!allowSubStudyWelcomeEmail()" :disabled="!allowSubStudyWelcomeEmail()">{{_("TrueNTH Sub-Study Welcome")}}</option>
             {% endcall %}
             <!--
                 set P3P invite/reminder tile visibility based on whether user's org matches config variable, ACCEPT_TERMS_ON_NEXT_ORG - this is the case of MUSIC patient

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -322,7 +322,7 @@
                 {%endif %}
                 <option value="reminder" data-url="{{url_for('portal.patient_reminder_email', user_id=person.id)}}">{{_("TrueNTH Reminder")}}</option>
                 <!-- reactive option, will only show when user is in sub-study and email is available -->
-                <option value="welcome" data-url="{{url_for('portal.patient_welcome_email', user_id=person.id, research_study_id=1)}}" v-show="allowSubStudyWelcomeEmail()">{{_("TrueNTH Sub-Study Welcome")}}</option>
+                <option value="welcome" data-url="{{url_for('portal.patient_invite_email', user_id=person.id, research_study_id=1)}}" v-show="allowSubStudyWelcomeEmail()">{{_("TrueNTH Sub-Study Welcome")}}</option>
             {% endcall %}
             <!--
                 set P3P invite/reminder tile visibility based on whether user's org matches config variable, ACCEPT_TERMS_ON_NEXT_ORG - this is the case of MUSIC patient

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -322,7 +322,7 @@
                 {%endif %}
                 <option value="reminder" data-url="{{url_for('portal.patient_reminder_email', user_id=person.id)}}">{{_("TrueNTH Reminder")}}</option>
                 <!-- reactive option, will only show when user is in sub-study and email is available -->
-                <option value="welcome" data-url="{{url_for('portal.patient_invite_email', user_id=person.id, research_study_id=1)}}" v-show="allowSubStudyWelcomeEmail()">{{_("TrueNTH Sub-Study Welcome")}}</option>
+                <option value="welcome" data-url="{{url_for('portal.patient_invite_email', user_id=person.id, research_study_id=1)}}" v-show="allowSubStudyWelcomeEmail()" :disabled="!allowSubStudyWelcomeEmail()">{{_("TrueNTH Sub-Study Welcome")}}</option>
             {% endcall %}
             <!--
                 set P3P invite/reminder tile visibility based on whether user's org matches config variable, ACCEPT_TERMS_ON_NEXT_ORG - this is the case of MUSIC patient

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -191,7 +191,7 @@ def patient_profile(patient_id):
 
     from ..models.qb_status import QB_Status, patient_research_study_status
     from ..models.research_study import EMPRO_RS_ID, ResearchStudy
-    
+
     user = current_user()
     patient = get_user(patient_id, 'edit')
     consent_agreements = Organization.consent_agreements(

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -189,7 +189,7 @@ def longitudinal_report(subject_id, instrument_id):
 def patient_profile(patient_id):
     """individual patient view function, intended for staff"""
 
-    from ..models.qb_status import QB_Status, patient_research_study_status
+    from ..models.qb_status import patient_research_study_status
     from ..models.research_study import EMPRO_RS_ID, ResearchStudy
 
     user = current_user()

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -188,6 +188,10 @@ def longitudinal_report(subject_id, instrument_id):
 @oauth.require_oauth()
 def patient_profile(patient_id):
     """individual patient view function, intended for staff"""
+
+    from ..models.qb_status import QB_Status, patient_research_study_status
+    from ..models.research_study import EMPRO_RS_ID, ResearchStudy
+    
     user = current_user()
     patient = get_user(patient_id, 'edit')
     consent_agreements = Organization.consent_agreements(
@@ -202,10 +206,17 @@ def patient_profile(patient_id):
                 display.link_label is not None):
             user_interventions.append({"name": intervention.name})
 
+    enrolled_in_substudy = EMPRO_RS_ID \
+        in ResearchStudy.assigned_to(patient)
+    research_study_status = patient_research_study_status(patient)
+    substudy_assessment_is_ready = enrolled_in_substudy \
+        and research_study_status[EMPRO_RS_ID]['ready']
+
     return render_template(
         'profile/patient_profile.html', user=patient,
         current_user=user,
         consent_agreements=consent_agreements,
+        substudy_assessment_is_ready=substudy_assessment_is_ready,
         user_interventions=user_interventions)
 
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -52,7 +52,6 @@ from ..models.app_text import (
     UndefinedAppText,
     UserInviteEmail_ATMA,
     UserReminderEmail_ATMA,
-    UserWelcomeEmail_ATMA,
     VersionedResource,
     app_text,
     get_terms,
@@ -708,19 +707,25 @@ def profile(user_id):
                            consent_agreements=consent_agreements)
 
 
-@portal.route('/patient-invite-email/<int:user_id>')
+@portal.route(
+    '/patient-invite-email/<int:user_id>', defaults={'research_study_id': 0})
+@portal.route('/patient-invite-email/<int:user_id>/<int:research_study_id>')
 @roles_required([ROLE.ADMIN.value, ROLE.STAFF_ADMIN.value, ROLE.STAFF.value])
 @oauth.require_oauth()
-def patient_invite_email(user_id):
+def patient_invite_email(user_id, research_study_id):
     """Patient Invite Email Content"""
     user = get_user(user_id, 'edit')
 
     try:
         top_org = user.first_top_organization()
         if top_org:
-            name_key = UserInviteEmail_ATMA.name_key(org=top_org.name)
+            name_key = UserInviteEmail_ATMA.name_key(
+                org=top_org.name,
+                research_study_id=research_study_id)
         else:
-            name_key = UserInviteEmail_ATMA.name_key()
+            name_key = UserInviteEmail_ATMA.name_key(
+                research_study_id=research_study_id
+            )
         args = load_template_args(user=user)
         item = MailResource(
             app_text(name_key), locale_code=user.locale_code, variables=args)
@@ -741,6 +746,7 @@ def patient_reminder_email(user_id):
     :param research_study_id: set for targeted reminder emails, defaults to 0
 
     """
+    from ..models.qb_status import QB_Status
     user = get_user(user_id, 'edit')
     research_study_id = int(request.args.get('research_study_id', 0))
     try:
@@ -751,60 +757,27 @@ def patient_reminder_email(user_id):
             name_key = UserReminderEmail_ATMA.name_key(org=top_org.name)
         else:
             name_key = UserReminderEmail_ATMA.name_key()
-        item = mailResource_by_name_key(name_key, user, research_study_id)
-    except UndefinedAppText:
-        """return no content and 204 no content status"""
-        return '', 204
 
-    return jsonify(subject=item.subject, body=item.body)
-
-
-@portal.route('/patient-welcome-email/<int:user_id>')
-@roles_required([ROLE.ADMIN.value, ROLE.STAFF_ADMIN.value, ROLE.STAFF.value])
-@oauth.require_oauth()
-def patient_welcome_email(user_id):
-    """Patient Welcome Email Content for a Research Study
-
-    Query string
-    :param research_study_id: set for targeted welcome email, defaults to 0
-
-    """
-    from ..models.research_study import ResearchStudy
-    user = get_user(user_id, 'edit')
-    research_study_id = int(request.args.get('research_study_id', 0))
-    research_study_title = ResearchStudy.query.get(
-        research_study_id).as_fhir()['title']
-    try:
-        if research_study_title:
-            name_key = UserWelcomeEmail_ATMA.name_key(
-                research_study=research_study_title)
+        # If the user has a pending questionnaire bank, include for due date
+        qstats = QB_Status(
+            user,
+            research_study_id=research_study_id,
+            as_of_date=datetime.utcnow())
+        qbd = qstats.current_qbd()
+        if qbd:
+            qb_id, qb_iteration = qbd.qb_id, qbd.iteration
         else:
-            name_key = UserWelcomeEmail_ATMA.name_key()
-        item = mailResource_by_name_key(name_key, user, research_study_id)
+            qb_id, qb_iteration = None, None
+
+        args = load_template_args(
+            user=user, questionnaire_bank_id=qb_id, qb_iteration=qb_iteration)
+        item = MailResource(
+            app_text(name_key), locale_code=user.locale_code, variables=args)
     except UndefinedAppText:
         """return no content and 204 no content status"""
         return '', 204
 
     return jsonify(subject=item.subject, body=item.body)
-
-
-def mailResource_by_name_key(name_key, user, research_study_id=0):
-    from ..models.qb_status import QB_Status
-    # If the user has a pending questionnaire bank, include for due date
-    qstats = QB_Status(
-        user,
-        research_study_id=research_study_id,
-        as_of_date=datetime.utcnow())
-    qbd = qstats.current_qbd()
-    if qbd:
-        qb_id, qb_iteration = qbd.qb_id, qbd.iteration
-    else:
-        qb_id, qb_iteration = None, None
-
-    args = load_template_args(
-        user=user, questionnaire_bank_id=qb_id, qb_iteration=qb_iteration)
-    return MailResource(
-        app_text(name_key), locale_code=user.locale_code, variables=args)
 
 
 @portal.route('/share-your-story')

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -772,7 +772,8 @@ def patient_welcome_email(user_id):
     from ..models.research_study import ResearchStudy
     user = get_user(user_id, 'edit')
     research_study_id = int(request.args.get('research_study_id', 0))
-    research_study_title = ResearchStudy.query.get(research_study_id).as_fhir()['title']
+    research_study_title = ResearchStudy.query.get(
+        research_study_id).as_fhir()['title']
     try:
         if research_study_title:
             name_key = UserWelcomeEmail_ATMA.name_key(
@@ -789,7 +790,7 @@ def patient_welcome_email(user_id):
 
 def mailResource_by_name_key(name_key, user, research_study_id=0):
     from ..models.qb_status import QB_Status
-     # If the user has a pending questionnaire bank, include for due date
+    # If the user has a pending questionnaire bank, include for due date
     qstats = QB_Status(
         user,
         research_study_id=research_study_id,

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -736,8 +736,10 @@ def patient_invite_email(user_id):
 @oauth.require_oauth()
 def patient_reminder_email(user_id):
     """Patient Reminder Email Content
+
     Query string
     :param research_study_id: set for targeted reminder emails, defaults to 0
+
     """
     user = get_user(user_id, 'edit')
     research_study_id = int(request.args.get('research_study_id', 0))
@@ -762,8 +764,10 @@ def patient_reminder_email(user_id):
 @oauth.require_oauth()
 def patient_welcome_email(user_id):
     """Patient Welcome Email Content for a Research Study
+
     Query string
     :param research_study_id: set for targeted welcome email, defaults to 0
+
     """
     from ..models.research_study import ResearchStudy
     user = get_user(user_id, 'edit')
@@ -800,7 +804,6 @@ def mailResource_by_name_key(name_key, user, research_study_id=0):
         user=user, questionnaire_bank_id=qb_id, qb_iteration=qb_iteration)
     return MailResource(
         app_text(name_key), locale_code=user.locale_code, variables=args)
-
 
 
 @portal.route('/share-your-story')


### PR DESCRIPTION
Address https://jira.movember.com/browse/TN-2711
Changes include:

- Adding sub-study welcome email option to select dropdown list
- Allow sub-study welcome email option to be available only if there is a valid user email and user has an assigned treating clinician as per specs
- Present sub-study welcome email option only when sub-study assessment is ready.

Note, pending: clean-up of the sub-study welcome email content in LR. 