### PR TITLE
TN-2798 currate research_study apis

### DIFF
--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -119,8 +119,7 @@ def assessment_engine_view(user):
         localize_datetime(assessment_status.completed_date, user)
         if assessment_status.completed_date else None)
     assessment_is_due = (
-        BASE_RS_ID in research_study_status and
-        research_study_status[BASE_RS_ID]['ready'])
+        research_study_status.get(BASE_RS_ID, {}).get('ready', False))
     enrolled_in_indefinite = assessment_status.enrolled_in_classification(
         "indefinite")
     substudy_assessment_status = QB_Status(

--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -118,7 +118,9 @@ def assessment_engine_view(user):
     comp_date = (
         localize_datetime(assessment_status.completed_date, user)
         if assessment_status.completed_date else None)
-    assessment_is_due = research_study_status[BASE_RS_ID]['ready']
+    assessment_is_due = (
+        BASE_RS_ID in research_study_status and
+        research_study_status[BASE_RS_ID]['ready'])
     enrolled_in_indefinite = assessment_status.enrolled_in_classification(
         "indefinite")
     substudy_assessment_status = QB_Status(

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -518,7 +518,7 @@ def patient_research_study_status(patient, ignore_QB_status=False):
 
         assessment_status = QB_Status(
             patient, research_study_id=rs, as_of_date=as_of_date)
-        if assessment_status.overall_status == 'Withdrawn':
+        if assessment_status.overall_status == OverallStatus.withdrawn:
             rs_status['errors'].append('Withdrawn')
             continue
 

--- a/portal/models/research_study.py
+++ b/portal/models/research_study.py
@@ -53,12 +53,18 @@ class ResearchStudy(db.Model):
 
     @staticmethod
     def assigned_to(user):
-        """Returns set of all ResearchStudy IDs assigned to given user"""
+        """Returns list of all ResearchStudy IDs assigned to given user
+
+        NB: assignment doesn't equate to ready status.  User may have
+        since withdrawn or failed to meet necessary business rules such
+        as clinician assignments.  For user's current status, see
+         ``qb_status.patient_research_study_status()``
+        """
         base_study = 0
-        results = []
+        results = set()
         iqbs = qbs_by_intervention(user, classification=None)
         if iqbs:
-            results.append(base_study)  # Use dummy till system need arises
+            results.add(base_study)  # Use dummy till system need arises
 
         for rp, _ in ResearchProtocol.assigned_to(
                 user, research_study_id='all'):
@@ -70,9 +76,8 @@ class ResearchStudy(db.Model):
             # count in an `assigned_to` check
             c_date, w_date = consent_withdrawal_dates(user, rs_id)
             if c_date or w_date and rs_id not in results:
-                results.append(rs_id)
-        results.sort()
-        return results
+                results.add(rs_id)
+        return sorted(results)
 
 
 @cache.memoize(timeout=TWO_HOURS)

--- a/portal/static/js/src/mixins/CurrentUser.js
+++ b/portal/static/js/src/mixins/CurrentUser.js
@@ -27,8 +27,8 @@ var CurrentUser = { /* global $ i18next */
                     callback({error: true});
                     return false;
                 }
-                self.setUserResearchStudies(function() {
-                    self.setUserRoles(function() { /* set user roles */
+                self.setUserRoles(function() { /* set user roles */
+                    self.setUserResearchStudies(function() {
                         self.setUserOrgs(self.getUserId());
                         self.initOrgsList(function() { /* set user orgs */
                             callback();
@@ -89,15 +89,36 @@ var CurrentUser = { /* global $ i18next */
         isAdminUser: function() {
             return this.isAdmin;
         },
+        isPatientUser: function() {
+            return this.userRoles.indexOf("patient") !== -1
+        },
         setUserResearchStudies: function(callback) {
             callback = callback || function() {};
-            tnthAjax.getResearchStudies(this.userId, "", data => {
+            if (this.isPatientUser()) {
+                this.setPatientResearchStudies(callback);
+                return;
+            }
+            this.setStaffResearchStudies(callback);
+        },
+        setStaffResearchStudies: function(callback) {
+            callback = callback || function() {};
+            tnthAjax.getStaffResearchStudies(this.userId, "", data => {
                 if (data && data.research_study) {
                     this.userResearchStudyIds = data.research_study.map(item => item.id);
                 }
                 callback();
             });
-        },  
+        },
+        setPatientResearchStudies: function(callback) {
+            callback = callback || function() {};
+            let self = this;
+            tnthAjax.getPatientResearchStudies(this.userId, "", data => {
+                if (data && data.research_study) {
+                    this.userResearchStudyIds = Object.keys(data.research_study).map(item => parseInt(item));
+                }
+                callback();
+            });
+        },
         getUserOrgs: function () {
             if (this.userOrgs.length === 0) {
                 this.setUserOrgs(this.userId);

--- a/portal/static/js/src/mixins/CurrentUser.js
+++ b/portal/static/js/src/mixins/CurrentUser.js
@@ -92,29 +92,14 @@ var CurrentUser = { /* global $ i18next */
         isPatientUser: function() {
             return this.userRoles.indexOf("patient") !== -1
         },
+        getRoleType: function() {
+            return this.isPatientUser()?"patient":"staff";
+        },
         setUserResearchStudies: function(callback) {
             callback = callback || function() {};
-            if (this.isPatientUser()) {
-                this.setPatientResearchStudies(callback);
-                return;
-            }
-            this.setStaffResearchStudies(callback);
-        },
-        setStaffResearchStudies: function(callback) {
-            callback = callback || function() {};
-            tnthAjax.getStaffResearchStudies(this.userId, "", data => {
-                if (data && data.research_study) {
-                    this.userResearchStudyIds = data.research_study.map(item => item.id);
-                }
-                callback();
-            });
-        },
-        setPatientResearchStudies: function(callback) {
-            callback = callback || function() {};
-            let self = this;
-            tnthAjax.getPatientResearchStudies(this.userId, "", data => {
-                if (data && data.research_study) {
-                    this.userResearchStudyIds = Object.keys(data.research_study).map(item => parseInt(item));
+            tnthAjax.getUserResearchStudies(this.userId, this.getRoleType(), "", data => {
+                if (data) {
+                    this.userResearchStudyIds = Object.keys(data).map(item => parseInt(item));
                 }
                 callback();
             });

--- a/portal/static/js/src/modules/Global.js
+++ b/portal/static/js/src/modules/Global.js
@@ -81,28 +81,11 @@ export default { /*global $ i18next */ /*initializing functions performed only o
         return cachedCurrentUserId;
     },
     /*
-     * return research study object containing research studies participated by user
-     * @param userId Id of the user
-     * @param callback post ajax callback function that will receive data
-     */
-    getUserResearchStudies: function(userId, callback) {
-        callback = callback || function() {};
-        if (!userId) {
-            callback();
-            return;
-        }
-        $.ajax({
-            type: "GET",
-            url: `/api/user/${userId}/research_study`
-        }).done(data => {
-           callback(data);
-        }).fail(callback);
-    },
-    /*
-     * dynamically show/hide sub-study specific UI elements
+     * dynamically show/hide sub-study specific UI resources elements
+     * for the consumption by staff users
      * @param elementSelector A DOMString containing one or more selectors to match, e.g. #tnthWrapper .blah
      */
-    setSubstudyElementsVis: function(elementSelector, callback) {
+    setSubstudyResourcesVis: function(elementSelector, callback) {
         callback = callback || function() {};
         if (!elementSelector) {
             callback({error: true});
@@ -110,7 +93,10 @@ export default { /*global $ i18next */ /*initializing functions performed only o
         }
         this.getCurrentUser((userId) => {
             if (!userId) return;
-            this.getUserResearchStudies(userId, data => {
+            $.ajax({
+                type: "GET",
+                url: `/api/staff/${userId}/research_study`
+            }).done(data => {
                 if (!data || !data.research_study || !data.research_study.length) {
                     callback({error: true});
                     return;
@@ -181,9 +167,9 @@ export default { /*global $ i18next */ /*initializing functions performed only o
                 });
                 self.handleDisableLinks();
                 /*
-                 * show sub-study specific links
+                 * show sub-study specific resources links
                  */
-                self.setSubstudyElementsVis("#tnthNavWrapper .eproms-substudy")
+                self.setSubstudyResourcesVis("#tnthNavWrapper .empro-resources");
             }, 350);
             self.getNotification(function(data) { //ajax to get notifications information
                 self.notifications(data);

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -1,4 +1,5 @@
 import Utility from "./Utility.js";
+import {convertArrayToObject} from "./Utility.js";
 import tnthDates from "./TnthDate.js";
 import SYSTEM_IDENTIFIER_ENUM from "./SYSTEM_IDENTIFIER_ENUM.js";
 import CLINICAL_CODE_ENUM from "./CLINICAL_CODE_ENUM.js";
@@ -296,6 +297,22 @@ export default { /*global $ */
                 $(".get-orgs-error").html(data.error);
                 callback({"error": errorMessage});
             }
+        });
+    },
+    "getUserResearchStudies": function(userId, roleType, params, callback) {
+        callback = callback || function() {};
+        if (!userId) {
+            callback({error: i18next.t("User id is required.")});
+            return false;
+        }
+        roleType = roleType || "patient";
+        this.sendRequest(`/api/${roleType}/${userId}/research_study`, "GET", userId, params, 
+        function(data) {
+            if (!data || data.error || !data.research_study) {
+                callback({"error": data.error});
+                return;
+            }
+            callback(convertArrayToObject(data.research_study, "id"));
         });
     },
     "getPatientResearchStudies": function(userId, params, callback) {

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -315,42 +315,6 @@ export default { /*global $ */
             callback(convertArrayToObject(data.research_study, "id"));
         });
     },
-    "getPatientResearchStudies": function(userId, params, callback) {
-        callback = callback || function() {};
-        if (!userId) {
-            callback({error: i18next.t("User id is required.")});
-            return false;
-        }
-        this.sendRequest("/api/patient/" + userId + "/research_study", "GET", userId, params, function(data) {
-            if (data) {
-                if (!data.error) {
-                    callback(data);
-                    return true;
-                } else {
-                    callback({"error": data.error});
-                    return false;
-                }
-            }
-        });
-    },
-    "getStaffResearchStudies": function(userId, params, callback) {
-        callback = callback || function() {};
-        if (!userId) {
-            callback({error: i18next.t("User id is required.")});
-            return false;
-        }
-        this.sendRequest("/api/staff/" + userId + "/research_study", "GET", userId, params, function(data) {
-            if (data) {
-                if (!data.error) {
-                    callback(data);
-                    return true;
-                } else {
-                    callback({"error": data.error});
-                    return false;
-                }
-            }
-        });
-    },
     getSubStudyTriggers: function(userId, params, callback) {
         callback = callback || function() {};
         params = params || {};

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -298,13 +298,31 @@ export default { /*global $ */
             }
         });
     },
-    "getResearchStudies": function(userId, params, callback) {
+    "getPatientResearchStudies": function(userId, params, callback) {
         callback = callback || function() {};
         if (!userId) {
             callback({error: i18next.t("User id is required.")});
             return false;
         }
-        this.sendRequest("/api/user/" + userId + "/research_study", "GET", userId, params, function(data) {
+        this.sendRequest("/api/patient/" + userId + "/research_study", "GET", userId, params, function(data) {
+            if (data) {
+                if (!data.error) {
+                    callback(data);
+                    return true;
+                } else {
+                    callback({"error": data.error});
+                    return false;
+                }
+            }
+        });
+    },
+    "getStaffResearchStudies": function(userId, params, callback) {
+        callback = callback || function() {};
+        if (!userId) {
+            callback({error: i18next.t("User id is required.")});
+            return false;
+        }
+        this.sendRequest("/api/staff/" + userId + "/research_study", "GET", userId, params, function(data) {
             if (data) {
                 if (!data.error) {
                     callback(data);

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -413,3 +413,21 @@ export function sortArrayByField(arrObj, fieldName) {
     });
     return sortedArray;
 }
+/*
+ * convert an object into array based on an given key
+ */
+export function convertArrayToObject (array, key) {
+    if (!array) {
+        return false;
+    }
+    if (!Array.isArray(array)) {
+        return array;
+    }
+    array.reduce((acc, curr, index) => {
+        let useKey = curr[key];
+        if (!useKey) useKey = index;
+        acc[useKey] = curr;
+        return acc;
+    }, {});
+    return array;
+}

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -622,6 +622,12 @@ export default (function() {
                     return  orgTool.isSubStudyOrg(orgId);
                 }).length;
             },
+            /*
+             * subject is ready to take EMPRO assessment
+             */
+            isSubStudyReadyPatient: function() {
+                return this.isSubStudyPatient() && this.getResearchStudyStatus(EPROMS_SUBSTUDY_ID)["ready"];
+            },
             isSubStudyPatient: function() {
                 return this.computedIsSubStudyPatient;
             },
@@ -630,6 +636,9 @@ export default (function() {
             },
             getSubStudyStatusErrors: function() {
                 return this.getResearchStudyStatusErrors(EPROMS_SUBSTUDY_ID);
+            },
+            getResearchStudyStatus: function(studyId) {
+                return this.subjectResearchStudyStatuses[studyId];
             },
             /*
              * return any error associated with a research study status, e.g. patient withdrew
@@ -1758,10 +1767,11 @@ export default (function() {
             allowSubStudyWelcomeEmail: function() {
                 /*
                  *  to allow option for sub-study welcome email in the dropdown
-                 *  the subject needs to have consented to the sub-study, have a valid email and an
-                 *  assigned treating clinician
+                 *  the subject needs to have consented to the sub-study,
+                 *  ready for EMPRO assessment, 
+                 *  have a valid email and an assigned treating clinician
                  */
-                return this.isSubStudyPatient() && !this.userHasNoEmail() && this.hasTreatingClinician();
+                return this.isSubStudyReadyPatient() && !this.userHasNoEmail() && this.hasTreatingClinician();
             },
             initPatientEmailFormSection: function() {
                 var self = this;

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -570,11 +570,10 @@ export default (function() {
                 }
             },
             setSubjectResearchStudies: function() {
-                let self = this;
-                this.modules.tnthAjax.getPatientResearchStudies(this.subjectId, "", data => {
-                    if (data && data.research_study) {
-                        this.subjectResearchStudyStatuses = data.research_study;
-                        this.subjectReseachStudies = Object.keys(data.research_study).map(item => parseInt(item));
+                this.modules.tnthAjax.getUserResearchStudies(this.subjectId, "patient", "", data => {
+                    if (data) {
+                        this.subjectResearchStudyStatuses = data;
+                        this.subjectReseachStudies = Object.keys(data).map(item => parseInt(item));
                     }
                 });
             },
@@ -2984,13 +2983,24 @@ export default (function() {
                     };
                     self.modules.tnthAjax.getTerms(this.subjectId, "", true, function(data) {
                         if (data && data.tous) {
+                            let websiteConsentTerms = [
+                                ["website terms of use",
+                                "subject website consent"],
+                                ["empro website terms of use"]
+                            ];
                             (data.tous).forEach(function(item) {
-                                if (self.consent.touObj.length) {
+                                let fType = $.trim(item.type).toLowerCase();
+                                let exists = (self.consent.touObj).filter(tou => {
+                                    return tou.agreement_url === item.agreement_url;
+                                });
+                                if (exists.length) {
                                     return true;
                                 }
-                                var fType = $.trim(item.type).toLowerCase();
-                                var org = orgsList[item.organization_id];
-                                if (["subject website consent", "website terms of use"].indexOf(String(fType)) !== -1) {
+                                let org = orgsList[item.organization_id];
+                                let matchedTermTypes = websiteConsentTerms.filter(o => {
+                                    return o.indexOf(String(fType)) !== -1;
+                                });
+                                if (matchedTermTypes.length) {
                                     item.name = (org && org.name ? i18next.t(org.name) : "--");
                                     item.truenth_name = i18next.t("TrueNTH USA");
                                     item.accepted = self.modules.tnthDates.formatDateString(item.accepted); //format to accepted format D m y

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -3686,7 +3686,7 @@ section.header {
     height: 72px;
   }
   .error-message {
-    margin-top: 16px;
+    margin-top: 24px;
   }
   #postTxSubmitContainer {
     margin-bottom: 16px;

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -3236,8 +3236,9 @@ body.portal .copyright-container  {
     align-self: flex-end;
   }
   .error-message {
-    color: lighten(@errorMessageColor, 25%);
+    color: lighten(@errorMessageColor, 35%);
     margin: 16px 40px 0px;
+    font-weight: 600;
   }
 }
 .portal-flex-container .button-container,

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -90,7 +90,7 @@
                             <li class="resources-menu-item"><a href="{{PORTAL}}/resources">{{ _("Resources") }}</a></li>
                             {% endif %}
                             {% if user and user.has_role(ROLE.CLINICIAN.value, ROLE.STAFF.value, ROLE.STAFF_ADMIN.value) %}
-                                <li class="eproms-substudy"><a href="{{PORTAL}}/substudy-tailored-content">{{ _("EMPRO Resources") }}</a></li>
+                                <li class="eproms-substudy empro-resources"><a href="{{PORTAL}}/substudy-tailored-content">{{ _("EMPRO Resources") }}</a></li>
                             {% endif %}
                             <li><a href="{{PORTAL}}/logout" class="logout">{{ _("Log Out of TrueNTH") }}</a></li>
                         </ul>
@@ -146,7 +146,7 @@
                         <li class="resources-menu-item"><a href="{{PORTAL}}/resources">{{ _("Resources") }}</a></li>
                     {% endif %}
                     {% if user and user.has_role(ROLE.CLINICIAN.value, ROLE.STAFF.value, ROLE.STAFF_ADMIN.value) %}
-                        <li class="eproms-substudy"><a href="{{PORTAL}}/substudy-tailored-content">{{ _("EMPRO Resources") }}</a></li>
+                        <li class="eproms-substudy empro-resources"><a href="{{PORTAL}}/substudy-tailored-content">{{ _("EMPRO Resources") }}</a></li>
                     {% endif %}
                     {% if user %}<li><a href="{{PORTAL}}/logout" class="logout">{{ _("Log Out of TrueNTH") }}</a></li>{% endif %}
                 </ul>

--- a/portal/templates/profile/patient_profile.html
+++ b/portal/templates/profile/patient_profile.html
@@ -18,7 +18,7 @@
 {% endblock %}
 {% block profile_content %}
   {% if config.CUSTOM_PATIENT_DETAIL and current_user and current_user.has_role(ROLE.STAFF.value, ROLE.STAFF_ADMIN.value) -%}
-    {{ profile_macro.profileCustomDetail(person=user, substudy_assessment_is_ready=substudy_assessment_is_ready) }}
+    {{ profile_macro.profileCustomDetail(person=user) }}
     <div class="row">
       <div class="col-md-12 col-xs-12">
         <h4 class="profile-item-title detail-title">{{_("Patient Details")}}</h4>

--- a/portal/templates/profile/patient_profile.html
+++ b/portal/templates/profile/patient_profile.html
@@ -50,11 +50,7 @@
   {%- endif %}
   {{profile_macro.profileDemo(user, current_user)}}
   {%- if current_user.has_role(ROLE.STAFF.value, ROLE.STAFF_ADMIN.value) -%}
-    <div class="row" id="treatingCliniciansSection" class="eproms-substudy" v-show="isSubStudyPatient()"> 
-      <div class="col-md-12 col-xs-12">
-          {{profile_macro.profileTreatingClinician(user)}}
-      </div>
-    </div>
+      {{profile_macro.profileTreatingClinician(user)}}
   {%- endif -%}
   {%- if current_user.has_role(ROLE.STAFF.value, ROLE.STAFF_ADMIN.value, ROLE.CLINICIAN.value) -%}
     <div class="row" id="longitudinalReportSection" class="eproms-substudy" v-show="hasSubStudyAsssessmentData()"> 

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -905,7 +905,7 @@
                     will display triggers were present in the last determined trigger state
                     will be in a disabled state if the action state is "completed"
                 -->
-                <div id="questionsSection" class="content" :class="{disabled: isSubStudyTriggersResolved(), active: shouldShowSubstudyPostTx()}" v-show="shouldShowSubstudyPostTx()">
+                <div id="questionsSection" class="content" :class="{disabled: isSubStudyTriggersResolved() || hasSubStudyStatusErrors(), active: shouldShowSubstudyPostTx()}" v-show="shouldShowSubstudyPostTx()">
                     <div class="question" v-for="item in postTxQuestionnaire.questions" :linkId="item.linkId" :dataType="item.type" :text="item.text" >
                         <!-- question text -->
                         <span class="title" :class="item.type" v-text="item.text"></span>
@@ -970,6 +970,7 @@
                         <div id="postTxResolutionContainer" v-show="isSubStudyTriggersResolved()"></div>
                     </div>
                 </div>
+                <div class="study-error error-message" v-html="getSubStudyStatusErrors()"></div>
                 <div class="post-intervention-questionnaire-error error-message"></div>
             </div>
         {% endcall %}
@@ -977,7 +978,9 @@
   </div>
 {%- endmacro -%}
 {% macro profileTreatingClinician(person) %}
-    {% call profileSection(data_sections="locale, timezone") %}
+<div class="row" id="treatingCliniciansSection" class="eproms-substudy" v-show="isSubStudyPatient()"> 
+    <div class="col-md-12 col-xs-12">
+        {% call profileSection(data_sections="locale, timezone") %}
         {% call titleSection(id="treatingCliniciansLoc") -%}{{_("Treating Clinician")}}{%- endcall %}
         {% call viewSection(id="profileTreatingCliniciansViewContainer") -%}
             <table>
@@ -991,9 +994,11 @@
             </div>
             {{saveLoaderDiv("treatingClinicianContainer")}}
         {%- endcall %}
-        <div class="put-demo-error error-message"></div>
-        <div class="get-clinicians-error error-message"></div>
-    {% endcall %}
+            <div class="put-demo-error error-message"></div>
+            <div class="get-clinicians-error error-message"></div>
+        {% endcall %}
+    </div>
+</div>
 {%- endmacro %}
 {% macro profileSessionList(person, current_user) -%}
     <div id="userSessionsListContainer" data-profile-section-id="assessmentlist">

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -313,7 +313,7 @@
         {{emailReadyMessage()}}
     </div>
 {%- endmacro %}
-{% macro profileSendEmail(person, substudy_assessment_is_ready=false) -%}
+{% macro profileSendEmail(person) -%}
     {%- if person -%}
         <div class="email-form-container">
             {% call profileEmailForm(person) %}
@@ -321,10 +321,8 @@
                     <option value="invite" data-url="{{url_for('portal.patient_invite_email', user_id=person.id)}}">{{_("TrueNTH Invite")}}</option>
                 {%endif %}
                 <option value="reminder" data-url="{{url_for('portal.patient_reminder_email', user_id=person.id)}}">{{_("TrueNTH Reminder")}}</option>
-                {% if substudy_assessment_is_ready %}
-                    <!-- reactive option, will only show when user is in sub-study and email is available -->
-                    <option value="welcome" data-url="{{url_for('portal.patient_invite_email', user_id=person.id, research_study_id=1)}}"  :hidden="!allowSubStudyWelcomeEmail()" :disabled="!allowSubStudyWelcomeEmail()">{{_("EMPRO Welcome")}}</option>
-                {% endif %}
+                <!-- reactive option, will only show when user is in ready for sub-study and email is available -->
+                <option value="welcome" data-url="{{url_for('portal.patient_invite_email', user_id=person.id, research_study_id=1)}}"  :hidden="!allowSubStudyWelcomeEmail()" :disabled="!allowSubStudyWelcomeEmail()">{{_("EMPRO Welcome")}}</option>
             {% endcall %}
             <!--
                 set P3P invite/reminder tile visibility based on whether user's org matches config variable, ACCEPT_TERMS_ON_NEXT_ORG - this is the case of MUSIC patient
@@ -970,7 +968,10 @@
                         <div id="postTxResolutionContainer" v-show="isSubStudyTriggersResolved()"></div>
                     </div>
                 </div>
-                <div class="study-error error-message" v-html="getSubStudyStatusErrors()"></div>
+                <div class="study-error error-message" v-show="hasSubStudyStatusErrors()">
+                    <b>{{_("Errors: ")}}</b>
+                    <div v-html="getSubStudyStatusErrors()" ></div>
+                </div>
                 <div class="post-intervention-questionnaire-error error-message"></div>
             </div>
         {% endcall %}
@@ -1237,7 +1238,7 @@
         <div id="errorprofileSiteId" class="error-message"></div>
     </div>
 {%- endmacro %}
-{% macro profileCustomDetail(person, substudy_assessment_is_ready=false) -%}
+{% macro profileCustomDetail(person) -%}
      <div class="row" data-profile-section-id="custompatientdetail">
         <div class="col-md-12 col-xs-12">
             <h4 class="profile-item-title detail-title">{{_("Three ways to complete questionnaire")}}</h4>
@@ -1247,7 +1248,7 @@
                     <h4 id="customSendEmailLoc" class="profile-item-title index-item">{{_("Send email")}}</h4>
                     <br/>
                     <div class="text-muted custom-container-content">{{_("Invite or remind patient over email to complete their questionnaire")}}</div>
-                    <div>{{profileSendEmail(person, substudy_assessment_is_ready)}}</div>
+                    <div>{{profileSendEmail(person)}}</div>
                 </div>
                 <div class="profile-item-container custom-container-item-right">
                     <h4 id="customLoginAsLoc" class="profile-item-title index-item">{{_("Log in as patient")}}</h4>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -969,7 +969,8 @@
                     </div>
                 </div>
                 <div class="study-error error-message" v-show="hasSubStudyStatusErrors()">
-                    <b>{{_("Errors: ")}}</b>
+                    <span class="glyphicon glyphicon-alert warning icon" aria-hidden="true"></span>
+                    <b>{{_("Errors:")}}</b>
                     <div v-html="getSubStudyStatusErrors()" ></div>
                 </div>
                 <div class="post-intervention-questionnaire-error error-message"></div>

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -203,15 +203,10 @@ def patient_profile(patient_id):
                 display.link_label is not None):
             user_interventions.append({"name": intervention.name})
 
-    study_status = patient_research_study_status(patient)
-    substudy_assessment_is_ready = (
-        EMPRO_RS_ID in study_status and study_status[EMPRO_RS_ID]['ready'])
-
     return render_template(
         'profile/patient_profile.html', user=patient,
         current_user=user,
         consent_agreements=consent_agreements,
-        substudy_assessment_is_ready=substudy_assessment_is_ready,
         user_interventions=user_interventions)
 
 


### PR DESCRIPTION
The results returned by `/api/user/<id>/research_study` were both inadequate (in the patient's case) and confusing.

Branched into two APIs for the respective needs:
- `/api/staff/<id>/research_study` continues to return the list of research studies (as before) assigned to the organizations in common with the staff user
- `/api/patient/<id>/research_study` was enhanced to return more details about each research study assigned to the patient, such as `ready` and `error` status.
- Frontend code updates to consume new API, adjust presentation sub-study UI based on returned data from API, i.e. taking into consideration of whether subject is eligible and or ready for the sub-study