### PR TITLE
TN-2468 correct QBs due date to reflect desired `target_date`

### DIFF
--- a/portal/config/eproms/QuestionnaireBank.json
+++ b/portal/config/eproms/QuestionnaireBank.json
@@ -262,7 +262,7 @@
     },
     {
       "classification": "recurring",
-      "due": "{\"days\": 0}",
+      "due": "{\"days\": 15}",
       "expired": "{\"months\": 3, \"days\": -2}",
       "name": "IRONMAN_recurring_3mo_pattern",
       "overdue": "{\"days\": 16}",
@@ -298,7 +298,7 @@
     },
     {
       "classification": "recurring",
-      "due": "{\"days\": 0}",
+      "due": "{\"days\": 15}",
       "expired": "{\"months\": 3, \"days\": -2}",
       "name": "IRONMAN_v3_recurring_3mo_pattern",
       "overdue": "{\"days\": 16}",
@@ -334,7 +334,7 @@
     },
     {
       "classification": "recurring",
-      "due": "{\"days\": 0}",
+      "due": "{\"months\": 1}",
       "expired": "{\"months\": 3, \"days\": -1}",
       "name": "IRONMAN_v5_recurring_3mo_pattern",
       "overdue": "{\"months\": 1, \"days\": 1}",
@@ -370,7 +370,7 @@
     },
     {
       "classification": "recurring",
-      "due": "{\"days\": 0}",
+      "due": "{\"days\": 15}",
       "expired": "{\"months\": 3, \"days\": -2}",
       "name": "IRONMAN_recurring_6mo_pattern",
       "overdue": "{\"days\": 16}",
@@ -413,7 +413,7 @@
     },
     {
       "classification": "recurring",
-      "due": "{\"days\": 0}",
+      "due": "{\"days\": 15}",
       "expired": "{\"months\": 3, \"days\": -2}",
       "name": "IRONMAN_v3_recurring_6mo_pattern",
       "overdue": "{\"days\": 16}",
@@ -456,7 +456,7 @@
     },
     {
       "classification": "recurring",
-      "due": "{\"days\": 0}",
+      "due": "{\"months\": 1}",
       "expired": "{\"months\": 3, \"days\": -1}",
       "name": "IRONMAN_v5_start6mo_yearly_end30mo",
       "overdue": "{\"months\": 1, \"days\": 1}",
@@ -506,7 +506,7 @@
     },
     {
       "classification": "recurring",
-      "due": "{\"days\": 0}",
+      "due": "{\"months\": 1}",
       "expired": "{\"months\": 3, \"days\": -1}",
       "name": "IRONMAN_v5_start3.5years_yearly",
       "overdue": "{\"months\": 1, \"days\": 1}",
@@ -549,7 +549,7 @@
     },
     {
       "classification": "recurring",
-      "due": "{\"days\": 0}",
+      "due": "{\"days\": 15}",
       "expired": "{\"months\": 3, \"days\": -2}",
       "name": "IRONMAN_recurring_annual_pattern",
       "overdue": "{\"days\": 16}",
@@ -606,7 +606,7 @@
     },
     {
       "classification": "recurring",
-      "due": "{\"days\": 0}",
+      "due": "{\"days\": 15}",
       "expired": "{\"months\": 3, \"days\": -2}",
       "name": "IRONMAN_v3_recurring_annual_pattern",
       "overdue": "{\"days\": 16}",
@@ -663,7 +663,7 @@
     },
     {
       "classification": "recurring",
-      "due": "{\"days\": 0}",
+      "due": "{\"months\": 1}",
       "expired": "{\"months\": 3, \"days\": -1}",
       "name": "IRONMAN_v5_recurring_annual_pattern",
       "overdue": "{\"months\": 1, \"days\": 1}",

--- a/portal/config/eproms/QuestionnaireBank.json
+++ b/portal/config/eproms/QuestionnaireBank.json
@@ -723,7 +723,7 @@
       "classification": "baseline",
       "name": "ironman_ss_baseline",
       "start": "{\"days\": 0}",
-      "due": "{\"days\": 0}",
+      "due": "{\"days\": 14}",
       "overdue": "{\"days\": 15}",
       "expired": "{\"months\": 1, \"days\": -1}",
       "recurs": [],
@@ -746,7 +746,7 @@
       "classification": "recurring",
       "name": "ironman_ss_recurring_monthly_pattern",
       "start": "{\"days\": 0}",
-      "due": "{\"days\": 0}",
+      "due": "{\"days\": 14}",
       "overdue": "{\"days\": 15}",
       "expired": "{\"months\": 1, \"days\": -1}",
       "recurs": [

--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -110,8 +110,8 @@ def assessment_engine_view(user):
 
     # variables needed for the templates
     due_date = (
-        localize_datetime(assessment_status.due_date, user)
-        if assessment_status.due_date else None)
+        localize_datetime(assessment_status.target_date, user)
+        if assessment_status.target_date else None)
     expired_date = (
         localize_datetime(assessment_status.expired_date, user)
         if assessment_status.expired_date else None)
@@ -128,8 +128,8 @@ def assessment_engine_view(user):
         as_of_date=now)
     enrolled_in_substudy = EMPRO_RS_ID in research_study_status
     substudy_due_date = (
-        localize_datetime(substudy_assessment_status.due_date, user)
-        if substudy_assessment_status.due_date else None)
+        localize_datetime(substudy_assessment_status.target_date, user)
+        if substudy_assessment_status.target_date else None)
     substudy_comp_date = (
         localize_datetime(substudy_assessment_status.completed_date, user)
         if substudy_assessment_status.completed_date else None)

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -26,6 +26,7 @@ class QB_Status(object):
         self.research_study_id = research_study_id
         for state in OverallStatus:
             setattr(self, "_{}_date".format(state.name), None)
+        self._target_date = None
         self._overall_status = None
         self._enrolled_in_common = False
         self._current = None

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -117,6 +117,10 @@ class QB_Status(object):
 
             if row.status == OverallStatus.due:
                 self._due_date = row.at
+                # HACK to manage target date until due means due (not start)
+                self._target_date = cur_qbd.questionnaire_bank.calculated_due(
+                    self._due_date)
+
             if row.status == OverallStatus.overdue:
                 self._overdue_date = row.at
             if row.status == OverallStatus.completed:
@@ -301,6 +305,18 @@ class QB_Status(object):
     @property
     def due_date(self):
         return self._due_date
+
+    @property
+    def target_date(self):
+        """HACK to address due vs start/available confusion
+
+        TN-2468 captures how the original intent of due was lost and
+        became the start/available date.  Until this is cleaned up (
+        by replacing OverallStatus.due with OverallStatus.start and
+        all related usage) continue to treat due == start/available
+        and provide a `target_date` for the QB.calculated_due value.
+        """
+        return self._target_date
 
     @property
     def expired_date(self):

--- a/portal/templates/site_overdue_table.html
+++ b/portal/templates/site_overdue_table.html
@@ -6,7 +6,7 @@
 	        <th>{{ _("TrueNTH ID") }}</th>
 	        <th>{{ _("Study ID") }}</th>
 	        <th>{{ _("Visit Name") }}</th>
-	        <th>{{ _("Due Date") }}</th>
+	        <th>{{ _("Available From") }}</th>
 	        <th>{{ _("Expired Date") }}</th>
 	    </tr>
     </thead>


### PR DESCRIPTION
Long history with the confusion between `start/available` and `due` dates for a QB.  The current implementation treats them ambiguously, maintaining both a `start` and `due` value on the QB itself, but calling the `start/available` date as `due` in the QB timeline and within all status checks.

TN-2468 addresses the confusion this creates for users, as they might get a reminder email for a 3 month prom that suggests it's `due` when it first becomes `available`.

At this point, this PR corrects:
- all EMPRO patient QBs, to have a due date 2 weeks after the start.
- all recurring IRONMAN QBs, to have a due date such that the original "visit" date is respected.  For example, a v3 3 month that first recurs at "3 months -15 days" now has a due of 15 days.
- the `due_date` variables used by the templates for AssessmentEngine cards now pick up the `target_date`, synonymous with the intent of `due_date` but not the same as `start/available`.