### PR TITLE
TN-2869 RP advancement issues

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -456,7 +456,7 @@ def update_qnr_authored(qnr_id, authored, actor):
     # Must clear the qb_id and iteration in case this authored date
     # change moves the QNR to a different visit.
     qnr.questionnaire_bank_id = None
-    qnr.qb_id = None
+    qnr.qb_iteration = None
     db.session.commit()
 
     # Invalidate timeline as this probably altered the status

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -420,6 +420,42 @@ class RP_flyweight(object):
         else:
             trace("out of QBs!")
 
+    def pre_loop_transition(self):
+        """Check start state before looping through timeline
+
+        If the organization has already retired one or more RPs,
+        step forward to the correct starting RP
+
+        """
+        # confirm the now current isn't already retired. rare situation that
+        # happens when an org has retired multiple RPs before a user's trigger
+
+        # historically, Research Protocol changes recorded in persistence
+        # files include retroactive dates, that is retired values far in the
+        # past.  add a safe buffer as a "look ahead", so we don't move too
+        # far in the RP history - allowing for the checks in `ordered_qbs()`
+        # to tie a user to the older, well retired RP if they have submitted
+        # QuestionnaireResponses defining the older RP.
+        retro_buffer = relativedelta(months=9)
+        while True:
+            # indefinite plays by a different set of rules
+            if self.classification == 'indefinite':
+                if (
+                        self.cur_rpd.retired and
+                        self.cur_rpd.retired + retro_buffer < self.td and
+                        self.consider_transition()):
+                    trace('pre-loop transition as RP retired before user trigger')
+                    self.transition()
+                else:
+                    break
+            else:
+                if self.consider_transition() and (
+                        self.cur_rpd.retired + retro_buffer) < self.cur_start:
+                    trace('pre-loop transition')
+                    self.transition()
+                else:
+                    break
+
     def transition(self):
         """Transition internal state to 'next' Research Protocol"""
         trace("transitioning to the next RP [{} - {})".format(
@@ -452,15 +488,6 @@ class RP_flyweight(object):
 
         # reset in case of another advancement
         self.skipped_nxt_start = None
-
-        # confirm the now current isn't already retired. rare situation that
-        # happens when an org has retired multiple RPs before a user's trigger
-        if (
-                self.cur_rpd.retired and
-                self.cur_rpd.retired < self.td and
-                self.consider_transition()):
-            trace('fire double transition as RP retired before user trigger')
-            self.transition()
 
 
 def ordered_qbs(user, classification=None):
@@ -507,6 +534,7 @@ def ordered_qbs(user, classification=None):
             trace("no current found in initial QBD lookup, bail")
             return
 
+        rp_flyweight.pre_loop_transition()
         while True:
             if rp_flyweight.consider_transition():
                 # if there's a nextRP and curRP is retired before the

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -420,6 +420,7 @@ def patient_timeline(patient_id):
 
     if trace:
         return jsonify(
+            rps=rps,
             status=status,
             posted=posted,
             timeline=results,


### PR DESCRIPTION
Found yet more special cases, some of which broke with previous hotfix (#3886)

Added a `pre_loop_trasition` to catch RPs up to the current or one previous so loop can correctly determine if it's time to transition RPs, or if the user has already submitted results associating the user with the older RP.

Also found a bug in `update_qnr_authored()`.  Once this PR is live on prod, this command should be run to clean up a bogus authored date:
```flask update-qnr-authored --actor pbugni@gmail.com --authored '20109-14 16:00:00' --qnr_id 5353```