### PR TITLE
TN-2644 EMPRO thank you modal - pop up on questionnaire completion fix

### DIFF
--- a/portal/static/js/src/components/LongitudinalReport.vue
+++ b/portal/static/js/src/components/LongitudinalReport.vue
@@ -238,7 +238,6 @@
         },
         hasInProgressData() {
             return this.assessmentData.filter(item => {
-                console.log(item)
                 return String(item.status).toLowerCase() === "in-progress";
             }).length;
         },

--- a/portal/static/js/src/empro.js
+++ b/portal/static/js/src/empro.js
@@ -84,6 +84,10 @@ emproObj.prototype.init = function() {
                 tnthDate.getDateWithTimeZone(new Date(assessmentDate), "yyyy-mm-dd"),
                 assessmentData[0].status];
             let assessmentCompleted = String(status).toLowerCase() === "completed";
+
+            /*
+             * associating each thank you modal popup accessed by assessment date
+             */
             let cachedAccessKey = `EMPRO_MODAL_ACCESSED_${this.userId}_${today}_${assessmentDate}`;
             /*
              * automatically pops up thank you modal IF sub-study assessment is completed,

--- a/portal/static/js/src/empro.js
+++ b/portal/static/js/src/empro.js
@@ -78,12 +78,13 @@ emproObj.prototype.init = function() {
             let assessmentData = (data.entry).sort(function(a, b) {
                 return new Date(b.authored) - new Date(a.authored);
             });
+            let assessmentDate = assessmentData[0]["authored"];
             let [today, authoredDate, status] = [
                 tnthDate.getDateWithTimeZone(new Date(), "yyyy-mm-dd"),
-                tnthDate.getDateWithTimeZone(new Date(assessmentData[0]["authored"]), "yyyy-mm-dd"),
+                tnthDate.getDateWithTimeZone(new Date(assessmentDate), "yyyy-mm-dd"),
                 assessmentData[0].status];
-            let cachedAccessKey = `EMPRO_MODAL_ACCESSED_${this.userId}_${today}`;
             let assessmentCompleted = String(status).toLowerCase() === "completed";
+            let cachedAccessKey = `EMPRO_MODAL_ACCESSED_${this.userId}_${today}_${assessmentDate}`;
             /*
              * automatically pops up thank you modal IF sub-study assessment is completed,
              * and sub-study assessment is completed today and the thank you modal has not already popped up today

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -3010,6 +3010,9 @@ export default (function() {
                     };
                     self.modules.tnthAjax.getTerms(this.subjectId, "", true, function(data) {
                         if (data && data.tous) {
+                            data.tous = (data.tous).sort(function(a, b) {
+                                return new Date(a.accepted) - new Date(b.accepted);
+                            });
                             let websiteConsentTerms = [
                                 ["website terms of use",
                                 "subject website consent"],


### PR DESCRIPTION
Per testing feedback from https://jira.movember.com/browse/TN-2644
Issue:
EMPRO thank you modal **didn't** automatically pop up right after completion of a EMPRO questionnaire of visit beyond baseline.  Example patients in EPROMS-TEST: IDs, 3404 and 3437

Fix includes:
- Identify whether a thank you modal should display based on a key that includes assessment date

Other changes:
- remove debugging console statement
- minor fix to sort TOU items on consent history table in profile by acceptance date


