### PR TITLE
Refactor / clean-up sub-study eligibility checks

### DIFF
--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -96,7 +96,7 @@ def assessment_engine_view(user):
     from ..models.research_study import BASE_RS_ID, EMPRO_RS_ID, ResearchStudy
     now = datetime.utcnow()
 
-    research_study_status = patient_research_study_status(user)
+    research_study_status = patient_research_study_status(user, False)
     assessment_status = QB_Status(
         user=user,
         research_study_id=BASE_RS_ID,

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -509,7 +509,7 @@ def patient_research_study_status(patient, ignore_QB_status):
         results.append(rs_status)
         if rs == EMPRO_RS_ID and patient.clinician_id is None:
             # Enforce biz rule - must have clinician on file.
-            rs_status['ready'] = False
+            rs_status['eligible'] = False
             rs_status['errors'].append("No clinician")
 
         if ignore_QB_status:

--- a/portal/models/research_study.py
+++ b/portal/models/research_study.py
@@ -69,26 +69,6 @@ class ResearchStudy(db.Model):
         results.sort()
         return results
 
-    @staticmethod
-    def assigned_to(user):
-        """Returns set of all ResearchStudy IDs assigned to given user"""
-        base_study = 0
-        results = []
-        iqbs = qbs_by_intervention(user, classification=None)
-        if iqbs:
-            results.append(base_study)  # Use dummy till system need arises
-
-        for rp, _ in ResearchProtocol.assigned_to(
-                user, research_study_id='all'):
-            rs_id = rp.research_study_id
-            if rs_id is None:
-                continue
-
-            if latest_consent(user, rs_id) and rs_id not in results:
-                results.append(rs_id)
-        results.sort()
-        return results
-
 
 def research_study_id_from_questionnaire(questionnaire_name):
     """Reverse lookup research_study_id from a questionnaire_name"""

--- a/portal/models/research_study.py
+++ b/portal/models/research_study.py
@@ -69,6 +69,26 @@ class ResearchStudy(db.Model):
         results.sort()
         return results
 
+    @staticmethod
+    def assigned_to(user):
+        """Returns set of all ResearchStudy IDs assigned to given user"""
+        base_study = 0
+        results = []
+        iqbs = qbs_by_intervention(user, classification=None)
+        if iqbs:
+            results.append(base_study)  # Use dummy till system need arises
+
+        for rp, _ in ResearchProtocol.assigned_to(
+                user, research_study_id='all'):
+            rs_id = rp.research_study_id
+            if rs_id is None:
+                continue
+
+            if latest_consent(user, rs_id) and rs_id not in results:
+                results.append(rs_id)
+        results.sort()
+        return results
+
 
 def research_study_id_from_questionnaire(questionnaire_name):
     """Reverse lookup research_study_id from a questionnaire_name"""

--- a/portal/trigger_states/empro_states.py
+++ b/portal/trigger_states/empro_states.py
@@ -81,13 +81,6 @@ def enter_user_trigger_critical_section(user_id):
 
     """
     ts = users_trigger_state(user_id)
-
-    # TODO remove this transition - outstanding integration work, should happen
-    #  when user first becomes eligible  - remove @pytest.mark.skip from
-    #  test_bogus_transition when done.
-    if ts.state == 'unstarted':
-        ts = initiate_trigger(user_id)
-
     sm = EMPRO_state(ts)
     sm.begin_process()
     # Record the historical transformation via insert.

--- a/portal/views/research_study.py
+++ b/portal/views/research_study.py
@@ -18,7 +18,10 @@ research_study_api = Blueprint('research_study_api', __name__)
 @crossdomain()
 @oauth.require_oauth()
 def rs_for_user(user_id):
-    """Returns simple JSON for research study user is associated with
+    """Returns simple JSON for research study user is eligible for
+
+    NB a user may be "eligible" but not yet "ready" for a given study. Use
+    ``qb_status.patient_research_study_status()`` to check.
 
     ---
     tags:

--- a/tests/test_trigger_states.py
+++ b/tests/test_trigger_states.py
@@ -29,7 +29,6 @@ def test_initial_state_view(client, initialized_patient_logged_in):
     assert results.json['state'] == 'unstarted'
 
 
-@pytest.mark.skip(reason="TODO in enter_user_trigger_critical_section")
 def test_bogus_transition(initialized_with_ss_qnr):
     """Attempt to jump to due without starting; expect exception"""
     with pytest.raises(TransitionNotAllowed):


### PR DESCRIPTION
Determine patient's research study eligibility in consistent manner.
Prevent qb_timeline row additions prior to patient's eligibility.
Provide bootstrap safe lookup.

Previously, sub-study qb_timeline rows were erroneously added for patients w/o a clinician.  This should be run on test dbs after merge.  (No, not worth a migration IMO)
`delete from qb_timeline where user_id in (select id from users where clinician_id is null and id in (select distinct(user_id) from qb_timeline where research_study_id = 1));`