### PR TITLE
TN-2811 retrieval of resources content by country code fix

### DIFF
--- a/portal/eproms_substudy_tailored_content/src/js/Base.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Base.js
@@ -159,7 +159,7 @@ export default {
             //console.log("Locale ", this.locale);
         },
         getCountryCode() {
-           return this.countryCode;
+            return this.countryCode;
          //return "GB";
          //return "CA";
         },
@@ -500,7 +500,8 @@ export default {
             }
             countryCode = countryCode ||this.getCountryCode();
             if (!this.isEligibleCountryCode(countryCode)) {
-                return;
+                //get the resources for default country code
+                countryCode = this.defaultCountryCode;
             }
             resourceSections.forEach(resourceSection => {
                 let topic = resourceSection.getAttribute("data-topic");

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1541,7 +1541,7 @@ export default (function() {
                     }
                     setTimeout(function() {
                         this.initPostTxQuestionnaireSection({clearCache: true});
-                    }.bind(this), 2000);
+                    }.bind(this), 3000);
                 });
                 return false;
             },

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -3374,7 +3374,7 @@ section.header {
       position: absolute;
       top: 0;
       z-index: 10;
-      min-height: 50px;
+      min-height: 72px;
     }
   }
   #triggersSection {


### PR DESCRIPTION
Fix in response to issue found in https://jira.movember.com/browse/TN-2811
tailored content for external resources was not loaded for users in Australia

Fix include:

- load default resources content if content for a specific country code is not found
- also minor styling fix for display of post intervention questionnaire response