### PR TITLE
correct trigger APIs to follow `/api/patient` pattern 

### DIFF
--- a/portal/eproms_substudy_tailored_content/src/js/Base.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Base.js
@@ -214,7 +214,7 @@ export default {
             params.maxTryAttempts = params.maxTryAttempts || 5;
             //get trigger domains IF a patient
             Promise.allSettled([
-                this.$http(`/api/user/${this.getUserID()}/triggers`)
+                this.$http(`/api/patient/${this.getUserID()}/triggers`)
             ]).then(response => {
                 let processedData = "";
                 try {

--- a/portal/static/js/src/components/LongitudinalReport.vue
+++ b/portal/static/js/src/components/LongitudinalReport.vue
@@ -332,7 +332,7 @@
             $.when(
                 $.ajax(`/api/questionnaire/${this.instrumentId}?system=${SYSTEM_IDENTIFIER_ENUM.TRUENTH_QUESTIONNAIRE_CODE_SYSTEM}`),
                 $.ajax(`/api/patient/${this.userId}/assessment/${this.instrumentId}`),
-                $.ajax(`/api/user/${this.userId}/trigger_history`)
+                $.ajax(`/api/patient/${this.userId}/trigger_history`)
             ).done((questionnaireData, assessmentData, triggerData) => {
                 this.errorMessage = "";
                

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -335,7 +335,7 @@ export default { /*global $ */
                 return;
             }
         }
-        this.sendRequest(`/api/user/${userId}/triggers`, "GET", userId, params, (data) => {
+        this.sendRequest(`/api/patient/${userId}/triggers`, "GET", userId, params, (data) => {
             if (!data || data.error || !data.state) {
                 callback({"error": true});
                 return false;
@@ -363,7 +363,7 @@ export default { /*global $ */
             callback({error: true});
             return false;
         }
-        this.sendRequest(`/api/user/${userId}/trigger_history`, "GET", userId, params, (data) => {
+        this.sendRequest(`/api/patient/${userId}/trigger_history`, "GET", userId, params, (data) => {
             if (!data || data.error) {
                 callback({"error": true});
                 return false;

--- a/portal/trigger_states/views.py
+++ b/portal/trigger_states/views.py
@@ -8,7 +8,7 @@ from ..models.user import get_user
 trigger_states = Blueprint('trigger_states', __name__)
 
 
-@trigger_states.route('/api/user/<int:user_id>/triggers')
+@trigger_states.route('/api/patient/<int:user_id>/triggers')
 @crossdomain()
 @oauth.require_oauth()
 def user_triggers(user_id):
@@ -64,7 +64,7 @@ def user_triggers(user_id):
     return jsonify(ts.as_json())
 
 
-@trigger_states.route('/api/user/<int:user_id>/trigger_history')
+@trigger_states.route('/api/patient/<int:user_id>/trigger_history')
 @crossdomain()
 @oauth.require_oauth()
 def user_trigger_history(user_id):

--- a/tests/test_trigger_states.py
+++ b/tests/test_trigger_states.py
@@ -24,7 +24,7 @@ def test_initial_state(test_user):
 def test_initial_state_view(client, initialized_patient_logged_in):
     """Confirm unknown user gets initial state"""
     user_id = initialized_patient_logged_in.id
-    results = client.get(f'/api/user/{user_id}/triggers')
+    results = client.get(f'/api/patient/{user_id}/triggers')
     assert results.status_code == 200
     assert results.json['state'] == 'unstarted'
 


### PR DESCRIPTION
make trigger APIs more consistent with other APIs like /timeline