### PR TITLE
TN-2762 sub-study tailored content related fixes

### DIFF
--- a/portal/eproms_substudy_tailored_content/src/components/Header.vue
+++ b/portal/eproms_substudy_tailored_content/src/components/Header.vue
@@ -15,6 +15,7 @@
                         this.content = response;
                         Vue.nextTick(() => {
                             getWrapperJS(`#${this.sectionId}`);
+                            this.setElementsVis();
                             setTimeout(function() {
                                 this.loaded = true;
                             }.bind(this), 300);
@@ -29,6 +30,12 @@
             getAppObj() {
                 return this.$parent;
             },
+            setElementsVis() {
+                let subStudyElements = document.querySelectorAll("#tnthNavWrapper .eproms-substudy");
+                subStudyElements.forEach(el => {
+                    el.classList.add("show");
+                });
+            }
         },
         data() {
             return {

--- a/portal/eproms_substudy_tailored_content/src/js/Base.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Base.js
@@ -1,10 +1,11 @@
 import NavMethods from "./Nav";
 import VideoMethods from "./Video";
-import {checkIE, getUrlParameter, tryParseJSON, PromiseAllSettledPolyfill} from "./Utility";
+import {checkIE, getUrlParameter, tryParseJSON, ElementClosestPolyfill, PromiseAllSettledPolyfill} from "./Utility";
 
 export default {
     created() {
         PromiseAllSettledPolyfill();
+        ElementClosestPolyfill();
     },
     mounted() {
         Promise.allSettled([
@@ -307,19 +308,20 @@ export default {
             let collapsibleElements = document.querySelectorAll(".collapsible");
             collapsibleElements.forEach(el => {
                 el.addEventListener('click', event => {
-                    let parentEl = event.target.parentElement;
+                    let targetElement = event.target.closest(".collapsible");
+                    let parentEl = targetElement.parentElement;
                     let collapsibleItems = parentEl.querySelectorAll(".collapsible");
                     collapsibleItems.forEach(item => {
-                        if (item === event.target) return true;
+                        if (item === targetElement) return true;
                         item.classList.remove("open");
                     });
-                    if (event.target.classList.contains("open")) {
-                        event.target.classList.remove("open");
+                    if (targetElement.classList.contains("open")) {
+                        targetElement.classList.remove("open");
                         return;
                     }
-                    event.target.classList.add("open");
+                    targetElement.classList.add("open");
                 });
-            })
+            }, true);
         },
         setTileLinkEvent() {
             let tileElements = document.querySelectorAll(".tiles-container .tile");

--- a/portal/eproms_substudy_tailored_content/src/js/Utility.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Utility.js
@@ -112,7 +112,7 @@ export function PromiseAllSettledPolyfill() {
 }
 
 export function ElementClosestPolyfill() {
-  //see https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+  //see https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#polyfill
   if (!Element.prototype.matches) {
     Element.prototype.matches =
       Element.prototype.msMatchesSelector ||

--- a/portal/eproms_substudy_tailored_content/src/js/Utility.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Utility.js
@@ -110,3 +110,23 @@ export function PromiseAllSettledPolyfill() {
     };
   }
 }
+
+export function ElementClosestPolyfill() {
+  //see https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+  if (!Element.prototype.matches) {
+    Element.prototype.matches =
+      Element.prototype.msMatchesSelector ||
+      Element.prototype.webkitMatchesSelector;
+  }
+  
+  if (!Element.prototype.closest) {
+    Element.prototype.closest = function(s) {
+      var el = this;
+      do {
+        if (Element.prototype.matches.call(el, s)) return el;
+        el = el.parentElement || el.parentNode;
+      } while (el !== null && el.nodeType === 1);
+      return null;
+    };
+  }
+}

--- a/portal/eproms_substudy_tailored_content/src/style/app.less
+++ b/portal/eproms_substudy_tailored_content/src/style/app.less
@@ -959,6 +959,9 @@ a {
     margin-bottom: 4px;
     font-size: @subtitleFontSize;
   }
+  ul {
+    margin-left: 16px;
+  }
 }
 .tiles-container {
   display: flex;

--- a/portal/eproms_substudy_tailored_content/webpack.config.js
+++ b/portal/eproms_substudy_tailored_content/webpack.config.js
@@ -113,7 +113,7 @@ module.exports = function(_env, argv) {
     plugins: [
       new VueLoaderPlugin(),
       new HtmlWebpackPlugin({
-        title: "Substudy Tailored Content",
+        title: "EMPRO Resources",
         template: path.join(__dirname, '/src/app.html'),
         filename: path.join(__dirname, `${templateDirectory}/substudy_tailored_content.html`),
         favicon: path.join(__dirname, '/src/assets/favicon.ico'),

--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -1011,7 +1011,7 @@ import {EPROMS_MAIN_STUDY_ID, EPROMS_SUBSTUDY_ID} from "./data/common/consts.js"
                     __filters["column_selections"].push($(this).attr("data-field"));
                 });
                 data["filters"] = __filters;
-                console.log("data? ", data)
+               
                 if (Object.keys(data).length > 0) {
                     tnthAjax.setTablePreference(userId, this.tableIdentifier, {
                         "data": JSON.stringify(data)

--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -485,6 +485,20 @@ import {EPROMS_MAIN_STUDY_ID, EPROMS_SUBSTUDY_ID} from "./data/common/consts.js"
                     });
                 }
                 $("#adminTableToolbar .orgs-filter-warning").popover();
+                $("#adminTable .filterControl select").on("change", function() {
+                    if ($(this).find("option:selected").val()) {
+                        $(this).addClass("active");
+                        return;
+                    }
+                    $(this).removeClass("active");
+                });
+                $("#adminTable .filterControl input").on("change", function() {
+                    if ($(this).val()) {
+                        $(this).addClass("active");
+                        return;
+                    }
+                    $(this).removeClass("active");
+                });
             },
             allowDeletedUserFilter: function() {
                 return $("#chkDeletedUsersFilter").length;
@@ -938,7 +952,9 @@ import {EPROMS_MAIN_STUDY_ID, EPROMS_SUBSTUDY_ID} from "./data/common/consts.js"
                         }
                         //note this is based on the trigger event for filtering specify in the plugin
                         $(fname).val(prefData.filters[item]);
-                        $(fname).addClass("active");
+                        if (prefData.filters[item]) {
+                            $(fname).addClass("active");
+                        }
                         $(fname).trigger($(fname).get(0).tagName === "INPUT" ? "keyup" : "change");
                     }
                 }
@@ -995,6 +1011,7 @@ import {EPROMS_MAIN_STUDY_ID, EPROMS_SUBSTUDY_ID} from "./data/common/consts.js"
                     __filters["column_selections"].push($(this).attr("data-field"));
                 });
                 data["filters"] = __filters;
+                console.log("data? ", data)
                 if (Object.keys(data).length > 0) {
                     tnthAjax.setTablePreference(userId, this.tableIdentifier, {
                         "data": JSON.stringify(data)

--- a/portal/static/js/src/modules/OrgTool.js
+++ b/portal/static/js/src/modules/OrgTool.js
@@ -614,7 +614,7 @@ export default (function() { /*global i18next $ */
         var self = this;
         $("#userOrgs input[name='organization']").each(function() {
             $(this).attr("data-save-container-id", "userOrgs");
-            $(this).on("click", function() {
+            $(this).on("click", function(e) {
                 var parentOrg = self.getElementParentOrg(this);
                 var orgsElements = $("#userOrgs input[name='organization']").not("[id='noOrgs']");
                 if ($(this).prop("checked")) {
@@ -628,7 +628,14 @@ export default (function() { /*global i18next $ */
                 if (sessionStorage.getItem("noOrgModalViewed")) {
                     sessionStorage.removeItem("noOrgModalViewed");
                 }
-
+                //validate for at least one selection checked
+                if (! $("#userOrgs input[name='organization']:checked").length || $(this).attr("id") === "noOrgs") {
+                    if (!$(this).is(":checked")) {
+                        e.preventDefault();
+                        return false;
+                    }
+                }
+               
                 if ($(this).attr("id") !== "noOrgs" && $("#fillOrgs").attr("patient_view")) {
                     if (tnthAjax.hasConsent(userId, parentOrg)) {
                         self.updateOrgs(userId, $("#clinics"), true);

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1203,6 +1203,15 @@ export default (function() {
                         selectListHTML += `<option value="${item.identifier[0].value}" ${String(item.identifier[0].value) === String(selectedValue) ? "selected": ""}>${item.name[0].given} ${item.name[0].family}</option>`
                     });
                     selectListHTML += "</select>";
+                    let selectedEntry = (data.entry).filter(item => {
+                        return String(item.identifier[0].value) === String(selectedValue);
+                    });
+
+                    if (selectedValue && !selectedEntry.length) {
+                        //clinician site changed, doesn't belong to the available sub-study clinic(s)
+                        $("#treatingCliniciansSection .get-clinicians-error").text(i18next.t("Assigned clinician is not from the site."));
+                    }
+
                     $("#treatingClinicianContainer .select-list").append(selectListHTML);
                     $( "#treatingClinicianContainer" ).delegate( "select", "change", function() {
                         if ($(this).val() === "") {
@@ -2609,6 +2618,16 @@ export default (function() {
                 var roles = $("#rolesGroup input:checkbox:checked").map(function() {
                     return {name: $(this).val()};
                 }).get();
+                /*
+                 * check if a role is selected
+                 */
+                if (!roles.length) {
+                    //make sure at least one role is selected
+                    //admin, staff admin functionality
+                    $(".put-roles-error").html("A role must be selected.");
+                    return false;
+                }
+                $(".put-roles-error").html("");
                 this.modules.tnthAjax.putRoles(this.subjectId, {"roles": roles}, $(event.target));
                 /*
                  * refresh user roles list since it has been uploaded
@@ -2629,7 +2648,9 @@ export default (function() {
                         self.userRoles = data.roles.map(function(role) {
                             return role.name;
                         });
-                        self.updateRolesUI(self.userRoles);
+                        Vue.nextTick(() => {
+                            self.updateRolesUI(self.userRoles);
+                        });
                     }
                 }, params);
             },
@@ -2654,6 +2675,7 @@ export default (function() {
                             });
                         }
                     }
+
                     /*
                      * alphabetize role list by the name property of each item in the array
                      * for ease of viewing and selection

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -1224,14 +1224,13 @@ select:not([multiple]) {
     display: none;
   }
   .profile-header {
-    margin-bottom: 0.75em;
     .subheader {
       margin-top: 16px;
       line-height: 1.55;
     }
   }
   .detail-title {
-    margin-bottom: 16px;
+    margin-bottom: 12px;
   }
  .detail-title {
     color: #ebefeb;
@@ -6215,5 +6214,22 @@ div.or {
     .modal-content {
       border: 0;
     }
+  }
+  #userSessionReportDetailHeader {
+    background-image: none !important;
+    border: 0;
+    height: auto;
+  }
+  #userSessionReportMainContainer [data-toggle] {
+    display: none;
+  }
+  #tnthNavWrapper, #tnthTopLinks, #tnthNavXs, #tnthUserBtn, #homeFooter {
+    display: none !important;
+  }
+  #mainNav {
+    height: 0;
+  }
+  .watermark {
+    display: none;
   }
 }


### PR DESCRIPTION
story: https://jira.movember.com/browse/TN-2762
Fixes for sub-study tailored content
- Allow collapsible UI element including its child element(s) to react to click event  and add polyfill for IE
- Allow empro substudy content menu to show in the context of sub-study tailored content
Also minor fixes to address:
- validation for missing role or organization selection
- display warning text related to assigned clinician (when clinician is not from one of the sub-study sites)
- styling updates
