### PR TITLE
Add critical USER_UNAUTHORIZED_ENDPOINT and enable clinicians to generate adherence reports

### DIFF
--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -161,6 +161,7 @@ class BaseConfig(object):
     USER_ENABLE_CHANGE_USERNAME = False  # prereq for disabling username
     USER_ENABLE_CONFIRM_EMAIL = False  # don't force email conf on new accounts
     USER_SHOW_USERNAME_EMAIL_DOES_NOT_EXIST = False
+    USER_UNAUTHORIZED_ENDPOINT = 'auth.unauthorized_endpoint'
     ENABLE_URL_AUTHENTICATED = os.environ.get('ENABLE_URL_AUTHENTICATED', 'false').lower() == 'true'
 
     STAFF_BULK_DATA_ACCESS = True

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -1025,3 +1025,21 @@ def authorize(*args, **kwargs):
         return redirect('/')
     # See "hardwired" note in docstring above
     return True
+
+
+@auth.route('/unauthorized_endpoint')
+@oauth.require_oauth()
+def unauthorized_endpoint():
+    """Redirection endpoint for logged-in users w/o adequate role/permission
+
+    Flask-User can be configured to point to a view such as this on an event
+    such as a user being logged in but lacking adequate role, say the view
+    is decorated with @roles_required().
+
+    By default, such a case redirects to '', and fails to return an adequate
+    status code, but rather a 302.
+
+    Most importantly, raise a 401 so clients can catch this scenario.
+
+    """
+    abort(401)

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -141,6 +141,8 @@ def report_slow_queries(response):
 
     """
     if current_app.config.get("LOG_SLOW_RESPONSES"):
+        if not hasattr(g, 'start_request_time'):
+            return response
         duration = time() - g.start_request_time
         if duration > 5.0:
             current_app.logger.warning("{} took {}".format(

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -142,7 +142,7 @@ def generate_numbers():
 @reporting_api.route('/api/report/questionnaire_status')
 @roles_required(
     [ROLE.ADMIN.value, ROLE.STAFF_ADMIN.value, ROLE.STAFF.value,
-     ROLE.INTERVENTION_STAFF.value])
+     ROLE.INTERVENTION_STAFF.value, ROLE.CLINICIAN.value])
 @oauth.require_oauth()
 def questionnaire_status():
     """Return ad hoc JSON or CSV listing questionnaire_status


### PR DESCRIPTION
Clinicians were blocked from accessing `/api/report/questionnaire_status` (an easy fix) but this was difficult to track as we didn't have a `USER_UNAUTHORIZED_ENDPOINT` configured, and would therefore simply redirect to '' and return a 301 status rather than a 401 as needed for the front end to be aware of the error situation.