### PR TITLE
TN-2748 bugfix and reprocess cleanup

### DIFF
--- a/portal/trigger_states/empro_states.py
+++ b/portal/trigger_states/empro_states.py
@@ -211,6 +211,7 @@ def evaluate_triggers(qnr, override_state=False):
         # post-intervention clinician follow up.  mark state if
         # one is found
         previous = TriggerState.query.filter(
+            TriggerState.user_id == qnr.subject_id).filter(
             TriggerState.state == 'resolved').order_by(
             TriggerState.timestamp.desc()).first()
         if previous and previous.triggers.get('action_state') not in (


### PR DESCRIPTION
Found a critical where clause missing on the query to mark previous post-intervention QB as `missed`.
When using the reprocess_qnr_id flag (debugging), clean up the trigger_state history.