### PR TITLE
TN-2786 fix action state for in progress EMPRO

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -1071,9 +1071,10 @@ def qb_status_visit_name(user_id, research_study_id, as_of_date):
                     if s.isdigit()]
                 assert len(digits) == 1
                 visit_month = digits[0]
-
+            # make sure triggers have been fired before evaluating acting state
             ts = TriggerState.query.filter(
                 TriggerState.user_id == user_id).filter(
+                TriggerState.state == 'triggered',
                 TriggerState.visit_month == visit_month).order_by(
                 TriggerState.timestamp.desc()).first()
             if ts and ts.triggers:


### PR DESCRIPTION
Related to this story:  https://jira.movember.com/browse/TN-2786
Address feedback from Diana here: https://mo-programs.slack.com/archives/GV6K6SURW/p1609818761011900?thread_ts=1608247980.052500&cid=GV6K6SURW Specifically, the EMPRO questionnaire is in progress but the Clinician Action Status has been updated to 'Required' see subject **3361** in EPROMS Test.  Diana's comment, `The clinician action status should be based on the triggers once the questionnaire has been completed (if any). If an EMPRO questionnaire is partially completed (if subject does not submit the questionnaire and it expires), then no intervention is required (even if the responses meet the trigger requirements)`

Fix include:

- check the trigger state, i.e. triggered, to ensure action(s) has been taken on user's trigger state, such as email
       sent to subject and staff, before evaluating action state
