### PR TITLE
TN-2933 call the correct research study api on a staff profile page

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -570,7 +570,8 @@ export default (function() {
                 }
             },
             setSubjectResearchStudies: function() {
-                this.modules.tnthAjax.getUserResearchStudies(this.subjectId, "patient", "", data => {
+                let roleType = this.isSubjectPatient() ? "patient": "staff";
+                this.modules.tnthAjax.getUserResearchStudies(this.subjectId, roleType, "", data => {
                     if (data) {
                         this.subjectResearchStudyStatuses = data;
                         this.subjectReseachStudies = Object.keys(data).map(item => parseInt(item));


### PR DESCRIPTION
Address story:  https://jira.movember.com/browse/TN-2933

- Issue:  An ajax call is fired off to the **patient** research study API on a **staff** profile page, resulting in a 400 error, i.e. incorrect role.
- Background for the ajax api call:  The call to the research study api is mainly relevant in the context of the patient profile page where certain UI elements can only be seen by the EMPRO patients.
- Fix:  Correctly call the research study API for staff on a staff profile page if it is determined that the subject is not a patient.

Implemented as a hot fix.
 
