### PR TITLE
TN-2859 extend trigger api

### DIFF
--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -96,7 +96,7 @@ def assessment_engine_view(user):
     from ..models.research_study import BASE_RS_ID, EMPRO_RS_ID, ResearchStudy
     now = datetime.utcnow()
 
-    research_study_status = patient_research_study_status(user, False)
+    research_study_status = patient_research_study_status(user)
     assessment_status = QB_Status(
         user=user,
         research_study_id=BASE_RS_ID,

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -469,7 +469,7 @@ class QB_Status(object):
                 f" {requested_indef} already!")
 
 
-def patient_research_study_status(patient, ignore_QB_status):
+def patient_research_study_status(patient, ignore_QB_status=False):
     """Returns details regarding patient readiness for available studies
 
     Wraps complexity of checking multiple QB_Status and ResearchStudy

--- a/portal/trigger_states/empro_domains.py
+++ b/portal/trigger_states/empro_domains.py
@@ -1,6 +1,7 @@
 """Module to handle complexity of domain scoring and triggers"""
 from collections import defaultdict
 
+from ..date_tools import FHIR_datetime
 from ..models.observation import Observation
 from ..models.questionnaire_response import first_last_like_qnr
 
@@ -136,6 +137,7 @@ class DomainManifold(object):
                 triggers['domain'][domain] = dt.triggers
 
         triggers['source'] = {
+            'authored': FHIR_datetime.as_fhir(self.cur_qnr.authored),
             'qnr_id': self.cur_qnr.id,
             'qb_id': self.cur_qnr.questionnaire_bank_id,
             'qb_iteration': self.cur_qnr.qb_iteration}

--- a/portal/trigger_states/views.py
+++ b/portal/trigger_states/views.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, current_app, jsonify, request
 from .empro_states import users_trigger_state
+from .models import TriggerState
 from ..views.crossdomain import crossdomain
 from ..extensions import oauth
 from ..models.user import get_user
@@ -61,3 +62,32 @@ def user_triggers(user_id):
         ts = users_trigger_state(user_id)
 
     return jsonify(ts.as_json())
+
+
+@trigger_states.route('/api/user/<int:user_id>/trigger_history')
+@crossdomain()
+@oauth.require_oauth()
+def user_trigger_history(user_id):
+    """Return a JSON list of user's historical trigger records
+
+    Returns ordered list (oldest to newest) of a user's trigger
+    state history.
+
+    :returns list of TriggerStates: with ``state`` attribute meaning:
+      - unstarted: no info avail for user
+      - due: users triggers unavailable; assessment due
+      - inprocess: triggers are not ready; continue to poll for results
+      - processed: triggers available in TriggerState.triggers attribute
+      - triggered: action taken on triggers (such as emails sent).
+        ``triggers`` available as are ``triggers.actions``.
+      - resolved: all actions completed (such as post-intervention QB taken)
+        ``triggers`` available as are ``triggers.actions``.
+
+    """
+    # confirm view access
+    get_user(user_id, 'view')
+
+    history = TriggerState.query.filter(
+        TriggerState.user_id == user_id).order_by(TriggerState.id)
+    results = [ts.as_json() for ts in history]
+    return jsonify(results)

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -28,7 +28,7 @@ from ..models.encounter import EC
 from ..models.fhir import bundle_results
 from ..models.identifier import Identifier
 from ..models.intervention import INTERVENTION
-from ..models.qb_timeline import QB_StatusCacheKey, invalidate_users_QBT
+from ..models.qb_timeline import invalidate_users_QBT
 from ..models.questionnaire import Questionnaire
 from ..models.questionnaire_response import (
     NoFutureDates,
@@ -39,10 +39,8 @@ from ..models.research_study import (
     research_study_id_from_questionnaire,
 )
 from ..models.role import ROLE
-from ..models.user import User, current_user, get_user
+from ..models.user import current_user, get_user
 from ..timeout_lock import LockTimeout, guarded_task_launch
-from ..trace import dump_trace, establish_trace
-from ..type_tools import check_int
 from .crossdomain import crossdomain
 
 assessment_engine_api = Blueprint('assessment_engine_api', __name__)
@@ -649,6 +647,102 @@ def assessment(patient_id, instrument_id):
 
     link = {'rel': 'self', 'href': request.url}
     return jsonify(bundle_results(elements=documents, links=[link]))
+
+
+@assessment_engine_api.route(
+    '/api/patient/<int:patient_id>/questionnaire_response/<int:qnr_id>'
+)
+@crossdomain()
+@oauth.require_oauth()
+def get_qnr_by_id(patient_id, qnr_id):
+    """Return the patient's requested questionaire_response
+
+    Retrieve a minimal FHIR doc in JSON format including the
+    'QuestionnaireResponse' resource type.
+    ---
+    operationId: getQuestionnaireResponseById
+    tags:
+      - Assessment Engine
+    produces:
+      - application/json
+    parameters:
+      - name: patient_id
+        in: path
+        description: TrueNTH patient ID
+        required: true
+        type: integer
+        format: int64
+      - name: qnr_id
+        in: path
+        description:
+          ID (primary key) of the requested Questionnaire Response
+        required: true
+        type: string
+        enum:
+          - epic26
+          - eq5d
+      - name: patch_dstu2
+        in: query
+        description: whether or not to make bundles DTSU2 compliant
+        required: false
+        type: boolean
+        default: false
+    responses:
+      200:
+        description: successful operation
+        schema:
+          $ref: "#/definitions/QuestionnaireResponse"
+      401:
+        description:
+          if missing valid OAuth token or logged-in user lacks permission
+          to view requested patient
+    security:
+      - ServiceToken: []
+
+    """
+    patient = get_user(
+        patient_id, 'view', allow_on_url_authenticated_encounters=True)
+    qnr = QuestionnaireResponse.query.get(qnr_id)
+    if not qnr:
+        abort(404)
+
+    if qnr.subject_id != patient.id:
+        abort(
+            400,
+            "Requested patient doesn't own requested questionnaire_response")
+
+    # NB, document_answered returns a (potentially) modified *copy* of
+    # the document, so changes aren't persisted or found in db session
+    # cached objects.  see TN-2417 for example side-effects
+    document = qnr.document_answered
+    for question in document['group']['question']:
+        for answer in question['answer']:
+            # Hack: Extensions should be a list, correct in-place if need be
+            # todo: migrate towards FHIR spec in persisted data
+            if (
+                'extension' in answer.get('valueCoding', {}) and
+                not isinstance(answer['valueCoding']['extension'], (tuple, list))
+            ):
+                answer['valueCoding']['extension'] = [answer['valueCoding']['extension']]
+
+    # Hack: add missing "resource" wrapper for DTSU2 compliance
+    # Remove when all interventions compliant
+    if request.args.get('patch_dstu2'):
+        document = {
+            'resource': document,
+            'fullUrl': request.url,
+        }
+
+    # No place within the FHIR spec to associate 'visit name' nor a
+    # 'status' as per business rules (i.e. 'in-progress' becomes
+    # 'partially completed' once the associated QB expires).
+    # Use FHIR `extension`s to pass these fields to clients.
+    extensions = qnr.extensions()
+    if extensions:
+        assert('extension' not in qnr.document)  # catch future collisions
+        document['extension'] = extensions
+
+    return jsonify(document)
 
 
 @assessment_engine_api.route('/api/patient/assessment')

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -202,8 +202,7 @@ def patient_profile(patient_id):
             user_interventions.append({"name": intervention.name})
 
     substudy_status = [
-        study for study in patient_research_study_status(
-            patient, ignore_QB_status=False) if
+        study for study in patient_research_study_status(patient) if
         study['research_study_id'] == EMPRO_RS_ID]
     substudy_assessment_is_ready = (
         substudy_status and substudy_status['ready'])

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -205,7 +205,7 @@ def patient_profile(patient_id):
         study for study in patient_research_study_status(patient) if
         study['research_study_id'] == EMPRO_RS_ID]
     substudy_assessment_is_ready = (
-        substudy_status and substudy_status['ready'])
+        substudy_status and substudy_status[0]['ready'])
 
     return render_template(
         'profile/patient_profile.html', user=patient,

--- a/tests/test_trigger_states.py
+++ b/tests/test_trigger_states.py
@@ -69,6 +69,8 @@ def test_base_eval(
         TriggerState.user_id == test_user_id).filter(
         TriggerState.state == 'processed').one()
     assert ts.questionnaire_response_id == initialized_with_ss_qnr.id
+    assert ts.triggers['source']['qnr_id'] == ts.questionnaire_response_id
+    assert ts.triggers['source']['authored'] == '2020-09-30T00:00:00+00:00'
 
 
 def test_cur_hard_trigger():


### PR DESCRIPTION
Added `authored` field to triggers['source'].
Added new view `/api/user/<int:user_id>/trigger_history` to return list of user's trigger states and details.  Example result:

```json
[
  {
    "state": "due",
    "timestamp": "2020-12-01T19:10:55+00:00",
    "user_id": 3160
  },
  {
    "state": "inprocess",
    "timestamp": "2020-12-01T19:10:55+00:00",
    "user_id": 3160
  },
  {
    "state": "processed",
    "timestamp": "2020-12-01T19:10:59+00:00",
    "triggers": {
      "domain": {
        "anxious": {},
        "discouraged": {},
        "fatigue": {},
        "general_pain": {},
        "insomnia": {},
        "joint_pain": {},
        "sad": {},
        "social_isolation": {}
      },
      "source": {
        "qb_id": 114,
        "qb_iteration": null,
        "qnr_id": 2579
      }
    },
    "user_id": 3160
  }
]
```

Extended assessment API to obtain a QNR by id.  Example use:
`/api/patient/3160/questionnaire_response/2579`