### PR TITLE
TN-2854, TN-2955, TN-2972: Adherence reports

### DIFF
--- a/portal/models/qbd.py
+++ b/portal/models/qbd.py
@@ -107,15 +107,17 @@ class QBD(object):
         if not query.count():
             # Check indefinite case, which doesn't generate timeline rows
             if self._questionnaire_bank.classification == 'indefinite':
-                query = QuestionnaireResponse.query.filter(
+                found = QuestionnaireResponse.query.filter(
                     QuestionnaireResponse.subject_id == user_id).filter(
                     QuestionnaireResponse.status == 'completed').join(
                     QuestionnaireBank).filter(
-                    QuestionnaireResponse.questionnaire_bank_id == QuestionnaireBank.id).filter(
-                    QuestionnaireBank.classification == 'indefinite').with_entities(
-                    QuestionnaireResponse.document['authored'].label('authored'))
-                first = query.first()
-                if first:
-                    return FHIR_datetime.parse(first[0])
+                    QuestionnaireResponse.questionnaire_bank_id ==
+                    QuestionnaireBank.id).filter(
+                    QuestionnaireBank.classification ==
+                    'indefinite').with_entities(
+                    QuestionnaireResponse.document['authored'].label(
+                        'authored')).first()
+                if found:
+                    return FHIR_datetime.parse(found[0])
             return None
         return query.first().at

--- a/portal/models/qbd.py
+++ b/portal/models/qbd.py
@@ -114,7 +114,8 @@ class QBD(object):
                     QuestionnaireResponse.questionnaire_bank_id == QuestionnaireBank.id).filter(
                     QuestionnaireBank.classification == 'indefinite').with_entities(
                     QuestionnaireResponse.document['authored'].label('authored'))
-                if query.count():
-                    return FHIR_datetime.parse(query.first()[0])
+                first = query.first()
+                if first:
+                    return FHIR_datetime.parse(first[0])
             return None
         return query.first().at

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -522,6 +522,14 @@ def patient_timewarp(patient_id, days):
         changed.append(f'email_message {em.id}')
         em.sent_at = em.sent_at - delta
 
+    # access records in audit
+    from ..models.audit import Audit
+    query = Audit.query.filter(Audit.subject_id == user.id).filter(
+        Audit._context == 'access')
+    for ar in query:
+        changed.append(f"audit {ar.id}")
+        ar.timestamp = ar.timestamp - delta
+
     db.session.commit()
 
     # Recalculate users timeline & qnr associations


### PR DESCRIPTION
Number of fixes, enhancements on adherence reports.

- Withdrawn users now include consent dates
- EMPRO columns added for triggers and access (TN-2854)
- Timewarp adjusts audits tracking access (TN-2972)