### PR TITLE
Feature/empro post tx q updates

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1599,7 +1599,6 @@ export default (function() {
                             }
                             if (self.isSubStudyTriggersResolved()) return;
                             //initialize datepicker
-                            console.log("timestamp? ", self.subStudyTriggers.date)
                             $(`${containerIdentifier} .data-datepicker`).datepicker(
                                 {
                                     "format": "dd M yyyy",

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1599,8 +1599,14 @@ export default (function() {
                             }
                             if (self.isSubStudyTriggersResolved()) return;
                             //initialize datepicker
+                            console.log("timestamp? ", self.subStudyTriggers.date)
                             $(`${containerIdentifier} .data-datepicker`).datepicker(
-                                {"format": "dd M yyyy","forceParse": false, "autoclose": true, endDate: new Date()}
+                                {
+                                    "format": "dd M yyyy",
+                                    "forceParse": false,
+                                    "autoclose": true,
+                                    startDate: new Date(self.subStudyTriggers.date), //restrict entry so date entered cannot be before the trigger date
+                                    endDate: new Date()}
                             ).on("changeDate", self.onResponseChangeFieldEvent);
                         });
 

--- a/portal/templates/profile/patient_profile.html
+++ b/portal/templates/profile/patient_profile.html
@@ -58,7 +58,10 @@
           {{profile_macro.longitudinalReport(user)}}
       </div>
     </div>
-    {{profile_macro.postInterventionQuestionnaire(user)}}
+    <!-- post intervention questionnaire, EMPRO only -->
+    {%- if enrolled_in_substudy -%}
+      {{profile_macro.postInterventionQuestionnaire(user)}}
+    {%- endif -%}
   {%- endif -%}
   {{profile_macro.profileDemoDetail(user, current_user)}}
   {{profile_macro.profileCommunications(user, current_user)}}

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -17,6 +17,7 @@ from ..extensions import oauth
 from ..models.coding import Coding
 from ..models.intervention import Intervention
 from ..models.organization import Organization
+from ..models.qb_status import patient_research_study_status
 from ..models.qb_timeline import QB_StatusCacheKey, qb_status_visit_name
 from ..models.role import ROLE
 from ..models.research_study import EMPRO_RS_ID, ResearchStudy
@@ -203,10 +204,13 @@ def patient_profile(patient_id):
         if (display.access and display.link_url is not None and
                 display.link_label is not None):
             user_interventions.append({"name": intervention.name})
+    research_study_status = patient_research_study_status(patient)
+    enrolled_in_substudy = EMPRO_RS_ID in research_study_status
 
     return render_template(
         'profile/patient_profile.html', user=patient,
         current_user=user,
+        enrolled_in_substudy=enrolled_in_substudy,
         consent_agreements=consent_agreements,
         user_interventions=user_interventions)
 


### PR DESCRIPTION
Some minor fixes related to post tx questionnaire UI

- https://jira.movember.com/browse/TN-2944 - restrict date entry for post intervention questionnaire to not allow date prior to the trigger date
- https://jira.movember.com/browse/TN-2969 - add additional conditional in the template to prevent post intervention questionnaire section be presented in the profile page for an NON-EMPRO patient (hypothesis is that perhaps the frontend code somehow failed to prevent the section from being presented?)

