### PR TITLE
TN-2989 correctly manage 'next' in 2FA

### DIFF
--- a/portal/models/login.py
+++ b/portal/models/login.py
@@ -49,13 +49,13 @@ def login_user(user, auth_method=None):
         current_app.logger.debug(f"2FA OTP for {user.id}: {code}")
         email = EmailMessage(
             subject=_("TrueNTH Access Code"),
-            body=_("One Time Authentication Code: %(code)s", code=code),
+            body=_("One-time access code: %(code)06d", code=code),
             recipients=user.email,
             sender=current_app.config['MAIL_DEFAULT_SENDER'],
             user_id=user.id)
         if current_app.config.get("MAIL_SUPPRESS_SEND"):
             # Dump to console for easy access
-            print(f"!!!!!!!! 2FA Code: {code} !!!!!!!!")
+            print(email.body)
         else:
             email.send_message()
 

--- a/portal/models/login.py
+++ b/portal/models/login.py
@@ -49,11 +49,11 @@ def login_user(user, auth_method=None):
         current_app.logger.debug(f"2FA OTP for {user.id}: {code}")
         email = EmailMessage(
             subject=_("TrueNTH Access Code"),
-            body=_("One Time Authentication Code: %s" % code),
+            body=_("One Time Authentication Code: %(code)s", code=code),
             recipients=user.email,
             sender=current_app.config['MAIL_DEFAULT_SENDER'],
             user_id=user.id)
-        if current_app.config.get("DEV_SYSTEM_WO_EMAIL", None):
+        if current_app.config.get("MAIL_SUPPRESS_SEND"):
             # Dump to console for easy access
             print(f"!!!!!!!! 2FA Code: {code} !!!!!!!!")
         else:

--- a/portal/static/js/flask_user/2fa.js
+++ b/portal/static/js/flask_user/2fa.js
@@ -1,0 +1,11 @@
+$(document).ready(function() {
+    $("#submitValidationCode").on("click", function(e) {
+        e.stopPropagation();
+        if (!$("#faInput").val()) return;
+        $(".buttons-container").addClass("loading");
+        setTimeout(function() {
+            $("#TwoFAForm").submit();
+        }, 50);
+
+    });
+});

--- a/portal/static/js/flask_user/2fa.js
+++ b/portal/static/js/flask_user/2fa.js
@@ -1,11 +1,20 @@
 $(document).ready(function() {
-    $("#submitValidationCode").on("click", function(e) {
-        e.stopPropagation();
+    var submitForm = function() {
         if (!$("#faInput").val()) return;
         $(".buttons-container").addClass("loading");
         setTimeout(function() {
             $("#TwoFAForm").submit();
         }, 50);
-
+    };
+    $("#submitValidationCode").on("click", function(e) {
+        e.stopPropagation();
+        submitForm();
+    });
+    $(document).keypress(function(event) {
+        if (event.which === 13) {
+           submitForm();
+           return false;
+        }
+        return true;
     });
 });

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -451,9 +451,9 @@ a.btn {
   .v-icon__svg {
     fill: @mutedColor;
     font-size: 18px;
-    height: 18px; 
+    height: 18px;
     width: 18px;
-  } 
+  }
 }
 body.landing {
   min-height: 100%;
@@ -1247,7 +1247,7 @@ select:not([multiple]) {
     background-image: @defaultFooterWhiteLogoPath;
     position: relative;
     top: 6px;
-  } 
+  }
 }
 #footerMovember {
   display: inline-block;
@@ -2005,7 +2005,7 @@ div.footer-wrapper.right-panel {
       min-height: 50px;
     }
   }
-  .exportReport__status.active:before, 
+  .exportReport__status.active:before,
   .export__status.active:before {
     position: absolute;
     animation: borderLoader 750ms infinite linear;
@@ -3622,7 +3622,7 @@ section.header {
   position: relative;
   &.active {
     min-height: 250px;
-  } 
+  }
   .loader {
     position: absolute;
     top: 0;
@@ -4678,6 +4678,39 @@ input.clinic {
   input {
     width: 300px;
     max-width: 100%;
+  }
+}
+
+#TwoFAForm {
+  .buttons-container {
+    position: relative;
+    min-height: 56px;
+    .loader {
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      top: 0;
+      background: #FFF;
+      z-index: 10;
+      i {
+        position: absolute;
+        left: 0;
+        top: 8px;
+      }
+      display: none;
+    }
+    .btn {
+      width: 100%;
+    }
+    &.loading {
+      .loader {
+        display: block;
+      }
+      .btn {
+        visibility: hidden;
+      }
+    }
   }
 }
 

--- a/portal/templates/flask_user/second_factor.html
+++ b/portal/templates/flask_user/second_factor.html
@@ -4,13 +4,13 @@
 
     <h3 class="tnth-headline">{{ _("Two Factor Athentication") }}</h3><br />
 
-    <p>{{ _("You should receive an email with a token. Enter the token below for access.") }}</p>
+    <p>{{ _("You should receive an email with a 4 digit code. Enter the code below for access.") }}</p>
 
     <form action="{{ url_for('auth.two_factor_auth') }}" method="post">
         {{ form.hidden_tag() }}
-        {{ render_field(form.key, label=_("Token"), tabindex=5) }}
+        {{ render_field(form.key, label=_("Code"), tabindex=5) }}
 
-        <button type="submit" class="btn btn-tnth-primary">{{ _("Validate Token") }}</button>
+        <button type="submit" class="btn btn-tnth-primary">{{ _("Validate Code") }}</button>
     </form>
 
 {% endblock %}

--- a/portal/templates/flask_user/second_factor.html
+++ b/portal/templates/flask_user/second_factor.html
@@ -1,8 +1,8 @@
 {% extends "layout.html" %}
 {% block main %}
 {% from "flask_user/_macros.html" import render_field %}
-    <h3 class="tnth-headline">{{ _("Two Factor Athentication") }}</h3>
-    <p>{{ _("You should receive an email with a 4 digit code. Enter the code below for access.") }}</p>
+    <h3 class="tnth-headline">{{ _("Two-factor Athentication") }}</h3>
+    <p>{{ _("You should receive an email with a 6 digit code. Enter the code below for access.") }}</p>
     <div class="row">
         <div class="col-xs-6 col-sm-4 col-md-3">
             <form id="TwoFAForm" action="{{ url_for('auth.two_factor_auth') }}" method="post">

--- a/portal/templates/flask_user/second_factor.html
+++ b/portal/templates/flask_user/second_factor.html
@@ -1,16 +1,22 @@
 {% extends "layout.html" %}
 {% block main %}
 {% from "flask_user/_macros.html" import render_field %}
-
-    <h3 class="tnth-headline">{{ _("Two Factor Athentication") }}</h3><br />
-
+    <h3 class="tnth-headline">{{ _("Two Factor Athentication") }}</h3>
     <p>{{ _("You should receive an email with a 4 digit code. Enter the code below for access.") }}</p>
-
-    <form action="{{ url_for('auth.two_factor_auth') }}" method="post">
-        {{ form.hidden_tag() }}
-        {{ render_field(form.key, label=_("Code"), tabindex=5) }}
-
-        <button type="submit" class="btn btn-tnth-primary">{{ _("Validate Code") }}</button>
-    </form>
-
+    <div class="row">
+        <div class="col-xs-6 col-sm-4 col-md-3">
+            <form id="TwoFAForm" action="{{ url_for('auth.two_factor_auth') }}" method="post">
+                {{ form.hidden_tag() }}
+                {{ render_field(form.key, label=" ", tabindex=5, id="faInput") }}
+                <div class="buttons-container">
+                    <div class="loader"><i class="fa fa-spinner fa-spin fa-2x"></i></div>
+                    <button id="submitValidationCode" type="button" class="btn btn-tnth-primary">{{ _("Validate Code") }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
 {% endblock %}
+{% block additional_scripts -%}
+    {{super()}}
+    <script src="{{ url_for('static', filename='js/flask_user/2fa.js') }}"></script>
+{%- endblock %}

--- a/portal/templates/flask_user/second_factor.html
+++ b/portal/templates/flask_user/second_factor.html
@@ -2,7 +2,7 @@
 {% block main %}
 {% from "flask_user/_macros.html" import render_field %}
     <h3 class="tnth-headline">{{ _("Two Factor Athentication") }}</h3>
-    <p>{{ _("You should receive an email with a %(code)d digit code. Enter the code below for access.", code=6) }}</p>
+    <p>{{ _("You should receive an email with a %(length)d digit code. Enter the code below for access.", length=6) }}</p>
     <div class="row">
         <div class="col-xs-6 col-sm-4 col-md-3">
             <form id="TwoFAForm" action="{{ url_for('auth.two_factor_auth') }}" method="post">

--- a/portal/templates/flask_user/second_factor.html
+++ b/portal/templates/flask_user/second_factor.html
@@ -1,8 +1,8 @@
 {% extends "layout.html" %}
 {% block main %}
 {% from "flask_user/_macros.html" import render_field %}
-    <h3 class="tnth-headline">{{ _("Two-factor Athentication") }}</h3>
-    <p>{{ _("You should receive an email with a 6 digit code. Enter the code below for access.") }}</p>
+    <h3 class="tnth-headline">{{ _("Two Factor Athentication") }}</h3>
+    <p>{{ _("You should receive an email with a %(code)d digit code. Enter the code below for access.", code=6) }}</p>
     <div class="row">
         <div class="col-xs-6 col-sm-4 col-md-3">
             <form id="TwoFAForm" action="{{ url_for('auth.two_factor_auth') }}" method="post">

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -603,11 +603,13 @@ def next_after_login():
     # It's stored in the session to survive the various redirections needed
     # for external auth, etc.  If found in the session, pop and redirect
     # as defined.
-    elif 'next' in session:
-        next_url = session['next']
-        del session['next']
-        current_app.logger.debug("next_after_login: [have session['next']] "
-                                 "-> {}".format(next_url))
+    elif 'next' in session or request.args.get('next'):
+        next_url = request.args.get('next')
+        if 'next' in session:
+            next_url = session['next']
+            del session['next']
+            current_app.logger.debug("next_after_login: [have session['next']] "
+                                     "-> {}".format(next_url))
         if 'suspend_initial_queries' in session:
             del session['suspend_initial_queries']
         resp = redirect(next_url)

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -608,8 +608,8 @@ def next_after_login():
         if 'next' in session:
             next_url = session['next']
             del session['next']
-            current_app.logger.debug("next_after_login: [have session['next']] "
-                                     "-> {}".format(next_url))
+            current_app.logger.debug(
+                "next_after_login: [have session['next']] -> %s", next_url)
         if 'suspend_initial_queries' in session:
             del session['suspend_initial_queries']
         resp = redirect(next_url)


### PR DESCRIPTION
2FA was being thwarted by unauthenticated request to restricted resources.  Difficult to wire in with flask-user, but found a way by patching the `make_safe_url()` function of flask-user.

Replaced the `token` term with `code` as suggested in parent story TN-2974