### PR TITLE
TN-2885 Intervention QB remains available till next post

### DIFF
--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -356,6 +356,22 @@ export default { /*global $ */
             return true;
         });
     },
+    "getTriggersHistory": function(userId, params, callback) {
+        callback = callback || function() {};
+        params = params || {};
+        if (!userId) {
+            callback({error: true});
+            return false;
+        }
+        this.sendRequest(`/api/user/${userId}/trigger_history`, "GET", userId, params, (data) => {
+            if (!data || data.error) {
+                callback({"error": true});
+                return false;
+            }
+            callback(data);
+            return true;
+        });
+    },
     "getCliniciansList": function(orgIds, callback) {
         callback = callback || function() {};
         orgIds = orgIds || [];

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1227,7 +1227,16 @@ export default (function() {
                 });
             },
             setSubStudyAssessmentData: function(data) {
+                if (!data || !data.length) return;
+                //latest first
+                data = (data).sort(function(a, b) {
+                    return new Date(b.authored) - new Date(a.authored);
+                });
                 this.subStudyAssessment.data = data;
+            },
+            getLastSubStudyAssessmentDate: function() {
+                if (!this.subStudyAssessment.data || !this.subStudyAssessment.data.length) return "";
+                return this.modules.tnthDates.formatDateString(this.subStudyAssessment.data[0].authored);
             },
             hasSubStudyAsssessmentData: function() {
                 return this.computedSubStudyAssessmentData.length;
@@ -1348,11 +1357,10 @@ export default (function() {
                 });
             },
             shouldShowSubstudyPostTx: function() {
-                //TODO need to also show post tx section IF there is previous response for this subject and the subject does not have triggers in the current patient questionnaire responses
                 return this.isSubStudyPatient() && (this.hasSubStudyTriggers() || this.hasPrevSubStudyPostTx());
             },
             isSubStudyTriggersResolved: function() {
-                return this.subStudyTriggers.state === "resolved";
+                return this.subStudyTriggers.state === "resolved" || this.subStudyTriggers.state === "completed";
             },
             onResponseChangeFieldEvent: function(event) {
                 let targetElement = $(event.target);
@@ -1434,7 +1442,7 @@ export default (function() {
                         });
 
                     });
-                }, params);
+                }, {...params, ...{clearCache: true}});
             },
             submitPostTxQuestionnaire: function(e) {
                 e.preventDefault();
@@ -1541,8 +1549,8 @@ export default (function() {
                         return;
                     }
                     setTimeout(function() {
-                        this.initPostTxQuestionnaireSection({clearCache: true});
-                    }.bind(this), 2750);
+                        location.reload();
+                    }.bind(this), 2000);
                 });
                 return false;
             },

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1357,10 +1357,13 @@ export default (function() {
                 });
             },
             shouldShowSubstudyPostTx: function() {
-                return this.isSubStudyPatient() && (this.hasSubStudyTriggers() || this.hasPrevSubStudyPostTx());
+                return this.isSubStudyPatient() && (this.hasSubStudyTriggers() || this.isPostTxActionRequired() || this.hasPrevSubStudyPostTx());
+            },
+            isPostTxActionRequired: function() {
+                return String(this.subStudyTriggers.state).toLowerCase() === "due" || String(this.subStudyTriggers.state).toLowerCase() === "overdue";
             },
             isSubStudyTriggersResolved: function() {
-                return this.subStudyTriggers.state === "resolved" || this.subStudyTriggers.state === "completed";
+                return String(this.subStudyTriggers.state).toLowerCase() === "resolved" || String(this.subStudyTriggers.state).toLowerCase() === "completed";
             },
             onResponseChangeFieldEvent: function(event) {
                 let targetElement = $(event.target);
@@ -1401,6 +1404,9 @@ export default (function() {
                     return;
                 }
                 $(`${containerIdentifier} .btn-submit`).addClass("disabled").attr("disabled", true);
+            },
+            shouldShowPostTxQuestionnaireSection: function() {
+                return this.isSubStudyPatient() && this.hasSubStudyAsssessmentData();
             },
             initPostTxQuestionnaireSection: function(params) {
                 if (!this.subjectId || !this.isSubStudyPatient()) {

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -3469,7 +3469,9 @@ section.header {
 }
 #postTxQuestionnaireContainer {
   position: relative;
-  min-height: 250px;
+  &.active {
+    min-height: 250px;
+  }
   .loader {
     position: absolute;
     top: 0;
@@ -3523,6 +3525,20 @@ section.header {
       }
     }
   }
+  #noTriggersSection {
+      margin-bottom: 12px;
+      margin-top: 16px;
+      padding-top: 16px;
+      border-top: 1px solid rgba(0, 0, 0, 0.2);
+      border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+      .item {
+        margin-bottom: 16px;
+        .text {
+          font-weight: 500;
+        }
+      }
+  }
+
   #reportNoteSection {
     margin-bottom: 32px;
     font-style: italic;

--- a/portal/templates/profile/patient_profile.html
+++ b/portal/templates/profile/patient_profile.html
@@ -65,7 +65,7 @@
     <!-- require a static bookmark link for post intervention questionnaire section for the dynamically generated content. Othewise the hash location won't go to the section correctly -->
     <a href="#postInterventionQuestionnaireLoc"></a>
     <div id="postInterventionQuestionnaireLoc">&nbsp;</div>
-    <div class="row" id="postInterventionQuestionnaireSection" class="eproms-substudy" v-show="shouldShowSubstudyPostTx()"> 
+    <div class="row" id="postInterventionQuestionnaireSection" class="eproms-substudy" v-show="hasSubStudyAsssessmentData()"> 
       <div class="col-md-12 col-xs-12">
           {{profile_macro.postInterventionQuestionnaire(user)}}
       </div>

--- a/portal/templates/profile/patient_profile.html
+++ b/portal/templates/profile/patient_profile.html
@@ -62,14 +62,7 @@
           {{profile_macro.longitudinalReport(user)}}
       </div>
     </div>
-    <!-- require a static bookmark link for post intervention questionnaire section for the dynamically generated content. Othewise the hash location won't go to the section correctly -->
-    <a href="#postInterventionQuestionnaireLoc"></a>
-    <div id="postInterventionQuestionnaireLoc">&nbsp;</div>
-    <div class="row" id="postInterventionQuestionnaireSection" class="eproms-substudy" v-show="hasSubStudyAsssessmentData()"> 
-      <div class="col-md-12 col-xs-12">
-          {{profile_macro.postInterventionQuestionnaire(user)}}
-      </div>
-    </div>
+    {{profile_macro.postInterventionQuestionnaire(user)}}
   {%- endif -%}
   {{profile_macro.profileDemoDetail(user, current_user)}}
   {{profile_macro.profileCommunications(user, current_user)}}

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -864,8 +864,9 @@
         <!-- don't show this if no hard triggers ?? -->
         <div id="postTxQuestionnaireContainer" class="eproms-substudy" data-profile-section-id="postTxQuestionnaire">
             <div class="loader" v-show="postTxQuestionnaire.loading"><i class="fa fa-spinner fa-spin fa-2x icon"></i></div>
-            <h5 class="muted">{{_("Actions Required (for Clinicians/Site Staff)")}}</h5>
-            <div id="triggersSection">
+            <!-- display trigger areas if indicated -->
+            <div id="triggersSection" v-if="hasSubStudyTriggers()">
+                <h5 class="muted" v-show="!isSubStudyTriggersResolved()">{{_("Actions Required (for Clinicians/Site Staff)")}}</h5>
                 <div class="item">{{_("EMPRO questionnaire completed on:")}} <span class="text" v-text="subStudyTriggers.date"></span></div>
                 <div class="item">{{_("ACTION REQUIRED for high distress areas:")}}
                     <ul class="list">
@@ -873,8 +874,19 @@
                     </ul>
                 </div>
             </div>
+            <!-- no triggers indicated -->
+            <div id="noTriggersSection" v-else>
+                <div class="item">{{_("Last EMPRO questionnaire completed on:")}} <span class="text" v-text="getLastSubStudyAssessmentDate()"></span></div>
+                <div class="item text-muted">{{_("No high distress areas indicated")}}</div>
+            </div>
             <div id="reportNoteSection">{{_("View subject EMPRO report for more information")}}</div>
-            <div id="questionsSection" class="content" :class="{disabled: isSubStudyTriggersResolved()}">
+            <!-- 
+                post intervention questionnaire section 
+                NOTE: 
+                will display if there are currently triggers
+                will be in a disabled state if the action state is "resolved"
+            -->
+            <div id="questionsSection" class="content" :class="{disabled: isSubStudyTriggersResolved(), active: shouldShowSubstudyPostTx()}" v-show="shouldShowSubstudyPostTx()">
                 <div class="question" v-for="item in postTxQuestionnaire.questions" :linkId="item.linkId" :dataType="item.type" :text="item.text" >
                     <!-- question text -->
                     <span class="title" :class="item.type" v-text="item.text"></span>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -859,101 +859,108 @@
     {% endcall %}
 {%- endmacro -%}
 {%- macro postInterventionQuestionnaire(person) -%}
-    {% call profileSection(editable=false) %}
-    {% call titleSection() -%}{{_("IRONMAN EMPRO")}}{%- endcall %}
-        <!-- don't show this if no hard triggers ?? -->
-        <div id="postTxQuestionnaireContainer" class="eproms-substudy" data-profile-section-id="postTxQuestionnaire">
-            <div class="loader" v-show="postTxQuestionnaire.loading"><i class="fa fa-spinner fa-spin fa-2x icon"></i></div>
-            <!-- display trigger areas if indicated -->
-            <div id="triggersSection" v-if="hasSubStudyTriggers()">
-                <h5 class="muted" v-show="!isSubStudyTriggersResolved()">{{_("Actions Required (for Clinicians/Site Staff)")}}</h5>
-                <div class="item">{{_("EMPRO questionnaire completed on:")}} <span class="text" v-text="subStudyTriggers.date"></span></div>
-                <div class="item">{{_("ACTION REQUIRED for high distress areas:")}}
-                    <ul class="list">
-                        <li v-for="item in subStudyTriggers.domains" v-text="item" class="text"></li>
-                    </ul>
+<!-- require a static bookmark link for post intervention questionnaire section for the dynamically generated content. Othewise the hash location won't go to the section correctly -->
+<a href="#postInterventionQuestionnaireLoc"></a>
+<div id="postInterventionQuestionnaireLoc">&nbsp;</div>
+<div class="row" id="postInterventionQuestionnaireSection" class="eproms-substudy" v-show="shouldShowPostTxQuestionnaireSection()"> 
+    <div class="col-md-12 col-xs-12">
+        {% call profileSection(editable=false) %}
+        {% call titleSection() -%}{{_("IRONMAN EMPRO")}}{%- endcall %}
+            <div id="postTxQuestionnaireContainer" class="eproms-substudy" data-profile-section-id="postTxQuestionnaire">
+                <div class="loader" v-show="postTxQuestionnaire.loading"><i class="fa fa-spinner fa-spin fa-2x icon"></i></div>
+                <!-- display trigger areas if indicated -->
+                <div id="triggersSection" v-if="hasSubStudyTriggers()">
+                    <h5 class="muted" v-show="!isSubStudyTriggersResolved()">{{_("Actions Required (for Clinicians/Site Staff)")}}</h5>
+                    <div class="item">{{_("EMPRO questionnaire completed on:")}} <span class="text" v-text="subStudyTriggers.date"></span></div>
+                    <div class="item">{{_("ACTION REQUIRED for high distress areas:")}}
+                        <ul class="list">
+                            <li v-for="item in subStudyTriggers.domains" v-text="item" class="text"></li>
+                        </ul>
+                    </div>
                 </div>
-            </div>
-            <!-- no triggers indicated -->
-            <div id="noTriggersSection" v-else>
-                <div class="item">{{_("Last EMPRO questionnaire completed on:")}} <span class="text" v-text="getLastSubStudyAssessmentDate()"></span></div>
-                <div class="item text-muted">{{_("No high distress areas indicated")}}</div>
-            </div>
-            <div id="reportNoteSection">{{_("View subject EMPRO report for more information")}}</div>
-            <!-- 
-                post intervention questionnaire section 
-                NOTE: 
-                will display if there are currently triggers
-                will be in a disabled state if the action state is "resolved"
-            -->
-            <div id="questionsSection" class="content" :class="{disabled: isSubStudyTriggersResolved(), active: shouldShowSubstudyPostTx()}" v-show="shouldShowSubstudyPostTx()">
-                <div class="question" v-for="item in postTxQuestionnaire.questions" :linkId="item.linkId" :dataType="item.type" :text="item.text" >
-                    <!-- question text -->
-                    <span class="title" :class="item.type" v-text="item.text"></span>
-                    <!-- date type answer-->
-                    <input type="text" class="data-datepicker form-control answer" readonly placeholder="d M yyyy"
-                            :class="{disabled: isSubStudyTriggersResolved()}"
-                            :dataType="item.type"
+                <!-- no triggers indicated -->
+                <!-- show the last completed EMPRO date && indicate no triggers -->
+                <div id="noTriggersSection" v-else>
+                    <div class="item">{{_("Last EMPRO questionnaire completed on:")}} <span class="text" v-text="getLastSubStudyAssessmentDate()"></span></div>
+                    <div class="item text-muted">{{_("No high distress areas indicated")}}</div>
+                </div>
+                <div id="reportNoteSection">{{_("View subject EMPRO report for more information")}}</div>
+                <!-- 
+                    post intervention questionnaire section 
+                    NOTE: 
+                    will display if there are currently triggers or action state is due or overdue
+                    will be in a disabled state if the action state is "resolved"
+                -->
+                <div id="questionsSection" class="content" :class="{disabled: isSubStudyTriggersResolved(), active: shouldShowSubstudyPostTx()}" v-show="shouldShowSubstudyPostTx()">
+                    <div class="question" v-for="item in postTxQuestionnaire.questions" :linkId="item.linkId" :dataType="item.type" :text="item.text" >
+                        <!-- question text -->
+                        <span class="title" :class="item.type" v-text="item.text"></span>
+                        <!-- date type answer-->
+                        <input type="text" class="data-datepicker form-control answer" readonly placeholder="d M yyyy"
+                                :class="{disabled: isSubStudyTriggersResolved()}"
+                                :dataType="item.type"
+                                :linkId="item.linkId"
+                                @change="onResponseChangeFieldEvent"
+                                v-if="item.type == 'date'"
+                        >
+                        <!-- boolean type answer-->
+                        <input type="checkbox"
+                            class="bool answer" 
+                            :dataType = "item.type"
                             :linkId="item.linkId"
                             @change="onResponseChangeFieldEvent"
-                            v-if="item.type == 'date'"
-                    >
-                    <!-- boolean type answer-->
-                    <input type="checkbox"
-                        class="bool answer" 
-                        :dataType = "item.type"
-                        :linkId="item.linkId"
-                        @change="onResponseChangeFieldEvent"
-                        v-if="item.type == 'boolean'">
-                    <!-- open-choice (checkboxes) type answer -->
-                    <div class="choices answer" v-if="item.type == 'open-choice'">
-                        <div class="choice" v-for="option in item.option">
-                            <input 
-                                type="checkbox"
+                            v-if="item.type == 'boolean'">
+                        <!-- open-choice (checkboxes) type answer -->
+                        <div class="choices answer" v-if="item.type == 'open-choice'">
+                            <div class="choice" v-for="option in item.option">
+                                <input 
+                                    type="checkbox"
+                                    :code="option.valueCoding.code"
+                                    :class="{other: /other/gi.test(option.valueCoding.display)}"
+                                    :dataType="item.type"
+                                    :linkId="item.linkId"
+                                    :value="option.valueCoding.display"
+                                    @change="onResponseChangeFieldEvent"
+                                >
+                                <span class="text" v-text="option.valueCoding.display"></span>
+                                <textarea
+                                    class="form-control addl-text other-text"
+                                    dataType="string"
+                                    :code="option.valueCoding.code"
+                                    :linkId="item.linkId"
+                                    @change="onResponseChangeFieldEvent"
+                                    v-if="/other/gi.test(option.valueCoding.display)"
+                                ></textarea>
+                            </div>
+                        </div>
+                        <!-- choice (select) type answer -->
+                        <select class="form-control answer" v-if="item.type == 'choice'" 
+                            :linkId="item.linkId"
+                            :dataType="item.type"
+                            @change="onResponseChangeFieldEvent"
+                        >
+                            <option value="">{{_("Select")}}</option>
+                            <option v-for="option in item.option"
                                 :code="option.valueCoding.code"
-                                :class="{other: /other/gi.test(option.valueCoding.display)}"
                                 :dataType="item.type"
                                 :linkId="item.linkId"
                                 :value="option.valueCoding.display"
-                                @change="onResponseChangeFieldEvent"
-                            >
-                            <span class="text" v-text="option.valueCoding.display"></span>
-                            <textarea
-                                class="form-control addl-text other-text"
-                                dataType="string"
-                                :code="option.valueCoding.code"
-                                :linkId="item.linkId"
-                                @change="onResponseChangeFieldEvent"
-                                v-if="/other/gi.test(option.valueCoding.display)"
-                            ></textarea>
+                                v-text="option.valueCoding.display"></option>
+                        </select>
+                    </div>
+                    <div class="footer-container">
+                        <div id="postTxSubmitContainer" class="buttons-container" v-show="!isSubStudyTriggersResolved()">
+                            <button class="btn-submit btn btn-tnth-primary disabled" @click="submitPostTxQuestionnaire">{{_("Submit")}}</button>
                         </div>
+                        {{saveLoaderDiv("postTxSubmitContainer")}}
+                        <div id="postTxResolutionContainer" v-show="isSubStudyTriggersResolved()"></div>
                     </div>
-                    <!-- choice (select) type answer -->
-                    <select class="form-control answer" v-if="item.type == 'choice'" 
-                        :linkId="item.linkId"
-                        :dataType="item.type"
-                        @change="onResponseChangeFieldEvent"
-                    >
-                        <option value="">{{_("Select")}}</option>
-                        <option v-for="option in item.option"
-                            :code="option.valueCoding.code"
-                            :dataType="item.type"
-                            :linkId="item.linkId"
-                            :value="option.valueCoding.display"
-                            v-text="option.valueCoding.display"></option>
-                    </select>
                 </div>
-                <div class="footer-container">
-                    <div id="postTxSubmitContainer" class="buttons-container" v-show="!isSubStudyTriggersResolved()">
-                        <button class="btn-submit btn btn-tnth-primary disabled" @click="submitPostTxQuestionnaire">{{_("Submit")}}</button>
-                    </div>
-                    {{saveLoaderDiv("postTxSubmitContainer")}}
-                    <div id="postTxResolutionContainer" v-show="isSubStudyTriggersResolved()"></div>
-                </div>
+                <div class="post-intervention-questionnaire-error error-message"></div>
             </div>
-            <div class="post-intervention-questionnaire-error error-message"></div>
-        </div>
-    {% endcall %}
+        {% endcall %}
+    </div>
+  </div>
 {%- endmacro -%}
 {% macro profileTreatingClinician(person) %}
     {% call profileSection(data_sections="locale, timezone") %}

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -888,8 +888,8 @@
                 <!-- 
                     post intervention questionnaire section 
                     NOTE: 
-                    will display if there are currently triggers or action state is due or overdue
-                    will be in a disabled state if the action state is "resolved"
+                    will display triggers were present in the last determined trigger state
+                    will be in a disabled state if the action state is "completed"
                 -->
                 <div id="questionsSection" class="content" :class="{disabled: isSubStudyTriggersResolved(), active: shouldShowSubstudyPostTx()}" v-show="shouldShowSubstudyPostTx()">
                     <div class="question" v-for="item in postTxQuestionnaire.questions" :linkId="item.linkId" :dataType="item.type" :text="item.text" >

--- a/portal/trigger_states/empro_states.py
+++ b/portal/trigger_states/empro_states.py
@@ -132,10 +132,6 @@ def initiate_trigger(user_id):
 
     # Check and update the status of pending work.
     if ts.state == 'triggered':
-        # Just ran out of time, resolve as 'missed'
-        current_app.logger.debug(f"resolve 'missed' trigger for {user_id}")
-        triggers = copy.deepcopy(ts.triggers)
-        triggers['action_state'] = 'missed'
         sm = EMPRO_state(ts)
         sm.resolve()
         db.session.commit()
@@ -358,9 +354,9 @@ def empro_staff_qbd_accessor(qnr):
                 "specialized QBD accessor given wrong instrument "
                 f"{instrument}")
 
-        # find best match from subject's trigger_states.  should always be
-        # in `triggered` state, unless re-eval is in process due to consent
-        # change, or the like.
+        # find best match from subject's trigger_states.  will be in
+        # `triggered` state if current, or `resolved` if time has
+        # passed and the user now has the subsequent month due.
         query = TriggerState.query.filter(
             TriggerState.user_id == qnr.subject_id).filter(
             TriggerState.state.in_(('triggered', 'resolved'))).order_by(

--- a/portal/trigger_states/empro_states.py
+++ b/portal/trigger_states/empro_states.py
@@ -313,7 +313,7 @@ def fire_trigger_events():
 
         # Now seek out any pending actions, such as reminders to staff
         for ts in TriggerState.query.filter(
-                TriggerState.state.in_('triggered', 'resolved')):
+                TriggerState.state.in_(('triggered', 'resolved'))):
             # Need to consider state == resolved, as the user may
             # have a newer EMPRO due, but the previous still hasn't
             # received a post intervention QB from staff, noted by

--- a/portal/trigger_states/empro_states.py
+++ b/portal/trigger_states/empro_states.py
@@ -168,6 +168,11 @@ def evaluate_triggers(qnr, override_state=False):
     :return: None
 
     """
+    if qnr.status != 'completed':
+        raise ValueError(
+            f"QuestionnaireResponse: {qnr.id} with status: {qnr.status} "
+            "sent to evaluate_triggers, only 'completed' are eligible")
+
     try:
         # first, confirm state transition is allowed - raises if not
         ts = users_trigger_state(qnr.subject_id)

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -991,7 +991,7 @@ def assessment_update(patient_id):
 
     # TODO: only extract QuestionnaireResponses where the corresponding Questionnaire has the SDC extension
     qn_name = existing_qnr.document.get("questionnaire").get("reference", '').split('/')[-1]
-    if  qn_name == 'ironman_ss':
+    if qn_name == 'ironman_ss' and existing_qnr.status == 'completed':
         from ..tasks import extract_observations_task
         extract_observations_task.apply_async(
             kwargs={'questionnaire_response_id': existing_qnr.id}
@@ -1680,7 +1680,7 @@ def assessment_add(patient_id):
 
     # TODO: only extract QuestionnaireResponses where the corresponding Questionnaire has the SDC extension
     qn_name = questionnaire_response.document.get("questionnaire").get("reference", '').split('/')[-1]
-    if  qn_name == 'ironman_ss':
+    if qn_name == 'ironman_ss' and questionnaire_response.status == 'completed':
         from ..tasks import extract_observations_task
         extract_observations_task.apply_async(
             kwargs={'questionnaire_response_id': questionnaire_response.id}

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -387,7 +387,7 @@ def patient_timeline(patient_id):
         QuestionnaireResponse.authored)
 
     def get_recur_id(qnr):
-        if len(qnr.questionnaire_bank.recurs):
+        if qnr.questionnaire_bank and len(qnr.questionnaire_bank.recurs):
             return qnr.questionnaire_bank.recurs[0].id
         return None
 


### PR DESCRIPTION
Clinicians/staff can submit the post intervention QB even beyond the point at which a patient can take the next month's EMPRO.

In the patient/substudy view, the 'clinician action status` should show results/status from the last submitted EMPRO.

The patient_profile view should allow clinician/staff to fill out post-intervention QB until a subsequent visit has been posted by the patient.