### PR TITLE
Add `T` to datetime format string in failing migration on truenth-demo

### DIFF
--- a/portal/migrations/versions/481d8266a4c0_tn_2899_merge_authored_dates.py
+++ b/portal/migrations/versions/481d8266a4c0_tn_2899_merge_authored_dates.py
@@ -36,11 +36,11 @@ def upgrade():
         " code = 'paper'").next()[0]
     those_with_diffs = (
         "SELECT questionnaire_responses.id as id, subject_id, authored,"
-        " TO_TIMESTAMP(document->>'authored', 'YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AS doc_authored,"
+        " TO_TIMESTAMP(document->>'authored', 'YYYY-MM-DDTHH24:MI:SS')::timestamp without time zone AS doc_authored,"
         " coding_id, document FROM questionnaire_responses"
         " LEFT JOIN encounter_codings"
         " ON questionnaire_responses.encounter_id = encounter_codings.encounter_id"
-        " WHERE authored != TO_TIMESTAMP(document->>'authored', 'YYYY-MM-DD HH24:MI:SS')::timestamp without time zone;"
+        " WHERE authored != TO_TIMESTAMP(document->>'authored', 'YYYY-MM-DDTHH24:MI:SS')::timestamp without time zone;"
     )
     result = conn.execute(those_with_diffs)
     preferred_authored = []

--- a/portal/migrations/versions/68a25f790d27_.py
+++ b/portal/migrations/versions/68a25f790d27_.py
@@ -6,6 +6,7 @@ Create Date: 2020-12-08 14:17:28.279106
 
 """
 from alembic import op
+from flask import current_app
 import sqlalchemy as sa
 
 
@@ -15,6 +16,8 @@ down_revision = '7fd6b3abfec2'
 
 
 def upgrade():
+    if current_app.config.get('GIL'):
+        return
     op.add_column(
         'trigger_states',
         sa.Column('visit_month', sa.Integer()))
@@ -29,6 +32,8 @@ def upgrade():
 
 
 def downgrade():
+    if current_app.config.get('GIL'):
+        return
     op.drop_index(
         op.f('ix_trigger_states_visit_month'),
         table_name='trigger_states')


### PR DESCRIPTION
Potential fix on truenth-demo where the `T` separating date & time in `document->>'authored'` (as specified by ISO 8601) is killing the SQL `TO_TIMESTAMP` parse.