### PR TITLE
TN-2762 tailored content tile click event fix

### DIFF
--- a/portal/eproms_substudy_tailored_content/src/js/Base.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Base.js
@@ -522,6 +522,9 @@ export default {
                         resourceSection.append(div);
                     }
                     resourceSection.querySelector(".content").innerHTML = response;
+                    setTimeout(function() {
+                        this.setTileLinkEvent();
+                    }.bind(this), 150);
                 }).catch(e => {
                     this.setErrorMessage(`error fetching resources for country code ${countryCode} `, e)
                 });


### PR DESCRIPTION
fix based on feedback here:  https://jira.movember.com/browse/TN-2762
Issue clicking on resources tile in sub-study tailored content does open up the resource link
Cause - stemming from the fact that the content is dynamically generated
Fix - initiating tile on click event **after** the content has been populated 