### PR TITLE
TN-2877 Remove Deprecated Dependency Resolver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ redis==3.5.3
 requests-cache==0.5.2
 requests-oauthlib==1.1.0  # pyup: <1.2.0 # pin until OAuthlib>=3.0.0 # via flask-oauthlib
 requests==2.25.1          # via flask-recaptcha, requests-cache, requests-oauthlib, sphinx
-six==1.13.0               # via bcrypt, packaging, python-dateutil, python-memcached, sphinx, swagger-spec-validator, tox, validators, webtest
+six==1.14.0               # via bcrypt, packaging, python-dateutil, python-memcached, sphinx, swagger-spec-validator, tox, validators, webtest
 sqlalchemy==1.3.11         # via alembic, flask-sqlalchemy
 swagger-spec-validator==2.7.3
 urllib3==1.25.7             # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ flask-wtf==0.14.3         # via flask-user
 flask==1.0.3
 fuzzywuzzy==0.17.0
 healthcheck==1.3.3
-idna==3.1                 # via requests
+idna==2.10                 # via requests
 itsdangerous==1.1.0        # via flask
 jinja2==2.11.2              # via flask, flask-babel, sphinx
 jsonschema==3.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,8 @@ description = Default testing environment, run unit test suite
 deps =
     --requirement=requirements.dev.txt
     pytest-cov
-
-# TODO use 2020 resolver
-# https://discuss.python.org/t/announcement-pip-20-2-release/4863
 setenv =
     TESTING = true
-    PIP_USE_DEPRECATED = legacy-resolver
 passenv =
     FLASK_APP
     LANG


### PR DESCRIPTION
* Remove deprecated `pip` resolver flag
* Update pinned dependencies to resolve conflicts between dependencies
  * pip now considers dependencies of dependencies when choosing versions to install
