### PR TITLE
add missing guard for early triggers missing `actions`.

### DIFF
--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -510,9 +510,10 @@ def patient_timewarp(patient_id, days):
                     triggers['source']['authored'] = FHIR_datetime.as_fhir(
                         FHIR_datetime.parse(triggers['source']['authored'])
                         - delta)
-                for email in triggers['actions']['email']:
-                    email['timestamp'] = FHIR_datetime.as_fhir(
-                        FHIR_datetime.parse(email['timestamp']) - delta)
+                if 'actions' in triggers:
+                    for email in triggers['actions']['email']:
+                        email['timestamp'] = FHIR_datetime.as_fhir(
+                            FHIR_datetime.parse(email['timestamp']) - delta)
                 ts.triggers = triggers
 
     # reminder email dates


### PR DESCRIPTION
fixes bug noticed in error email:
```
  File "/opt/venvs/portal/lib/python3.7/site-packages/portal/views/patient.py", line 513, in patient_timewarp
    for email in triggers['actions']['email']:
KeyError: 'actions'
```