### PR TITLE
TN-2998 allow timewarp on demo systems.

### DIFF
--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -2267,6 +2267,34 @@
     {
       "extension": [
         {
+          "timezone": "Europe/Stockholm",
+          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
+        },
+        {
+          "research_protocols": [
+            {"name": "IRONMAN v5"}
+          ],
+          "url": "http://us.truenth.org/identity-codes/research-protocol"
+        }
+      ],
+      "id": 146166,
+      "identifier": [
+        {
+          "system": "http://pcctc.org/",
+          "use": "secondary",
+          "value": "146-166"
+        }
+      ],
+      "language": "en_GB",
+      "name": "Umeå University Hospital",
+      "partOf": {
+        "reference": "api/organization/24000"
+      },
+      "resourceType": "Organization"
+    },
+    {
+      "extension": [
+        {
           "url": "http://hl7.org/fhir/valueset/languages",
           "valueCodeableConcept": {
             "coding": [

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -472,7 +472,8 @@ def patient_timewarp(patient_id, days):
     from portal.models.questionnaire_response import QuestionnaireResponse
     from portal.models.user_consent import UserConsent
 
-    if current_app.config['SYSTEM_TYPE'] not in ('development', 'testing'):
+    if current_app.config['SYSTEM_TYPE'] not in (
+            'demo', 'development', 'testing'):
         abort(404)
 
     if days < 1:

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -472,7 +472,7 @@ def patient_timewarp(patient_id, days):
     from portal.models.questionnaire_response import QuestionnaireResponse
     from portal.models.user_consent import UserConsent
 
-    if current_app.config['SYSTEM_TYPE'] != "production":
+    if current_app.config['SYSTEM_TYPE'] == "production":
         abort(404)
 
     if days < 1:

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -472,8 +472,7 @@ def patient_timewarp(patient_id, days):
     from portal.models.questionnaire_response import QuestionnaireResponse
     from portal.models.user_consent import UserConsent
 
-    if current_app.config['SYSTEM_TYPE'] not in (
-            'demo', 'development', 'testing'):
+    if current_app.config['SYSTEM_TYPE'] != "production":
         abort(404)
 
     if days < 1:


### PR DESCRIPTION
Was a hotfix, reverted to standard flow as time allows for this to go out with the current sprint.