### PR TITLE
UI updates Longitudinal report & post intervention questionnaire

### DIFF
--- a/portal/static/js/src/components/LongitudinalReport.vue
+++ b/portal/static/js/src/components/LongitudinalReport.vue
@@ -2,18 +2,22 @@
 	<div id="longitudinalReportContainer" class="report">
         <div class="loader" v-show="loading"><i class="fa fa-spinner fa-spin fa-2x"></i></div>
 		<div class="error-message" v-show="hasValue(errorMessage)" v-html="errorMessage"></div>
-        <div class="content" :class="{triggers:hasTriggers()}" v-show="!loading">
-            <div v-show="hasTriggers()" class="text-muted text-right report-legend" :class="{active: hasTriggers()}">
+        <div class="content" :class="{'has-legend':shouldShowLegend()}" v-show="!loading">
+            <div v-show="shouldShowLegend()" class="text-muted text-right report-legend" :class="{active: shouldShowLegend()}">
                 <span class="title" v-text="triggerLegendTitle"></span>
                 <span class="hard-trigger-legend" v-text="hardTriggerLegend" v-show="hasHardTriggers()"></span>
                 <span class="soft-trigger-legend" v-text="softTriggerLegend" v-show="hasSoftTriggers()"></span>
+                <span class="in-progress-legend" v-show="hasInProgressData()" v-text="inProgressLegend"></span>
             </div>
             <span class="nav-arrow start" @click="setGoBackward()" v-show="!hasValue(errorMessage)" :class="{disabled: getToStartIndex()}">&lt;</span>
             <span class="nav-arrow end" @click="setGoForward()" v-show="!hasValue(errorMessage)" :class="{disabled: getToEndIndex()}">&gt;</span>
             <table class="report-table" v-show="!hasValue(errorMessage)">
                 <THEAD>
                     <TH class="title" v-text="questionTitleHeader"></TH>
-                    <TH class="cell date" :data-column-index="index+1" v-for="(item, index) in questionnaireDates" :key="'head_'+index" v-html="item"></TH>
+                    <TH class="cell date" :data-column-index="index+1" v-for="(item, index) in questionnaireDates" :key="'head_'+index">
+                        <span v-html="item"></span>
+                        <span class="in-progress-legend" aria-hidden="true" v-show="isAssessmentInProgress(index)"></span>
+                    </TH>
                 </THEAD>
                 <TBODY>
                     <TR v-for="(item, qindex) in questions" :key="'question_'+ qindex">
@@ -231,7 +235,20 @@
         },
         hasHardTriggers() {
             return this.triggerData.hardTriggers.length;
-        }, 
+        },
+        hasInProgressData() {
+            return this.assessmentData.filter(item => {
+                console.log(item)
+                return String(item.status).toLowerCase() === "in-progress";
+            }).length;
+        },
+        shouldShowLegend() {
+            return this.hasTriggers() || this.hasInProgressData();
+        },
+        isAssessmentInProgress(index) {
+            if (!this.assessmentData[index]) return false;
+            return String(this.assessmentData[index].status).toLowerCase() === "in-progress";
+        },
         setDisplayData() {
             /*
              * prepping data for display

--- a/portal/static/js/src/data/common/AssessmentReportData.js
+++ b/portal/static/js/src/data/common/AssessmentReportData.js
@@ -12,5 +12,6 @@ export default {
     loadError: i18next.t("Unable to load report data"),
     triggerLegendTitle: i18next.t("Clinician use only"),
     softTriggerLegend: i18next.t("Support needed"),
-    hardTriggerLegend: i18next.t("Action required")
+    hardTriggerLegend: i18next.t("Action required"),
+    inProgressLegend: i18next.t("In-progress")
 };

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1281,6 +1281,19 @@ export default (function() {
                 });
                 this.subStudyAssessment.data = data;
             },
+            hasSubStudyAsssessmentData: function() {
+                return this.subStudyAssessment.data.length;
+            },
+            getSubStudyAssessmentStatus: function() {
+                if (!this.hasSubStudyAsssessmentData()) return "";
+                return String(this.subStudyAssessment.data[0].status).toLowerCase();
+            },
+            isSubStudyAssessmentCompleted: function() {
+                return this.getSubStudyAssessmentStatus() === "completed";
+            },
+            getSubStudyAssessmentStatusDisplay: function() {
+                return i18next.t("Last EMPRO questionnaire {status} on:").replace("{status}", this.getSubStudyAssessmentStatus());
+            },
             getLastSubStudyAssessmentDate: function() {
                 if (!this.subStudyAssessment.data || !this.subStudyAssessment.data.length) return "";
                 return this.modules.tnthDates.formatDateString(this.subStudyAssessment.data[0].authored);
@@ -1421,16 +1434,25 @@ export default (function() {
             shouldShowSubstudyPostTx: function() {
                 return this.isSubStudyPatient() && ((!this.hasSubStudyStatusErrors() && this.isPostTxActionRequired()) || this.hasPrevSubStudyPostTx());
             },
+            getPostTxActionStatus: function() {
+                if (!this.subStudyTriggers.data || !this.subStudyTriggers.data.action_state) {
+                    return "";
+                }
+                return String(this.subStudyTriggers.data.action_state).toLowerCase();
+            },
+            hasMissedPostTxAction: function() {
+                return this.hasSubStudyTriggers() && this.getPostTxActionStatus() === "missed";
+            },
             isPostTxActionRequired: function() {
                 return this.subStudyTriggers.data &&
-                (["due", "overdue", "required"].indexOf(String(this.subStudyTriggers.data.action_state).toLowerCase()) !== -1
+                (["due", "overdue", "required"].indexOf(this.getPostTxActionStatus()) !== -1
                 );
             },
             isSubStudyTriggersResolved: function() {
                 if (!this.subStudyTriggers.data) {
                     return true;
                 }
-                return String(this.subStudyTriggers.data.action_state).toLowerCase() === "completed" || this.subStudyTriggers.data.resolution;
+                return this.getPostTxActionStatus() === "completed" || this.subStudyTriggers.data.resolution;
             },
             onResponseChangeFieldEvent: function(event) {
                 let targetElement = $(event.target);

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -3388,7 +3388,8 @@ section.header {
       font-weight: 500;
     }
     .soft-trigger-legend,
-    .hard-trigger-legend {
+    .hard-trigger-legend,
+    .in-progress-legend {
       display:inline-block;
       margin-left: 8px;
     }
@@ -3399,6 +3400,18 @@ section.header {
     .hard-trigger-legend:before {
       content: "**";
       display: inline-block;
+    }
+    .in-progress-legend:before {
+      display: inline-block;
+      font-family: 'Glyphicons Halflings';
+      font-style: normal;
+      font-weight: 400;
+      line-height: 1;
+      -webkit-font-smoothing: antialiased;
+      content: "\270f";
+      margin-right: 4px;
+      position: relative;
+      top: 2px;
     }
   }
   .nav-arrow {
@@ -3429,7 +3442,7 @@ section.header {
       cursor: not-allowed;
     }
   }
-  .triggers {
+  .has-legend {
     .nav-arrow {
       top: 36px;
     }

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -892,9 +892,15 @@
                 </div>
                 <!-- no triggers indicated -->
                 <!-- show the last completed EMPRO date && indicate no triggers -->
-                <div id="noTriggersSection" v-else>
-                    <div class="item">{{_("Last EMPRO questionnaire completed on:")}} <span class="text" v-text="getLastSubStudyAssessmentDate()"></span></div>
-                    <div class="item text-muted">{{_("No high distress areas indicated")}}</div>
+                <div v-else>
+                    <div id="noTriggersSection">
+                        <div class="item">
+                            <span class="text" v-text="getSubStudyAssessmentStatusDisplay()"></span>
+                            <span class="text" v-text="getLastSubStudyAssessmentDate()"></span>
+                        </div>
+                        <!-- for assessment that has been completed, as triggers aren't calculated yet for assessment still in progress -->
+                        <div class="item text-muted" v-show="isSubStudyAssessmentCompleted()">{{_("No high distress areas indicated")}}</div>
+                    </div>
                 </div>
                 <div id="reportNoteSection">{{_("View subject EMPRO report for more information")}}</div>
                 <!-- 
@@ -967,6 +973,11 @@
                         {{saveLoaderDiv("postTxSubmitContainer")}}
                         <div id="postTxResolutionContainer" v-show="isSubStudyTriggersResolved()"></div>
                     </div>
+                </div>
+                <!-- indicate missed action status if triggers are displayed -->
+                <div class="action-status" v-show="hasMissedPostTxAction()">
+                    <span>{{_("Action status:")}}</span>
+                    <span class="text error-message" v-text="getPostTxActionStatus()"></span>
                 </div>
                 <div class="study-error error-message" v-show="hasSubStudyStatusErrors()">
                     <span class="glyphicon glyphicon-alert warning icon" aria-hidden="true"></span>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -898,7 +898,7 @@
                             <span class="text" v-text="getSubStudyAssessmentStatusDisplay()"></span>
                             <span class="text" v-text="getLastSubStudyAssessmentDate()"></span>
                         </div>
-                        <!-- for assessment that has been completed, as triggers aren't calculated yet for assessment still in progress -->
+                        <!-- IF no triggers are indicated, ONLY display as such for assessment that has been COMPLETED, as triggers aren't calculated yet for assessment still in progress -->
                         <div class="item text-muted" v-show="isSubStudyAssessmentCompleted()">{{_("No high distress areas indicated")}}</div>
                     </div>
                 </div>
@@ -974,7 +974,7 @@
                         <div id="postTxResolutionContainer" v-show="isSubStudyTriggersResolved()"></div>
                     </div>
                 </div>
-                <!-- indicate missed action status if triggers are displayed -->
+                <!-- indicate missed action status if triggers are present -->
                 <div class="action-status" v-show="hasMissedPostTxAction()">
                     <span>{{_("Action status:")}}</span>
                     <span class="text error-message" v-text="getPostTxActionStatus()"></span>


### PR DESCRIPTION
Followup changes to https://jira.movember.com/browse/TN-2835

Changes include:
- indicates as such, e.g. as a legend, when an assessment is **in progress** in both longitudinal report and post intervention questionnaire UI for clarity
- do not present "no high stress area found" verbiage on the UI in post intervention questionnaire section when the note is still in progress
- display an action status of Missed when occurs in the post intervention questionnaire for clarity