### PR TITLE
TN-3045 default to staff role for all but patients for privacy URL

### DIFF
--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -227,10 +227,13 @@ def privacy():
     user = current_user()
     if user:
         organization = user.first_top_organization()
-        role = None
-        for r in (ROLE.STAFF.value, ROLE.PATIENT.value):
-            if user.has_role(r):
-                role = r
+
+        # EPROMS only has privacy docs for staff and patient
+        # Give all roles besides patient the staff version
+        role = ROLE.STAFF.value
+        if user.has_role(ROLE.PATIENT.value):
+            role = ROLE.PATIENT.value
+
         # only include role and organization if both are defined
         if not all((role, organization)):
             role, organization = None, None


### PR DESCRIPTION
The privacy policy options on EPROMs are limited to:

```
- IRONMAN patient privacy URL
- IRONMAN staff privacy URL
- TrueNTH Global Registry patient privacy URL
- TrueNTH Global Registry staff privacy URL
```

for users other than patients, default to the staff version.
