### PR TITLE
TN-2786 bugfix to present URL authentication modal in patient home page

### DIFF
--- a/portal/eproms/templates/eproms/assessment_engine/ae_complete.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_complete.html
@@ -65,7 +65,8 @@
             title_text=title_text,
             card_class="portal-completed-container") -%}
             <div class="text-content">{{_("No questionnaire is due.")}}</div>
-            {{render_call_to_button(button_label=_("View previous questionnaire"), button_url=url_for("portal.profile", _anchor="proAssessmentsLoc"))}}
+            {{render_call_to_button(button_label=_("View previous questionnaire"), button_url=url_for("portal.profile", _anchor="proAssessmentsLoc"),
+            css_class="portal-weak-auth-disabled")}}
         {%- endcall -%}
         <!-- main study completed card -->
         {{completed_card(

--- a/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
@@ -20,9 +20,9 @@
         <a class="btn-lg btn-tnth-primary" href="/logout">{{ _("Log out") }}</a>
     </div>
 {%- endmacro -%}
-{%- macro render_call_to_button(button_label="", button_url="") -%}
+{%- macro render_call_to_button(button_label="", button_url="", css_class="") -%}
     <div class="button-container">
-        <a class="btn-lg btn-tnth-primary" href="{{button_url}}">{{button_label}}</a>
+        <a class="btn-lg btn-tnth-primary {{css_class}}" href="{{button_url}}">{{button_label}}</a>
     </div>
 {%- endmacro -%}
 {%- macro render_greeting(full_name="") -%}

--- a/portal/static/js/flask_user/urlAuthenticatedModal.js
+++ b/portal/static/js/flask_user/urlAuthenticatedModal.js
@@ -56,6 +56,7 @@ URLAuthenticatedModalObj.prototype.setUI = function() {
         }
         $(".modal").modal("hide");
         $("#"+self.MODAL_ELEMENT_IDENTIFIER).modal("show");
+        return false;
     })
     //elements needing to be hidden
     $(".portal-weak-auth-hide").each(

--- a/portal/static/js/src/portal.js
+++ b/portal/static/js/src/portal.js
@@ -6,7 +6,7 @@ $(document).on("ready", function() {
     $(".button-container").each(function() {
         $(this).prepend('<div class="loading-message-indicator"><i class="fa fa-spinner fa-spin fa-2x"></i></div>');
     });
-    $(".btn-tnth-primary").on("click", function(event) {
+    $(".btn-tnth-primary:not(.portal-weak-auth-disabled)").on("click", function(event) {
         if ($(this).hasClass("disabled")) {
             return false;
         }

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1264,7 +1264,12 @@ export default (function() {
                             display: $("#clincianSelector option:selected").text(),
                             reference: `api/clinician/${$(this).val()}`
                         });
-                        self.postDemoData($("#treatingClinicianContainer"), postData);
+                        self.postDemoData($("#treatingClinicianContainer"), postData, () => {
+                            /*
+                             * set research study status after clinician is set
+                             */
+                            self.setSubjectResearchStudies();
+                        });
                     });
                 });
             },

--- a/portal/templates/profile/user_profile.html
+++ b/portal/templates/profile/user_profile.html
@@ -56,14 +56,7 @@
         {{profile_macro.profileClinicalQuestions(user, current_user) | show_macro('clinical_questions')}}
         {{profile_macro.profileProcedures(user, current_user) | show_macro('procedures')}}
         {{profile_macro.profileInterventionReports(user) | show_macro('intervention_reports')}}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                {% call profile_macro.profileSection(editable=False) -%}
-                    {% call profile_macro.titleSection(id="patientReportsLoc") -%}{{_("Patient Reports")}}{% endcall %}
-                    {{profile_macro.patientReports(user)}}
-                {%- endcall %}
-            </div>
-        </div>
+        {{profile_macro.patientReports(user) | show_macro('intervention_reports')}}
         {{profile_macro.profileDeceased(user, current_user)}}
     {%- endif %}
     <div class="row">


### PR DESCRIPTION
feedback from testing https://jira.movember.com/browse/TN-2786
Issue: When accessing patient home page via url-authenticated link in the email - clicking on "**View Previous Questionnaire**" button on the patient home page, which _requires_ login before accessing the resource,  didn't present the URL authenticated modal directing user to login, as it should.

Fixes include:
- Add missing css class to the button that frontend code identifies as element(s) that invokes the authentication modal.
- prevents default on-click event from firing if the authentication modal is to be presented.