### PR TITLE
substudy thank you modal - presents it upon user's completion of sub-study assessment

### DIFF
--- a/portal/static/js/src/empro.js
+++ b/portal/static/js/src/empro.js
@@ -1,6 +1,7 @@
 import EMPRO_DOMAIN_MAPPINGS from "./data/common/empro_domain_mappings.json";
 import {SUBSTUDY_QUESTIONNAIRE_IDENTIFIER} from "./data/common/consts.js";
 import tnthAjax from "./modules/TnthAjax.js";
+import tnthDate from "./modules/TnthDate.js";
 
 var emproObj = function() {
     this.domains = [];
@@ -22,12 +23,12 @@ emproObj.prototype.populateDomainDisplay = function() {
         $("#emproModal .hardTriggersDisplayList").append(`<li>${domain.replace(/_/g, " ")}</li>`);
     });
 };
-emproObj.prototype.initThankyouModal = function() {
+emproObj.prototype.initThankyouModal = function(autoShow) {
     if (!$("#emproModal").length) {
         return;
     }
     $("#emproModal").modal({
-        show: false
+        show: autoShow
     });
 };
 emproObj.prototype.initReportLink = function() {
@@ -63,55 +64,87 @@ emproObj.prototype.initTriggerDomains = function() {
         * construct user report URL
         */
         this.initReportLink();
-        tnthAjax.getSubStudyTriggers(this.userId, false, function(data) {
-            if (!data || !data.triggers || !data.triggers.domain) {
-                return false;
+        tnthAjax.assessmentReport(this.userId, SUBSTUDY_QUESTIONNAIRE_IDENTIFIER, (data) => {
+            if (!data || !data.entry || !data.entry.length) {
+               this.initThankyouModal();
+               return;
             }
-            for (let key in data.triggers.domain) {
-                if (!Object.keys(data.triggers.domain[key]).length) {
-                    continue;
-                }
-                let mappedDomain = EMPRO_DOMAIN_MAPPINGS[key];
+            let [today, authoredDate, status] = [
+                tnthDate.getDateWithTimeZone(new Date(), "yyyy-mm-dd"),
+                tnthDate.getDateWithTimeZone(new Date(data.entry[0]["authored"]), "yyyy-mm-dd"),
+                data.entry[0].status];
+            let cachedAccessKey = `EMPRO_MODAL_ACCESSED_${this.userId}_${today}`;
+            let assessmentCompleted = String(status).toLowerCase() === "completed";
+            /*
+             * automatically pops up thank you modal IF sub-study assessment is completed,
+             * and sub-study assessment is completed today and the thank you modal has not already popped up today
+             */
+            let autoShowModal = !localStorage.getItem(cachedAccessKey) && 
+                                assessmentCompleted && 
+                                today === authoredDate;
+            this.initThankyouModal(autoShowModal);
+            if (autoShowModal) {
                 /*
-                 * get all user domains that have related triggers
+                 * set thank you modal accessed flag here
                  */
-                if (self.domains.indexOf(mappedDomain) === -1) {
-                    self.domains.push(mappedDomain);
-                }
-                for (let q in data.triggers.domain[key]) {
-                    if (data.triggers.domain[key][q] === "hard") {
-                        self.hasHardTrigger = true;
-                        /*
-                         * get all domain topics that have hard trigger
-                         */
-                        if (self.hardTriggerDomains.indexOf(mappedDomain) === -1) {
-                            self.hardTriggerDomains.push(mappedDomain);
-                        }
-                    }
-                    if (data.triggers.domain[key][q] === "soft") {
-                        self.hasSoftTrigger = true;
-                         /*
-                         * get all domain topics that have soft trigger
-                         */
-                        if (self.softTriggerDomains.indexOf(mappedDomain) === -1) {
-                            self.softTriggerDomains.push(mappedDomain);
-                        }
-                    }
-                }
+                localStorage.setItem(cachedAccessKey, `true`);
             }
-
             /*
-             * display user domain topic(s)
+             * don't continue on to invoke trigger API if sub-study assessment is not completed
              */
-            self.populateDomainDisplay();
-            /*
-             * show/hide sections based on triggers
-             */
-            self.initTriggerItemsVis();
-
-           //console.log("self.domains? ", self.domains);
-           //console.log("has hard triggers ", self.hasHardTrigger);
-           //console.log("has soft triggers ", self.hasSoftTrigger);
+            if (!assessmentCompleted) {
+                return;
+            }
+            tnthAjax.getSubStudyTriggers(this.userId, false, function(data) {
+                if (!data || !data.triggers || !data.triggers.domain) {
+                    return false;
+                }
+                for (let key in data.triggers.domain) {
+                    if (!Object.keys(data.triggers.domain[key]).length) {
+                        continue;
+                    }
+                    let mappedDomain = EMPRO_DOMAIN_MAPPINGS[key];
+                    /*
+                     * get all user domains that have related triggers
+                     */
+                    if (self.domains.indexOf(mappedDomain) === -1) {
+                        self.domains.push(mappedDomain);
+                    }
+                    for (let q in data.triggers.domain[key]) {
+                        if (data.triggers.domain[key][q] === "hard") {
+                            self.hasHardTrigger = true;
+                            /*
+                             * get all domain topics that have hard trigger
+                             */
+                            if (self.hardTriggerDomains.indexOf(mappedDomain) === -1) {
+                                self.hardTriggerDomains.push(mappedDomain);
+                            }
+                        }
+                        if (data.triggers.domain[key][q] === "soft") {
+                            self.hasSoftTrigger = true;
+                             /*
+                             * get all domain topics that have soft trigger
+                             */
+                            if (self.softTriggerDomains.indexOf(mappedDomain) === -1) {
+                                self.softTriggerDomains.push(mappedDomain);
+                            }
+                        }
+                    }
+                }
+    
+                /*
+                 * display user domain topic(s)
+                 */
+                self.populateDomainDisplay();
+                /*
+                 * show/hide sections based on triggers
+                 */
+                self.initTriggerItemsVis();
+    
+               //console.log("self.domains? ", self.domains);
+               //console.log("has hard triggers ", self.hasHardTrigger);
+               //console.log("has soft triggers ", self.hasSoftTrigger);
+            });
         });
     });
 }
@@ -119,5 +152,4 @@ emproObj.prototype.initTriggerDomains = function() {
 $(document).ready(function() {
     let EmproObj = new emproObj();
     EmproObj.initTriggerDomains();
-    EmproObj.initThankyouModal();
 });

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -2818,6 +2818,7 @@ body.portal .copyright-container  {
   justify-content: center;
 }
 .portal-item {
+  width: 100%;
   max-width: 100%;
 }
 .portal-header-container {
@@ -2904,6 +2905,8 @@ body.portal .copyright-container  {
 .portal-flex-container {
   display: flex;
   justify-content: center;
+  align-items: center;
+  flex-direction: column;
   flex-wrap: wrap;
   position: relative;
   padding-bottom: 1em;
@@ -2914,8 +2917,7 @@ body.portal .copyright-container  {
   color: #FFF;
   padding: 0.5em 1.75em 2.5em;
   position: relative;
-  width: 440px;
-  min-width: 420px;
+  width: 420px;
   max-width: 100%;
   margin: 1em auto;
   min-height: 250px;
@@ -2979,7 +2981,7 @@ body.portal .copyright-container  {
 @media (min-width: 992px) {
   .portal-description {
     margin: 1em;
-    width: 40%;
+    //width: 40%;
     &.full-width {
       width: 96%;
       min-height: 200px;
@@ -3093,7 +3095,7 @@ body.portal .copyright-container  {
   .bottom {
     display: flex;
     justify-content: center;
-    flex-direction: row;
+    flex-direction: column;
     flex-wrap: wrap;
   }
 }
@@ -3101,6 +3103,14 @@ body.portal .copyright-container  {
   .portal-skyscraper-container {
     .section-title {
       font-size: 1.4em;
+    }
+  }
+}
+@media (min-width: 992px) {
+
+  .portal-skyscraper-container {
+    .bottom {
+      flex-direction: row;
     }
   }
 }


### PR DESCRIPTION
address https://jira.movember.com/browse/TN-2644
allow user to land on the sub-study thank you modal upon completion of sub-study questionnaire.

Changes include:

- add check for when sub-study completion is done, IF completed today (which means the user has come from the questionnaire), then pops open the thank you modal automatically
- the modal will only automatically open **once**, any subsequent navigation back to the patient home page won't automatically invoke the modal (unless there are triggers)
- fix call the trigger API only when sub-study assessment is completed
- styling fixes
