### PR TITLE
Add timeout limit to tests

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -19,6 +19,7 @@ pygments==2.7.4           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytest==5.2.2
 pytest-flask==0.15.1
+pytest-timeout==1.4.2
 selenium==3.141.0
 snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,8 @@ commands =
     py.test \
         --cov portal \
         --cov-report xml:"{toxinidir}/coverage.xml" \
+        --timeout=3600 \
+        --timeout_method=thread \
 
         tests/test_assessment_engine.py \
         tests/test_clinical.py \


### PR DESCRIPTION
* Add 1 hour timeout limit to celery tests
  * If timeout exceeded, dump stack
* Changed Gitlab CI timeout from 1 hour to 2 hours [via web UI](https://docs.gitlab.com/ee/ci/pipelines/settings.html#timeout)