### PR TITLE
Audit logging viewing of sub-study tailored content

### DIFF
--- a/portal/eproms_substudy_tailored_content/src/js/Base.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Base.js
@@ -203,15 +203,6 @@ export default {
         getDefaultDomains() {
             return Object.keys(this.domainMappings);
         },
-        getMappedDomain() {
-            let mappedDomain = [];
-            for (let index in this.domainMappings) {
-                if (this.domainMappings[index] === this.getSelectedDomain()) {
-                    mappedDomain.push(index);
-                }
-            }
-            return mappedDomain.join(",");
-        },
         initTriggerDomains(params) {
             if (!this.isTriggersNeeded()) {
                 setTimeout(function() {
@@ -426,7 +417,6 @@ export default {
         },
         getDomainContent() {
             if (this.domainContent) {
-                console.log("WTF")
                 //already populated
                 this.setInitView();
                 return this.domainContent;
@@ -442,10 +432,10 @@ export default {
                             return;
                         }
                         //log access to domain content
-                        //TODO add a context?
-                        //just log the domain(s) here?
+                        //log accessed URL which includes the domain accessed
                         postData("/api/auditlog", {
-                            "message": (this.getMappedDomain() || this.getSelectedDomain())
+                            "message": window.location.href,
+                            "context": "access"
                         });
                     });
                     

--- a/portal/eproms_substudy_tailored_content/src/js/Base.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Base.js
@@ -431,10 +431,9 @@ export default {
                         if (this.isAtMainPage(this.getSelectedDomain())) {
                             return;
                         }
-                        //log access to domain content
-                        //log accessed URL which includes the domain accessed
+                        //log accessed content domain url 
                         postData("/api/auditlog", {
-                            "message": window.location.href,
+                            "message": "GET " + window.location.pathname + window.location.hash,
                             "context": "access"
                         });
                     });

--- a/portal/eproms_substudy_tailored_content/src/js/Utility.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Utility.js
@@ -69,6 +69,31 @@ export function tryParseJSON (jsonString){
   return false;
 };
 
+export function postData(url, data, callback) {
+  if (!url) return;
+  callback = callback || function() {};
+  let csrfToken = document.querySelector("#sessionMonitorProps").getAttribute("data-crsftoken");
+  $.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+        if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type) && !this.crossDomain) {
+            xhr.setRequestHeader("X-CSRFToken", csrfToken);
+        }
+    }
+  });
+  $.ajax({
+    type: "POST",
+    url: url,
+    data: data
+  }).done(function(data) {
+      console.log("data posted. url: " + url);
+      callback(data);
+  }).fail(function(xhr) {
+      //log error to console
+      console.log(`data not posted. url: ${url} status: ${xhr.status}`);
+      callback({error: true});
+  });
+}
+
 export function isInViewport(element) {
   if (!element) return false;
   const rect = element.getBoundingClientRect();

--- a/portal/models/audit.py
+++ b/portal/models/audit.py
@@ -17,7 +17,7 @@ class Context(Enum):
     # only add new contexts to END of list, otherwise ordering gets messed up
     (other, login, assessment, authentication, intervention, account,
      consent, user, observation, organization, group, procedure,
-     relationship, role, tou) = range(15)
+     relationship, role, tou, access) = range(16)
 
 
 class Audit(db.Model):

--- a/portal/views/truenth.py
+++ b/portal/views/truenth.py
@@ -79,9 +79,10 @@ def auditlog_addevent():
 
     """
     message = request.form.get('message')
+    context = request.form.get('context', 'other')
     if not message:
         return jsonify(message="missing required 'message' in post")
-    auditable_event('remote message: {0}'.format(message), context='other',
+    auditable_event('remote message: {0}'.format(message), context=context,
                     user_id=current_user().id, subject_id=current_user().id)
     return jsonify(message='ok')
 

--- a/portal/views/truenth.py
+++ b/portal/views/truenth.py
@@ -58,6 +58,9 @@ def auditlog_addevent():
           required:
             - message
           properties:
+            context:
+              type: string
+              description: context such as "access", default "other"
             message:
               type: string
               description: message text


### PR DESCRIPTION
https://jira.movember.com/browse/TN-2952
Logging sub-study **content** domain accessed.
example logged entry in audit table: `remote message: GET /substudy-tailored-content#/mood_changes`




