### PR TITLE
TN-2577 Add flask-session override for SameSite cookie settings

### DIFF
--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -184,6 +184,9 @@ class BaseConfig(object):
 
     # Only set cookies over "secure" channels (HTTPS) for non-dev deployments
     SESSION_COOKIE_SECURE = SYSTEM_TYPE.lower() != 'development'
+
+    # include cookies in cross-domain requests eg portal banner
+    SESSION_COOKIE_SAMESITE = 'None'
     PREFERRED_URL_SCHEME = os.environ.get('PREFERRED_URL_SCHEME', 'http')
 
     BABEL_CONFIG_FILENAME = 'gil.babel.cfg'

--- a/portal/extensions.py
+++ b/portal/extensions.py
@@ -28,6 +28,7 @@ from .csrf import csrf
 from .database import db
 from .models.login import login_user
 from .models.user import User, current_user
+from .session import SameSiteSession as Session
 
 db_adapter = SQLAlchemyAdapter(db, User)
 user_manager = UserManager(db_adapter)

--- a/portal/extensions.py
+++ b/portal/extensions.py
@@ -28,7 +28,7 @@ from .csrf import csrf
 from .database import db
 from .models.login import login_user
 from .models.user import User, current_user
-from .session import SameSiteSession as Session
+from .session import RedisSameSiteSession as Session
 
 db_adapter = SQLAlchemyAdapter(db, User)
 user_manager = UserManager(db_adapter)

--- a/portal/extensions.py
+++ b/portal/extensions.py
@@ -21,7 +21,6 @@ from flask_babel import Babel
 from flask_mail import Mail
 from flask_oauthlib.provider import OAuth2Provider
 from flask_recaptcha import ReCaptcha
-from flask_session import Session
 from flask_user import SQLAlchemyAdapter, UserManager
 
 from .csrf import csrf

--- a/portal/session.py
+++ b/portal/session.py
@@ -57,7 +57,7 @@ class BaseRedisSessionInterface(RedisSessionInterface):
         )
 
 
-class SameSiteSession(Session):
+class RedisSameSiteSession(Session):
     """Extends flask-session to passthrough SESSION_COOKIE_SAMESITE flask config"""
     def _get_interface(self, app):
         config = app.config.copy()
@@ -66,15 +66,6 @@ class SameSiteSession(Session):
         config.setdefault('SESSION_USE_SIGNER', False)
         config.setdefault('SESSION_KEY_PREFIX', 'session:')
         config.setdefault('SESSION_REDIS', None)
-        config.setdefault('SESSION_MEMCACHED', None)
-        config.setdefault('SESSION_FILE_DIR', os.path.join(os.getcwd(), 'flask_session'))
-        config.setdefault('SESSION_FILE_THRESHOLD', 500)
-        config.setdefault('SESSION_FILE_MODE', 384)
-        config.setdefault('SESSION_MONGODB', None)
-        config.setdefault('SESSION_MONGODB_DB', 'flask_session')
-        config.setdefault('SESSION_MONGODB_COLLECT', 'sessions')
-        config.setdefault('SESSION_SQLALCHEMY', None)
-        config.setdefault('SESSION_SQLALCHEMY_TABLE', 'sessions')
         session_interface = BaseRedisSessionInterface(
             config['SESSION_REDIS'],
             config['SESSION_KEY_PREFIX'],

--- a/portal/session.py
+++ b/portal/session.py
@@ -1,0 +1,83 @@
+import os
+
+from flask_session import Session, RedisSessionInterface
+from flask_session.sessions import total_seconds
+
+class BaseRedisSessionInterface(RedisSessionInterface):
+    """Override RedisSessionInterface save_session() method to passthrough flask config"""
+
+    def save_session(self, app, session, response):
+        domain = self.get_cookie_domain(app)
+        path = self.get_cookie_path(app)
+        if not session:
+            if session.modified:
+                self.redis.delete(self.key_prefix + session.sid)
+                response.delete_cookie(
+                    app.session_cookie_name,
+                    domain=domain,
+                    path=path,
+                )
+            return
+
+        # Modification case.  There are upsides and downsides to
+        # emitting a set-cookie header each request.  The behavior
+        # is controlled by the :meth:`should_set_cookie` method
+        # which performs a quick check to figure out if the cookie
+        # should be set or not.  This is controlled by the
+        # SESSION_REFRESH_EACH_REQUEST config flag as well as
+        # the permanent flag on the session itself.
+        # if not self.should_set_cookie(app, session):
+        #    return
+
+        httponly = self.get_cookie_httponly(app)
+        secure = self.get_cookie_secure(app)
+        # call new flask config method for reading configured sameSite cookie value
+        samesite = self.get_cookie_samesite(app)
+        expires = self.get_expiration_time(app, session)
+        val = self.serializer.dumps(dict(session))
+        self.redis.setex(
+            name=self.key_prefix + session.sid, value=val,
+            time=total_seconds(app.permanent_session_lifetime),
+        )
+        if self.use_signer:
+            session_id = self._get_signer(app).sign(want_bytes(session.sid))
+        else:
+            session_id = session.sid
+
+        response.set_cookie(
+            app.session_cookie_name,
+            session_id,
+            expires=expires,
+            httponly=httponly,
+            domain=domain,
+            path=path,
+            secure=secure,
+            samesite=samesite,
+        )
+
+
+class SameSiteSession(Session):
+    """Extends flask-session to passthrough SESSION_COOKIE_SAMESITE flask config"""
+    def _get_interface(self, app):
+        config = app.config.copy()
+        config.setdefault('SESSION_TYPE', 'null')
+        config.setdefault('SESSION_PERMANENT', True)
+        config.setdefault('SESSION_USE_SIGNER', False)
+        config.setdefault('SESSION_KEY_PREFIX', 'session:')
+        config.setdefault('SESSION_REDIS', None)
+        config.setdefault('SESSION_MEMCACHED', None)
+        config.setdefault('SESSION_FILE_DIR', os.path.join(os.getcwd(), 'flask_session'))
+        config.setdefault('SESSION_FILE_THRESHOLD', 500)
+        config.setdefault('SESSION_FILE_MODE', 384)
+        config.setdefault('SESSION_MONGODB', None)
+        config.setdefault('SESSION_MONGODB_DB', 'flask_session')
+        config.setdefault('SESSION_MONGODB_COLLECT', 'sessions')
+        config.setdefault('SESSION_SQLALCHEMY', None)
+        config.setdefault('SESSION_SQLALCHEMY_TABLE', 'sessions')
+        session_interface = BaseRedisSessionInterface(
+            config['SESSION_REDIS'],
+            config['SESSION_KEY_PREFIX'],
+            config['SESSION_USE_SIGNER'],
+            config['SESSION_PERMANENT'],
+        )
+        return session_interface

--- a/portal/session.py
+++ b/portal/session.py
@@ -3,6 +3,7 @@ import os
 from flask_session import Session, RedisSessionInterface
 from flask_session.sessions import total_seconds
 
+
 class BaseRedisSessionInterface(RedisSessionInterface):
     """Override RedisSessionInterface save_session() method to passthrough flask config"""
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,7 +4,7 @@
 alabaster==0.7.12         # via sphinx
 beautifulsoup4==4.8.1     # via webtest
 docutils==0.14            # via sphinx
-flask-testing==0.7.1
+flask-testing==0.8.0
 flask-webtest==0.0.9
 imagesize==1.1.0          # via sphinx
 mock==3.0.5

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -18,7 +18,7 @@ py==1.8.0                 # via tox
 pygments==2.6.1           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytest==5.2.2
-pytest-flask==0.15.0
+pytest-flask==0.15.1
 selenium==3.141.0
 snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ coverage==5.1
 decorator==4.4.0          # via validators
 dogpile.cache==0.9.0      # via flask-sqlalchemy-caching
 enum34==1.1.6
-flask-babel==0.12.2
+flask-babel==1.0.0
 flask-caching==1.8.0      # via flask-sqlalchemy-caching
 flask-dance[sqla]==1.4.0
 flask-login==0.4.1        # via flask-user

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,5 +60,5 @@ swagger-spec-validator==2.4.3
 urllib3==1.25.7             # via requests
 validators==0.14.0 # pyup: <=0.10.1 # pin until require_tld supported again
 vine==1.3.0               # via amqp
-werkzeug==0.16.0          # via flask
+werkzeug==1.0.1           # via flask
 wtforms==2.2.1            # via flask-wtf

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ flask-dance[sqla]==1.4.0
 flask-login==0.4.1        # via flask-user
 flask-mail==0.9.1         # via flask-user
 flask-migrate==2.5.3
-flask-oauthlib==0.9.5
+flask-oauthlib==0.9.6
 flask-recaptcha==0.4.2
 flask-session==0.3.1
 flask-sqlalchemy==2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ flask-sqlalchemy==2.4.1
 flask-sqlalchemy-caching==1.0.4
 flask-swagger==0.2.14
 git+https://github.com/uwcirg/Flask-User.git@0.6.21.2#egg=flask-user # pyup: <0.7 # pin until 1.0 is ready for prod
-flask-wtf==0.14.2         # via flask-user
+flask-wtf==0.14.3         # via flask-user
 flask==1.0.3
 fuzzywuzzy==0.17.0
 healthcheck==1.3.3


### PR DESCRIPTION
TN-2577

* Add flask-session override class ([base class](https://github.com/fengsp/flask-session/blob/0.3.2/flask_session/sessions.py))
* Include cookies in cross-site requests (eg portal banner) with [`SameSite=None`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#None)
* Update dependencies as necessary