### PR TITLE
TN-2919 preview site update

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -431,12 +431,14 @@ def no_email(email, actor):
     suppress_email(email, actor)
 
 
-@click.option('--qnr_id', help="Questionnaire Response ID")
+@click.option('--qnr_id', help="Questionnaire Response ID", required=True)
 @click.option(
     '--authored',
+    required=True,
     help="new datetime for qnr authored, format example: 2019-04-09 15:14:43")
 @click.option(
     '--actor',
+    required=True,
     help='email address of user taking this action, for audit trail'
 )
 @app.cli.command()
@@ -464,7 +466,8 @@ def update_qnr_authored(qnr_id, authored, actor):
     rs_id = 0
     if qnr.questionnaire_bank_id:
         qb = QuestionnaireBank.query.get(qnr.questionnaire_bank_id)
-        rs_id = research_study_id_from_questionnaire(qb.questionnaires[0])
+        rs_id = research_study_id_from_questionnaire(
+            qb.questionnaires[0].name)
 
     # Must clear the qb_id and iteration in case this authored date
     # change moves the QNR to a different visit.

--- a/manage.py
+++ b/manage.py
@@ -601,9 +601,10 @@ def merge_users(src_id, tgt_id, actor):
     print(message)
 
 
-@click.option('--org_id', help="Organization (site) ID")
+@click.option('--org_id', help="Organization (site) ID", required=True)
 @click.option(
     '--retired',
+    required=True,
     help="datetime for site's current protocol expiration,"
          " format example: 2019-04-09 15:14:43")
 @app.cli.command()

--- a/manage.py
+++ b/manage.py
@@ -686,14 +686,15 @@ def preview_site_update(org_id, retired):
     previous_rp = organization.research_protocols[-1]
     latest_rp = ResearchProtocol.query.order_by(
         ResearchProtocol.id.desc()).first()
-    previous_orgRP = OrganizationResearchProtocol.query.filter(
-        OrganizationResearchProtocol.research_protocol_id == previous_rp.id).filter(
+    previous_org_rp = OrganizationResearchProtocol.query.filter(
+        OrganizationResearchProtocol.research_protocol_id ==
+        previous_rp.id).filter(
         OrganizationResearchProtocol.organization_id == org_id).one()
-    previous_orgRP.retired_as_of=retired
-    new_orgRP = OrganizationResearchProtocol(
+    previous_org_rp.retired_as_of = retired
+    new_org_rp = OrganizationResearchProtocol(
         research_protocol=latest_rp,
         organization=organization)
-    db.session.add(new_orgRP)
+    db.session.add(new_org_rp)
     db.session.commit()
     print(f"Extending Research Protocols for {organization}")
     print(f"  - Adding RP {latest_rp.name}")
@@ -746,5 +747,5 @@ def preview_site_update(org_id, retired):
                 print(f"\t\t\t{modified_t[item][1]} ==> {modified_t[item][0]}")
 
     # Restore organization to pre-test RPs
-    db.session.delete(new_orgRP)
+    db.session.delete(new_org_rp)
     db.session.commit()

--- a/manage.py
+++ b/manage.py
@@ -710,10 +710,11 @@ def preview_site_update(org_id, retired):
     for patient in query:
         QuestionnaireResponse.purge_qb_relationship(
             subject_id=patient.id,
+            research_study_id=0,
             acting_user_id=admin.id,
         )
         update_users_QBT(
-            patient.id, invalidate_existing=True)
+            patient.id, research_study_id=0, invalidate_existing=True)
 
         after_qnrs = qnr_state(patient, name_map=qb_name_map)
         after_timeline = timeline_state(patient, name_map=qb_name_map)


### PR DESCRIPTION
Renamed branch - same PR as 3980, but no longer named as a `hotfix`:

Add new CLI preview-site-update to present expected changes for patients on a Research Protocol change.

Example run:
flask preview-site-update --retired "2021-02-01 13:00:00" --org_id 146102

Results from said example available on parent Jira issue: https://jira.movember.com/secure/attachment/99896/APC-RPv5-changes.txt

Not intended to be run on prod - checks config to confirm.