### PR TITLE
Correct `withdrawn` timeline rows

### DIFF
--- a/portal/migrations/versions/1a84c56e6abc_.py
+++ b/portal/migrations/versions/1a84c56e6abc_.py
@@ -1,0 +1,48 @@
+"""Withdrawn patient timeline cleanup
+
+Revision ID: 1a84c56e6abc
+Revises: f46c82c33c5c
+Create Date: 2021-03-18 14:56:43.257737
+
+"""
+from alembic import op
+from sqlalchemy.sql import text
+from portal.models.qb_timeline import invalidate_users_QBT
+
+# revision identifiers, used by Alembic.
+revision = '1a84c56e6abc'
+down_revision = 'f46c82c33c5c'
+
+
+def upgrade():
+    """A small handful of patients have an invalid timeline withdrawn row
+
+    When a user is withdrawn, the timeline mechanism expects to find either
+    zero timeline rows (if they withdrew before they got started) or at
+    least the `due` event matching the visit with the user's `withdrawn`
+    event.  This migration seeks out the few noticed on truenth-test,
+    as others may exist elsewhere, to fix the invalid state.
+
+    """
+    conn = op.get_bind()
+
+    withdrawn_rows = conn.execute(
+        "SELECT user_id, qb_id, qb_iteration FROM qb_timeline"
+        " WHERE status = 'withdrawn'").fetchall()
+
+    for user_id, qb_id, qb_iteration in withdrawn_rows:
+        # If there's a similar row for the user with a `due` status
+        # all is well.  Otherwise, said user needs an update
+        matching_due = conn.execute(text(
+            "SELECT id FROM qb_timeline WHERE user_id=:user_id"
+            " AND qb_id=:qb_id AND qb_iteration=:qb_iteration"
+            " AND status='due'"), user_id=user_id, qb_id=qb_id,
+            qb_iteration=qb_iteration).fetchall()
+        if len(matching_due) == 1:
+            continue
+        print(f"found problem user: {user_id}")
+        invalidate_users_QBT(user_id=user_id, research_study_id=0)
+
+
+def downgrade():
+    pass

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -110,9 +110,15 @@ class QB_Status(object):
             QBT.qb_iteration == cur_qbd.iteration).order_by(
             QBT.at, QBT.id)
 
+        # If the user has withdrawn, don't update status beyond the user's
+        # withdrawal date.
+        fencepost = (
+            self._withdrawal_date if self.withdrawn_by(self.as_of_date)
+            else self.as_of_date)
+
         # whip through ordered rows picking up available status
         for row in cur_rows:
-            if row.at <= self.as_of_date:
+            if row.at <= fencepost:
                 self._overall_status = row.status
 
             if row.status == OverallStatus.due:


### PR DESCRIPTION
A few error emails started rolling in since we merged #4019 on truenth-test.
Hardened the code to avoid this edge case, and added a migration to fix the handful of problem users.  (simply deletes their qb_timeline so it'll get constructed on next pass)