### PR TITLE
TN-2771 post tx status display fix

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -448,6 +448,7 @@ class RP_flyweight(object):
                         initial_trigger=self.td)
                     self.nxt_exp = calc_and_adjust_expired(
                         user=self.user, qbd=self.nxt_qbd,
+                        research_study_id=self.research_study_id,
                         initial_trigger=self.td)
                 if self.cur_start > self.nxt_start + relativedelta(months=1):
                     # Still no match means poorly defined RP QBs
@@ -1079,7 +1080,7 @@ def qb_status_visit_name(user_id, research_study_id, as_of_date):
                 results['action_state'] = ts.triggers.get(
                     'action_state', 'due')
             else:
-                results['action_state'] = 'due'
+                results['action_state'] = 'not applicable'
 
     return results
 

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -78,7 +78,8 @@ def render_patients_list(
             patient.current_qb = qb_status['visit_name']
             if research_study_id == EMPRO_RS_ID:
                 patient.clinician = clinician_name_map[patient.clinician_id]
-                patient.action_state = qb_status['action_state']
+                patient.action_state = qb_status['action_state'].title() \
+                    if qb_status['action_state'] else ""
             patients_list.append(patient)
     else:
         patients_list = query


### PR DESCRIPTION
Address feedback when testing:  https://jira.movember.com/browse/TN-2771
See Diana's comment: https://mo-programs.slack.com/archives/GV6K6SURW/p1608247980052500

Fixes include:
- Fix post intervention questionnaire status to "**not applicable**" when EPRO questionnaire has yet started, i.e. due.
- Capitalize first letter in post intervention questionnaire status when displayed in patient list
- Fix runtime patient list error related to missing position argument, i.e. research_study_id, for **calc_and_adjust_expired** function in qb_timeline.py