### PR TITLE
TN-2963 use study ID in EMPRO trigger emails to staff.

### DIFF
--- a/portal/trigger_states/empro_messages.py
+++ b/portal/trigger_states/empro_messages.py
@@ -107,6 +107,7 @@ def staff_emails(patient, hard_triggers, initial_notification):
     args = {
         'clinic_name': clinic,
         'patient_id': patient.id,
+        'study_id': patient.external_study_id,
         'post_intervention_assessment_link': link,
         'triggered_domains': triggered_domains_display
     }


### PR DESCRIPTION
NB, will only function once liferay templates are updated to use {study_id} - see https://jira.movember.com/browse/TN-2968