### PR TITLE
TN-2780 delay EMPRO start date till completion of global study w/i four weeks. 

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -509,6 +509,7 @@ def patient_research_study_status(patient, ignore_QB_status=False):
         results.append(rs_status)
         if rs == EMPRO_RS_ID and patient.clinician_id is None:
             # Enforce biz rule - must have clinician on file.
+            trace("no clinician; not eligible")
             rs_status['eligible'] = False
             rs_status['errors'].append("No clinician")
 

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -509,7 +509,7 @@ def ordered_qbs(user, research_study_id, classification=None):
     old_td, withdrawal_date = consent_withdrawal_dates(
         user, research_study_id=research_study_id)
     if not td:
-        if old_td:
+        if old_td and withdrawal_date:
             trace("withdrawn user, use previous trigger {}".format(old_td))
             td = old_td
         else:

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -451,7 +451,7 @@ class QNR_results(object):
             user=self.user, research_study_id=self.research_study_id)
         old_td, withdrawal_date = consent_withdrawal_dates(
             self.user, research_study_id=self.research_study_id)
-        if not td and old_td:
+        if not td and old_td and withdrawal_date:
             td = old_td
 
         def qbd_accessor(as_of_date, classification):

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -488,9 +488,6 @@ class QNR_results(object):
         if not acting_user:
             acting_user = User.query.filter_by(email='__system__').first()
         for qnr in self.qnrs:
-            if qnr.qnr_id == 2497:
-                import pdb;
-                pdb.set_trace()
             QuestionnaireResponse.query.get(
                 qnr.qnr_id).assign_qb_relationship(
                 acting_user_id=acting_user.id, qbd_accessor=qbd_accessor)

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -153,9 +153,9 @@ class QuestionnaireResponse(db.Model):
 
         if not self.questionnaire_bank_id:
             current_app.logger.warning(
-                "Can't locate QB for patient {}'s questionnaire_response "
+                "Can't locate QB for patient {}'s questionnaire_response {} "
                 "with reference to given instrument {}".format(
-                    self.subject_id, qn_name))
+                    self.subject_id, self.id, qn_name))
             self.questionnaire_bank_id = 0  # none of the above
             self.qb_iteration = None
 
@@ -488,6 +488,9 @@ class QNR_results(object):
         if not acting_user:
             acting_user = User.query.filter_by(email='__system__').first()
         for qnr in self.qnrs:
+            if qnr.qnr_id == 2497:
+                import pdb;
+                pdb.set_trace()
             QuestionnaireResponse.query.get(
                 qnr.qnr_id).assign_qb_relationship(
                 acting_user_id=acting_user.id, qbd_accessor=qbd_accessor)

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -319,7 +319,10 @@ def patient_timeline(patient_id):
     if trace:
         establish_trace("BEGIN time line lookup for {}".format(patient_id))
 
-    research_study_id = int(request.args.get('research_study_id', 0))
+    try:
+        research_study_id = int(request.args.get('research_study_id', 0))
+    except ValueError:
+        abort(400, "integer value required for 'research_study_id'")
     purge = request.args.get('purge', False)
     try:
         # If purge was given special 'all' value, also wipe out associated

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -314,7 +314,7 @@ def patient_timeline(patient_id):
     from ..models.questionnaire_bank import visit_name
     from ..trace import dump_trace, establish_trace
 
-    get_user(patient_id, permission='view')
+    user = get_user(patient_id, permission='view')
     trace = request.args.get('trace', False)
     if trace:
         establish_trace("BEGIN time line lookup for {}".format(patient_id))
@@ -333,6 +333,9 @@ def patient_timeline(patient_id):
                 research_study_id=research_study_id,
                 acting_user_id=current_user().id)
 
+        from ..cache import cache
+        from ..models.questionnaire_bank import trigger_date
+        cache.delete_memoized(trigger_date, user, research_study_id)
         update_users_QBT(
             patient_id,
             research_study_id=research_study_id,

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -376,12 +376,14 @@ def patient_timeline(patient_id):
         QuestionnaireResponse.subject_id == patient_id).order_by(
         QuestionnaireResponse.authored)
     posted = [{
-        'at, qb, iteration, status, name': "{}, {}, {}, {}, {}".format(
-            qnr.authored,
-            qb_names.get(qnr.questionnaire_bank_id),
-            qnr.qb_iteration,
-            qnr.status,
-            qnr.document['questionnaire']['reference'].split('/')[-1])
+        'qnr_id, at, qb, iteration, status, name':
+            "{}, {}, {}, {}, {}, {}".format(
+                qnr.id,
+                qnr.authored,
+                qb_names.get(qnr.questionnaire_bank_id),
+                qnr.qb_iteration,
+                qnr.status,
+                qnr.document['questionnaire']['reference'].split('/')[-1])
         } for qnr in qnrs]
 
     qbstatus = QB_Status(

--- a/tests/test_qb_timeline.py
+++ b/tests/test_qb_timeline.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import pytest
 
+from portal.cache import cache
 from portal.database import db
 from portal.date_tools import FHIR_datetime
 from portal.models.audit import Audit
@@ -17,7 +18,11 @@ from portal.models.qb_timeline import (
     second_null_safe_datetime,
     update_users_QBT,
 )
-from portal.models.questionnaire_bank import QuestionnaireBank, visit_name
+from portal.models.questionnaire_bank import (
+    QuestionnaireBank,
+    trigger_date,
+    visit_name,
+)
 from portal.models.questionnaire_response import QuestionnaireResponse
 from portal.views.user import withdraw_consent
 from tests import TEST_USER_ID, TestCase, associative_backdate
@@ -250,6 +255,7 @@ class TestQbTimeline(TestQuestionnaireBank):
 
         # update QBT should not re-establish baseline connection given dates
         self.test_user = db.session.merge(self.test_user)
+        cache.delete_memoized(trigger_date)
         qbstatus = QB_Status(
             user=self.test_user,
             research_study_id=0,

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 from flask_webtest import SessionScope
 import pytest
 
+from portal.cache import cache
 from portal.extensions import db
 from portal.models.audit import Audit
 from portal.models.clinical_constants import CC
@@ -296,6 +297,7 @@ class TestQuestionnaireBank(TestCase):
             start='{"months": 3}', cycle_length='{"months": 6}',
             termination='{"months": 24}')
         qb.recurs.append(recur)
+        cache.delete_memoized(trigger_date)
         assert trigger_date(
             self.test_user, research_study_id=0, qb=qb) == tx_date
 
@@ -333,6 +335,7 @@ class TestQuestionnaireBank(TestCase):
         self.add_procedure(code='7', display='Focal therapy',
                            system=ICHOM, setdate=tx_date)
         self.test_user = db.session.merge(self.test_user)
+        cache.delete_memoized(trigger_date)
         assert trigger_date(self.test_user, research_study_id=0) == tx_date
 
     def test_intervention_in_progress(self):
@@ -360,6 +363,7 @@ class TestQuestionnaireBank(TestCase):
         self.test_user = db.session.merge(self.test_user)
         obs = self.test_user.observations.first()
         assert obs.codeable_concept.codings[0].display == 'biopsy'
+        cache.delete_memoized(trigger_date)
         assert trigger_date(
             self.test_user, research_study_id=0, qb=qb) == obs.issued
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -14,6 +14,7 @@ from portal.models.qb_timeline import invalidate_users_QBT
 from portal.models.questionnaire_bank import (
     QuestionnaireBank,
     QuestionnaireBankQuestionnaire,
+    trigger_date
 )
 from portal.models.research_protocol import ResearchProtocol
 from portal.models.role import ROLE
@@ -91,6 +92,7 @@ class TestReporting(TestCase):
             db.session.commit()
         crv, self.test_user = map(db.session.merge, (crv, self.test_user))
 
+        cache.delete_memoized(trigger_date)
         invalidate_users_QBT(self.test_user.id, research_study_id='all')
         a_s = QB_Status(
             self.test_user, research_study_id=0, as_of_date=datetime.utcnow())


### PR DESCRIPTION
The `trigger_date` (nothing to do w/ EMPRO triggers, but the old term for the initial trigger to start a QB) for EMPRO is now delayed until a "recent" (must be within 4 weeks of consent, or we wait for subsequent) global study QB is on file as `completed`.