### PR TITLE
Update pytest

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -17,7 +17,7 @@ psycopg2-binary==2.8.6
 py==1.10.0                # via tox
 pygments==2.7.4           # via sphinx
 pyparsing==2.4.7          # via packaging
-pytest==5.2.3
+pytest==6.1.0
 pytest-flask==0.15.1
 pytest-timeout==1.4.2
 selenium==3.141.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -14,7 +14,7 @@ pluggy==0.13.1             # via tox
 # use pre-compiled binary for testing, build from source for prod
 # http://initd.org/psycopg/docs/install.html#binary-install-from-pypi
 psycopg2-binary==2.8.6
-py==1.8.0                 # via tox
+py==1.10.0                # via tox
 pygments==2.7.4           # via sphinx
 pyparsing==2.4.7          # via packaging
 pytest==5.2.2

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -17,7 +17,7 @@ psycopg2-binary==2.8.6
 py==1.10.0                # via tox
 pygments==2.7.4           # via sphinx
 pyparsing==2.4.7          # via packaging
-pytest==5.2.2
+pytest==5.2.3
 pytest-flask==0.15.1
 pytest-timeout==1.4.2
 selenium==3.141.0


### PR DESCRIPTION
Update pytest to latest working version. 

NB newer versions of py.test seem to be more prone to timing out ([see CI failure rate](https://github.com/uwcirg/truenth-portal/commits/fixup/update-pytest_stepwise)). If this continues to be a problem, we should revert this change.