### PR TITLE
TN-2902 clinician email on hard trigger only

### DIFF
--- a/portal/trigger_states/empro_states.py
+++ b/portal/trigger_states/empro_states.py
@@ -215,7 +215,7 @@ def evaluate_triggers(qnr, override_state=False):
             TriggerState.state == 'resolved').order_by(
             TriggerState.timestamp.desc()).first()
         if previous and previous.triggers.get('action_state') not in (
-                'completed', 'missed'):
+                'completed', 'missed', 'not applicable'):
             triggers = copy.deepcopy(previous.triggers)
             triggers['action_state'] = 'missed'
             previous.triggers = triggers
@@ -320,9 +320,12 @@ def fire_trigger_events():
             # received a post intervention QB from staff, noted by
             # the action_state:
             if (
-                    'action_state' in ts.triggers and
-                    ts.triggers['action_state'] in ('completed', 'missed')):
+                    'action_state' not in ts.triggers or
+                    ts.triggers['action_state'] in (
+                    'completed', 'missed', 'not applicable')):
                 continue
+
+            assert ts.triggers['action_state'] in ('required', 'overdue')
 
             if ts.reminder_due():
                 patient = User.query.get(ts.user_id)

--- a/portal/trigger_states/models.py
+++ b/portal/trigger_states/models.py
@@ -85,10 +85,17 @@ class TriggerState(db.Model):
 
     def reminder_due(self):
         """Determine if reminder is due from internal state"""
-        first_sent = FHIR_datetime.parse(
-            self.triggers['actions']['email'][0]['timestamp'])
-        last_sent = FHIR_datetime.parse(
-            self.triggers['actions']['email'][-1]['timestamp'])
+        # locate first and most recent *staff* email
+        first_sent, last_sent = None, None
+        for email in self.triggers['actions']['email']:
+            if 'staff' in email['context']:
+                if not first_sent:
+                    first_sent = FHIR_datetime.parse(email['timestamp'])
+                last_sent = FHIR_datetime.parse(email['timestamp'])
+
+        if not first_sent:
+            return
+
         now = datetime.utcnow()
 
         # To be sent daily after the initial 48 hours


### PR DESCRIPTION
Found several issues resulting in emails being sent to EMPRO clinicians/staff where the user had NOT generated hard triggers in their EMPRO submission.

NB - existing trigger_states rows in the db may continue to display bad behavior, but all new patients are expected to work correctly.