### PR TITLE
Adding additional query info to exception text seen on prod.

### DIFF
--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -186,7 +186,8 @@ def load_template_args(
                 QBT.qb_iteration == qb_iteration).filter(
                 QBT.status == OverallStatus.due).one()
         except NoResultFound:
-            raise NoCurrentQB("no applicable QB for {}".format(user))
+            raise NoCurrentQB("no applicable QB{}:{} for {}".format(
+                questionnaire_bank_id, qb_iteration, user))
 
         # Due and start are synonymous in all contexts other than
         # communicating the "due" date to the user.  Adjust what is


### PR DESCRIPTION
As were now getting elast alerts from the celery jobs, this one keeps happening, and I can't make sense of it (as user 2907 most certainly has a valid QB looking at their timeline).
Adding more info to the exception text to help sleuth out the error.

Example elast alert: ```raised unexpected: NoCurrentQB('no applicable QB for user 2907')```