### PR TITLE
remove date range restriction for consent datepicker

### DIFF
--- a/portal/static/js/src/modules/Consent.js
+++ b/portal/static/js/src/modules/Consent.js
@@ -179,7 +179,7 @@ export default { /*global i18next datepicker $*/
         $("#consentDateModal").on("hidden.bs.modal", function() {
             $(this).removeClass("active");
         });
-        $("#consentDateModal .consent-date").datepicker({"format": "d M yyyy","forceParse": false,"endDate": new Date(),"autoclose": true});
+        $("#consentDateModal .consent-date").datepicker({"format": "d M yyyy","forceParse": false, "autoclose": true});
         $("#consentDateModal .consent-hour, #consentDateModal .consent-minute, #consentDateModal .consent-second").each(function() {
             Utility.convertToNumericField($(this));
         });


### PR DESCRIPTION
Remove date range constraint on the allowable dates to be selected from date picker for consent date.
Note again: datepicker for consent date is only available in the test environment