### PR TITLE
TN-2924 exclude weekends for EMPRO reminder schedules.

### DIFF
--- a/portal/date_tools.py
+++ b/portal/date_tools.py
@@ -1,5 +1,5 @@
 """Module for additional datetime tools/utilities"""
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 import json
 
 from dateutil import parser
@@ -172,3 +172,22 @@ def utcnow_sans_micro():
     """
     now = datetime.utcnow()
     return now.replace(microsecond=0)
+
+
+def weekday_delta(start, end):
+    """Returns the datetime delta of end-start excluding weekends"""
+    if end < start:
+        raise ValueError("unexpected end date less than start")
+
+    days = end - start
+    includes_weekend_days = 0
+    i = start
+    while True:
+        if i > end:
+            break
+        if i.isoweekday() > 5:
+            includes_weekend_days += 1
+        i = i + timedelta(days=1)
+
+    corrected_end = end - timedelta(days=includes_weekend_days)
+    return corrected_end - start

--- a/portal/date_tools.py
+++ b/portal/date_tools.py
@@ -179,15 +179,14 @@ def weekday_delta(start, end):
     if end < start:
         raise ValueError("unexpected end date less than start")
 
-    days = end - start
-    includes_weekend_days = 0
+    included_weekend_days = 0
     i = start
     while True:
         if i > end:
             break
         if i.isoweekday() > 5:
-            includes_weekend_days += 1
+            included_weekend_days += 1
         i = i + timedelta(days=1)
 
-    corrected_end = end - timedelta(days=includes_weekend_days)
+    corrected_end = end - timedelta(days=included_weekend_days)
     return corrected_end - start

--- a/tests/test_date_tools.py
+++ b/tests/test_date_tools.py
@@ -1,11 +1,15 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 
 import pytest
 from werkzeug.exceptions import BadRequest
 
-from portal.date_tools import FHIR_datetime, RelativeDelta, localize_datetime
-from tests import TestCase
+from portal.date_tools import (
+    FHIR_datetime,
+    RelativeDelta,
+    localize_datetime,
+    weekday_delta,
+)
 
 
 def test_localize_datetime_none():
@@ -54,3 +58,15 @@ def test_int_date(app_logger):
     with pytest.raises(BadRequest) as e:
         dt = FHIR_datetime.parse(acceptance_date, 'acceptance date')
     assert 'acceptance date' in str(e.value)
+
+
+def test_weekday_count():
+    monday = datetime.strptime("2021-01-04T12:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+    friday = datetime.strptime("2021-01-08T12:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+    assert weekday_delta(monday, friday) == timedelta(days=4)
+
+
+def test_weekday_count_skips_weekends():
+    monday = datetime.strptime("2021-01-04T12:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+    next_monday = datetime.strptime("2021-01-11T12:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+    assert weekday_delta(monday, next_monday) == timedelta(days=5)


### PR DESCRIPTION
When calculating if it's time to send a reminder email to staff for EMPRO triggered patient follow ups, we need to exclude weekends.

Added new date_tools utility function `weekday_delta()` to calculate time delta between two dates, omitting weekend days.