### PR TITLE
Allow multiple clinicians in adherence report

### DIFF
--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -40,7 +40,7 @@ def time_request(url, params=None):
     return response
 
 
-def get_terms(locale_code, org=None, role=None, research_study_id=None):
+def get_terms(locale_code, org=None, role=None, research_study_id=0):
     """Shortcut to lookup correct terms given org and role"""
     if org:
         try:

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -728,7 +728,7 @@ class OrgNode(object):
         """Insert new nodes into the org tree
 
         Designed for this special organization purpose, we expect the
-        tree is built from the top (root) down, so no rebalancing is
+        tree is built from the top (root) down, so no re-balancing is
         necessary.
 
         :param id: of organization to insert
@@ -748,13 +748,11 @@ class OrgNode(object):
             node = OrgNode(id=id, parent=self)
             self.children[id] = node
             return node
-        else:
-            # Could be adding to root node, confirm it's top level
-            assert (self.id is None and partOf_id is None)
-            node = OrgNode(id=id, parent=self)
-            assert id not in self.children
-            self.children[id] = node
-            return node
+
+        # Invalid case if still here
+        raise ValueError(
+            "Bogus OrgTree node insertion attempt "
+            f"{id}: {partOf_id}")
 
     def top_level(self):
         """Lookup top_level organization id from the given node
@@ -944,7 +942,8 @@ class OrgTree(object):
         while node is not self.root:
             ids.append(node.id)
             if node.parent is None:
-                break
+                raise ValueError(
+                    f"invalid OrgTree state - {node.id} lost parent!")
             node = node.parent
         return ids
 

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -944,7 +944,7 @@ class OrgTree(object):
         while node is not self.root:
             ids.append(node.id)
             if node.parent is None:
-                raise ValueError(f"{node.id} has null parent")
+                break
             node = node.parent
         return ids
 

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -122,9 +122,10 @@ def adherence_report(
 
             if research_study_id == EMPRO_RS_ID:
                 # Add clinician data for EMPRO reports
-                if patient.clinician_id:
-                    row['clinician'] = (
-                        User.query.get(patient.clinician_id).display_name)
+                if len(patient.clinicians) > 0:
+                    row['clinician'] = ';'.join(
+                        clinician.display_name for clinician in
+                        patient.clinicians)
                 # As we may be looking at `prev_qbd` can't use qb_stats
                 cd = last_viable.completed_date(patient.id)
                 if cd:


### PR DESCRIPTION
Overlooked single clinician assumption in adherence report.  Fixed and finally caught the simple case of org tree breaking behind `/api/research_study` -- only mystery is why this was hard to reproduce.