### PR TITLE
TN-2941 one QNR per encounter

### DIFF
--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1661,6 +1661,12 @@ def assessment_add(patient_id):
     })
 
     encounter = current_user().current_encounter()
+    if QuestionnaireResponse.query.filter(
+            QuestionnaireResponse.encounter_id == encounter.id).count():
+        # Another QuestionnaireResponse already attached to this encounter,
+        # force a refresh to maintain a discrete QNR <=> Encounter pair.
+        encounter = current_user().current_encounter(force_refresh=True)
+
     if 'entry_method' in request.args:
         encounter_type = getattr(
             EC, request.args['entry_method'].upper()).codings[0]


### PR DESCRIPTION
generate a fresh encounter if a new QuestionnaireResponse comes in, and the user's current_encounter() already belongs to an existing QuestionnaireResponse.