### PR TITLE
sub-study longitudinal report - prompt url-authenticated user to login

### DIFF
--- a/portal/eproms/templates/eproms/assessment_engine/ae_complete.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_complete.html
@@ -46,7 +46,8 @@
                 substudy_assessment_status=substudy_assessment_status,
                 substudy_due_date=substudy_due_date,
                 enrolled_in_substudy=enrolled_in_substudy,
-                substudy_assessment_is_ready=substudy_assessment_is_ready
+                substudy_assessment_is_ready=substudy_assessment_is_ready,
+                substudy_assessment_errors=substudy_assessment_errors
             )}}
         {%- endif -%}
         <!-- both main and sub-study completed -->

--- a/portal/eproms/templates/eproms/assessment_engine/ae_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_due.html
@@ -32,43 +32,22 @@
     <!-- main study due card -->
     {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=due_title_text)}}
     {%- if enrolled_in_substudy -%}
-        {%- if substudy_assessment_is_due -%}
-            <!-- substudy due card, NOTE if global study work is still due, this tile will be disabled -->
-            {{empro_due(
-                substudy_assessment_is_due=substudy_assessment_is_due,
-                assessment_status=assessment_status,
-                OverallStatus=OverallStatus,
-                substudy_assessment_status=substudy_assessment_status,
-                substudy_due_date=substudy_due_date,
-                enrolled_in_substudy=enrolled_in_substudy,
-                substudy_assessment_is_ready=substudy_assessment_is_ready
-            )}}
-            <!-- main study and/or substudy completed cards-->
-            {{completed_cards(
-                user=user,
-                assessment_status=assessment_status,
-                OverallStatus=OverallStatus,
-                comp_date=comp_date,
-                substudy_assessment_status=substudy_assessment_status,
-                enrolled_in_substudy=enrolled_in_substudy
-            )}}
-        {%- else -%}
-            {{completed_card(
-                assessment_status=assessment_status,
-                OverallStatus=OverallStatus,
-                comp_date=comp_date,
-                title_text=completed_title_text)
-            }}
-            <!-- it is possible that user has completed empro at this point, so need to show -->
-            {{empro_completed(
-                user=user,
-                OverallStatus=OverallStatus,
-                substudy_assessment_status=substudy_assessment_status,
-                substudy_comp_date=substudy_comp_date,
-                enrolled_in_substudy=enrolled_in_substudy,
-                card_class="disabled" if not substudy_assessment_status.overall_status == OverallStatus.completed else ""
-            )}}          
-        {%- endif -%}
+        <!-- show main study completed card first -->
+        {{completed_card(
+            assessment_status=assessment_status,
+            OverallStatus=OverallStatus,
+            comp_date=comp_date,
+            title_text=completed_title_text)
+        }}
+        <!-- it is possible that user has completed empro at this point, so need to show -->
+        {{empro_completed(
+            user=user,
+            OverallStatus=OverallStatus,
+            substudy_assessment_status=substudy_assessment_status,
+            substudy_comp_date=substudy_comp_date,
+            enrolled_in_substudy=enrolled_in_substudy,
+            card_class="disabled" if not substudy_assessment_status.overall_status == OverallStatus.completed else ""
+        )}}
     {%- else -%}
         <!-- main study completed tile -->
         {{completed_card(

--- a/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
@@ -18,42 +18,22 @@
     <!-- main study due card -->
     {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=due_title_text)}}
     {%- if enrolled_in_substudy -%}
-        {%- if substudy_assessment_is_due -%}
-            <!-- substudy due card, NOTE if global study work is still due, this tile will be disabled -->
-            {{empro_due(
-                substudy_assessment_is_due=substudy_assessment_is_due,
-                assessment_status=assessment_status,
-                OverallStatus=OverallStatus,
-                substudy_assessment_status=substudy_assessment_status,
-                substudy_due_date=substudy_due_date,
-                enrolled_in_substudy=enrolled_in_substudy,
-                substudy_assessment_is_ready=substudy_assessment_is_ready
-            )}}
-            <!-- main study and/or substudy completed cards-->
-             {{completed_cards(
-                user=user,
-                assessment_status=assessment_status,
-                OverallStatus=OverallStatus,
-                comp_date=comp_date,
-                substudy_assessment_status=substudy_assessment_status,
-                enrolled_in_substudy=enrolled_in_substudy
-            )}}
-        {%- else -%}
-            {{completed_card(
-                assessment_status=assessment_status,
-                OverallStatus=OverallStatus,
-                comp_date=comp_date,
-                title_text=completed_title_text)}}
-             <!-- it is possible that user has completed empro at this point, so need to show -->
-            {{empro_completed(
-                user=user,
-                OverallStatus=OverallStatus,
-                substudy_assessment_status=substudy_assessment_status,
-                substudy_comp_date=substudy_comp_date,
-                enrolled_in_substudy=enrolled_in_substudy,
-                card_class="disabled" if not substudy_assessment_status.overall_status == OverallStatus.completed else ""
-            )}}
-        {%- endif -%}
+        <!-- show main study completed card first -->
+        {{completed_card(
+            assessment_status=assessment_status,
+            OverallStatus=OverallStatus,
+            comp_date=comp_date,
+            title_text=completed_title_text)
+        }}
+        <!-- it is possible that user has completed empro at this point, so need to show -->
+        {{empro_completed(
+            user=user,
+            OverallStatus=OverallStatus,
+            substudy_assessment_status=substudy_assessment_status,
+            substudy_comp_date=substudy_comp_date,
+            enrolled_in_substudy=enrolled_in_substudy,
+            card_class="disabled" if not substudy_assessment_status.overall_status == OverallStatus.completed else ""
+        )}}
     {%- else -%}
         <!-- main study completed tile -->
         {{completed_card(assessment_status=assessment_status, OverallStatus=OverallStatus, comp_date=comp_date, title_text=completed_title_text)}}

--- a/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
@@ -196,12 +196,17 @@
         {% endif %}
     </div>
 {%- endmacro -%}
-{%- macro empro_modal_default_report_block() -%}
+{%- macro empro_modal_default_report_block(user) -%}
     <div class="item">
         <h4>{{_("Your Report")}}</h4>
         <p>{{_("Here's where you'll find an ongoing summary of your responses, each time you complete a questionnaire.")}}</p>
         <div class="buttons-container">
-            <a class="btn btn-empro-primary btn-report longitudinal-report-link">{{_("View My Report")}}</a>
+            {%- if user and user.current_encounter().auth_method == 'url_authenticated' -%}
+                <!-- for an url authenticated user, trying to access the report will be prompted to login in -->
+                <a class="btn btn-empro-primary btn-report portal-weak-auth-disabled" href="{{url_for('patients.longitudinal_report', subject_id=user.id, instrument_id='ironman_ss')}}">{{_("View My Report")}}</a>
+            {%- else -%}
+                <a class="btn btn-empro-primary btn-report longitudinal-report-link">{{_("View My Report")}}</a>
+            {%- endif -%}
         </div>
     </div>
 {%- endmacro -%}
@@ -242,18 +247,18 @@
                         <p>{{_("Find your latest tips and tools below.")}}</p>
                     </div>
                     <div class="items-section no-trigger">
-                        {{empro_modal_default_report_block()}}
+                        {{empro_modal_default_report_block(user)}}
                         {{empro_modal_default_healthTip_block()}}
                         {{empro_modal_default_supportTeam_block(organization=user.organizations[0].name if user else "")}}
                     </div>
                     <div class="items-section hard-trigger">
                         {{empro_modal_hardTrigger_supportTeam_block(organization=user.organizations[0].name if user else "")}}
                         {{empro_modal_triggered_healthTip_block()}}
-                        {{empro_modal_default_report_block()}}
+                        {{empro_modal_default_report_block(user)}}
                     </div>
                     <div class="items-section soft-trigger">
                         {{empro_modal_triggered_healthTip_block()}}
-                        {{empro_modal_default_report_block()}}
+                        {{empro_modal_default_report_block(user)}}
                         {{empro_modal_default_supportTeam_block(organization=user.organizations[0].name if user else "")}}
                     </div>
                 </div>

--- a/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
@@ -70,10 +70,12 @@
                     substudy_assessment_status={},
                     substudy_due_date="",
                     enrolled_in_substudy=false,
-                    substudy_assessment_is_ready=false) -%}
+                    substudy_assessment_is_ready=false,
+                    substudy_assessment_errors=substudy_assessment_errors
+    ) -%}
     <!-- subject is in the sub-study and the sub-study questionnaire is due-->
     <!-- NOTE the tile is disabled IF global study work is not complete -->
-    {%- if  enrolled_in_substudy and substudy_assessment_is_due-%}
+    {%- if  enrolled_in_substudy -%}
         {% set substudy_title = "EMPRO" %}
         {% set button_label =  _('complete questionnaire') %}
         {%- call render_card_content(
@@ -93,6 +95,12 @@
                 <div class="text-content">{{_("Your questionnaire is ready. Please complete by %(substudy_due_date)s. By participating, we'll better understand your experience and offer useful tips and support.", substudy_due_date=substudy_due_date)}}</div>
             {%- endif -%}
             {{render_call_to_button(button_label=button_label, button_url=url_for('assessment_engine_api.present_needed'))}}
+            <!-- display any error if for some reason the assessment is not ready -->
+            {%- if substudy_assessment_errors and  substudy_assessment_errors|length %}
+                <div class="error-message">
+                    <span class='glyphicon glyphicon-alert warning icon' aria-hidden='true'></span>
+                    {{substudy_assessment_errors | join(", ")}}</div>
+            {%- endif -%}
         {%- endcall -%}
     {%- endif -%}
 {%- endmacro -%}

--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -141,7 +141,11 @@ def assessment_engine_view(user):
             OverallStatus.in_progress)
     substudy_assessment_is_ready = enrolled_in_substudy \
         and research_study_status[EMPRO_RS_ID]['ready']
-
+    substudy_assessment_is_eligible = enrolled_in_substudy \
+        and research_study_status[EMPRO_RS_ID]['eligible']
+    substudy_assessment_errors = enrolled_in_substudy \
+        and research_study_status[EMPRO_RS_ID]['errors'] \
+    
     return render_template(
         "eproms/assessment_engine.html",
         user=user,
@@ -162,7 +166,8 @@ def assessment_engine_view(user):
         substudy_assessment_is_due=substudy_assessment_is_due,
         substudy_due_date=substudy_due_date,
         substudy_comp_date=substudy_comp_date,
-        substudy_assessment_is_ready=substudy_assessment_is_ready
+        substudy_assessment_is_ready=substudy_assessment_is_ready,
+        substudy_assessment_errors=substudy_assessment_errors
     )
 
 

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -3033,11 +3033,15 @@ body.portal .copyright-container  {
   flex-direction: column;
   flex-grow: 1;
   justify-content: space-between;
-  // .text-content {
-  //   flex: 1;
-  // }
   .button-container {
     align-self: flex-end;
+  }
+  .error-message {
+    color: lighten(@errorMessageColor, 40%);
+    margin: 24px 16px 0;
+    .icon {
+      margin-right: 8px;
+    }
   }
 }
 .portal-flex-container .button-container,

--- a/portal/templates/admin/patients_substudy.html
+++ b/portal/templates/admin/patients_substudy.html
@@ -52,7 +52,7 @@
              data-show-export="true"
              data-export-data-type="all"
              >
-            {{testUsersCheckbox(postUrl=url_for('patients.patients_root'))}}
+            {{testUsersCheckbox(postUrl=url_for('patients.patients_substudy'))}}
           <thead>
               <tr>
                   <th data-field="id" data-visible="false" data-card-visible="false" data-sortable="false" data-class="tnth-hide">


### PR DESCRIPTION
part of https://jira.movember.com/browse/TN-2803
For **URL-authenticated** user, accessing the sub-study longitudinal report requires logging in first.
Frontend code is already in place that will check for any link with `portal-weak-auth-disabled` css class and prompts user to login first via a modal, see previous relevant commit here: 
https://github.com/uwcirg/truenth-portal/pull/3724

Fix include adding check for user authentication method and add `portal-weak-auth-disabled` to report link where applicable.