### PR TITLE
Quiet benign and seemingly worthless error which requires no action.

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -461,7 +461,7 @@ class User(db.Model, UserMixin):
         if query.count() == 0:
             if not generate_failsafe_if_missing:
                 return None
-            current_app.logger.error(
+            current_app.logger.warning(
                 "Failed to locate in-progress encounter for %d"
                 "; generate failsafe", self.id)
             return initiate_encounter(self, auth_method='failsafe')


### PR DESCRIPTION
We continue to see these on a rare basis.  No action is needed.  Just noise in our INBOXes - turning down.

Example message that was being generated:
```
{"written_at": "2021-06-08T09:38:24.736Z", "written_ts": 1623145104736012000, "msg": "Failed to locate in-progress encounter for <redacted id>; generate failsafe", "type": "log", "logger": "flask.app", "thread": "MainThread", "level": "ERROR", "module": "user", "line_no": 466, "correlation_id": "454300fc-c83d-11eb-8f14-0242ac120008"}
```