### PR TITLE
bugfix - substudy thankyou modal shouldn't popup when assessment hasn't

### DIFF
--- a/portal/static/js/src/empro.js
+++ b/portal/static/js/src/empro.js
@@ -66,7 +66,7 @@ emproObj.prototype.initTriggerDomains = function() {
         this.initReportLink();
         tnthAjax.assessmentReport(this.userId, SUBSTUDY_QUESTIONNAIRE_IDENTIFIER, (data) => {
             if (!data || !data.entry || !data.entry.length) {
-               this.initThankyouModal();
+               this.initThankyouModal(false);
                return;
             }
             let [today, authoredDate, status] = [

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -2906,7 +2906,6 @@ body.portal .copyright-container  {
   display: flex;
   justify-content: center;
   align-items: center;
-  flex-direction: column;
   flex-wrap: wrap;
   position: relative;
   padding-bottom: 1em;
@@ -2923,6 +2922,7 @@ body.portal .copyright-container  {
   min-height: 250px;
   overflow: hidden;
   line-height: 1.5;
+  align-self: stretch;
   p {
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Found bug when testing:  sub-study thank you modal is popping up when substudy assessment hasn't been done yet.

Fix is to pass the correct parameter to disable thank you modal popup