### PR TITLE
JSON Logging Fixups

### DIFF
--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -246,7 +246,7 @@ def configure_logging(app):  # pragma: no cover
         return
 
     # Configure for JSON logging
-    if json_logging._request_util is None:
+    if json_logging._current_framework is None:
         # Ugly internal ref to prevent multiple calls to `init_flask`
         json_logging.init_flask(enable_json=True)
         json_logging.init_request_instrument(app)

--- a/portal/factories/celery.py
+++ b/portal/factories/celery.py
@@ -1,4 +1,4 @@
-from celery import Celery, signals
+from celery import current_app, Celery, signals
 import logging
 import sys
 
@@ -9,12 +9,15 @@ __celery = None
 
 @signals.setup_logging.connect
 def on_setup_logging(**kwargs):
+    # prefer loglevel from flask app config (injected into celery app) over celery CLI option
+    log_level = current_app.conf.get('LOG_LEVEL') or kwargs.get('loglevel')
+
     logger = logging.getLogger('celery')
-    logger.setLevel(logging.INFO)
+    logger.setLevel(log_level)
     logger.addHandler(logging.StreamHandler(sys.stdout))
     logger.propagate = True
     logger = logging.getLogger('celery.app.trace')
-    logger.setLevel(logging.INFO)
+    logger.setLevel(log_level)
     logger.propagate = True
 
 


### PR DESCRIPTION
* Use the same module-global variable as `json_logging` ([`_current_framework`](https://github.com/bobbui/json-logging-python/blob/master/json_logging/__init__.py#L29)) to detect logging initialization
* Read celery loglevel from flask app, or `celery` CLI option
