### PR TITLE
TN-2950 restore withdrawn visit in adherence report

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -52,8 +52,7 @@ class QB_Status(object):
         self._withdrawal_date = withdrawn.at if withdrawn else None
         if self.withdrawn_by(self.as_of_date):
             self._overall_status = OverallStatus.withdrawn
-            trace("found user withdrawn; no valid qbs")
-            return
+            trace("found user withdrawn")
 
         # convert query to list of tuples for easier manipulation
         self.__ordered_qbs = [qbt.qbd() for qbt in users_qbs]
@@ -61,7 +60,7 @@ class QB_Status(object):
             # May have withdrawn prior to first qb
             if self._withdrawal_date:
                 self._overall_status = OverallStatus.withdrawn
-                trace("found user withdrawn; no valid qbs")
+                trace("found user withdrawn prior to start; no valid qbs")
             else:
                 self._overall_status = OverallStatus.expired
                 trace("no qb timeline data for {}".format(self.user))

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -57,7 +57,7 @@ def adherence_report(
     else:
         as_of_date = datetime.utcnow()
 
-    # If limited by org - grab org and all it's children as filter list
+    # If limited by org - use org and its children as filter list
     requested_orgs = (
         OrgTree().here_and_below_id(organization_id=org_id) if org_id
         else None)
@@ -115,9 +115,6 @@ def adherence_report(
                 qb_ids=[last_viable.qb_id],
                 qb_iteration=last_viable.iteration).entry_method()
             if entry_method:
-                current_app.logger.warn(
-                    "entry method %s visit %s last viable qb %d ",
-                    entry_method, row['visit'], last_viable.qb_id)
                 row['entry_method'] = entry_method
 
             if research_study_id == EMPRO_RS_ID:


### PR DESCRIPTION
Regression issue: need to capture the `current QBD` even if patient is withdrawn, for accurate reporting of withdrawn visit info.