### PR TITLE
Withdrawn sanity check should log error, not halt process

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -143,8 +143,8 @@ class QB_Status(object):
                 self.overall_status != OverallStatus.withdrawn):
             from flask import current_app
             current_app.logger.error(
-                "Unexpected state %s, user %d should be withdrawn", 
-                    self.overall_status, self.user.id)
+                "Unexpected state %s, user %d should be withdrawn",
+                self.overall_status, self.user.id)
 
     def older_qbds(self, last_known):
         """Generator to return QBDs and status prior to last known

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -138,6 +138,14 @@ class QB_Status(object):
         else:
             self._current = cur_qbd
 
+        # Withdrawn sanity check
+        if self.withdrawn_by(self.as_of_date) and (
+                self.overall_status != OverallStatus.withdrawn):
+            from flask import current_app
+            current_app.logger.error(
+                "Unexpected state {}, user {} should be withdrawn".format(
+                    self.overall_status, self.user.id))
+
     def older_qbds(self, last_known):
         """Generator to return QBDs and status prior to last known
 

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -143,8 +143,8 @@ class QB_Status(object):
                 self.overall_status != OverallStatus.withdrawn):
             from flask import current_app
             current_app.logger.error(
-                "Unexpected state {}, user {} should be withdrawn".format(
-                    self.overall_status, self.user.id))
+                "Unexpected state %s, user %d should be withdrawn", 
+                    self.overall_status, self.user.id)
 
     def older_qbds(self, last_known):
         """Generator to return QBDs and status prior to last known

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -138,13 +138,6 @@ class QB_Status(object):
         else:
             self._current = cur_qbd
 
-        # Withdrawn sanity check
-        if self.withdrawn_by(self.as_of_date) and (
-                self.overall_status != OverallStatus.withdrawn):
-            raise RuntimeError(
-                "Unexpected state {}, should be withdrawn".format(
-                    self.overall_status))
-
     def older_qbds(self, last_known):
         """Generator to return QBDs and status prior to last known
 


### PR DESCRIPTION
Couldn't generate an acceptance report due to a single user's mis-filed QNRs.

Generate an error log, don't halt the process via exception.