### PR TITLE
TN-3027 Adherence report entry method work

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -639,9 +639,11 @@ class QNR_results(object):
         # return only one, namely the most frequent
         # if not all were the same as most frequent, include ratio
         max_key = max(found, key=lambda key: found[key])
-        total_found = sum(value for value in found.values())
-        if found[max_key] != total_found:
-            return f"{max_key} {found[max_key]}:{total_found}"
+        show_ratio = False
+        if show_ratio:
+            total_found = sum(value for value in found.values())
+            if found[max_key] != total_found:
+                return f"{max_key} {found[max_key]}:{total_found}"
         return max_key
 
     def required_qs(self, qb_id):

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 import copy
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
@@ -621,22 +621,28 @@ class QNR_results(object):
                 return qnr.authored
 
     def entry_method(self):
-        """Returns first entry method found in results, or None"""
-        found = set()
+        """Returns most common entry method over set of QNRs in this visit"""
+        found = defaultdict(int)
         for qnr in self.qnrs:
-            if qnr.encounter_id is not None:
-                encounter = Encounter.query.get(qnr.encounter_id)
-                if encounter.type and len(encounter.type):
-                    for item in encounter.type:
-                        found.add(item.code)
-                        # work around issue TN-2941, reporting only first
-                        # as the encounter didn't accurately track
-                        break
-                else:
-                    found.add('online')
+            encounter = Encounter.query.get(qnr.encounter_id)
+            if encounter.auth_method == 'staff_authenticated':
+                found['staff_authenticated'] += 1
+            elif encounter.type and len(encounter.type):
+                for item in encounter.type:
+                    found[item.code] += 1
             else:
-                found.add('online')
-        return ','.join(found)
+                found['online'] += 1
+
+        if not found:
+            return None
+
+        # return only one, namely the most frequent
+        # if not all were the same as most frequent, include ratio
+        max_key = max(found, key=lambda key: found[key])
+        total_found = sum(value for value in found.values())
+        if found[max_key] != total_found:
+            return f"{max_key} {found[max_key]}:{total_found}"
+        return max_key
 
     def required_qs(self, qb_id):
         """Return required list (order counts) of Questionnaires for QB"""

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -622,11 +622,21 @@ class QNR_results(object):
 
     def entry_method(self):
         """Returns first entry method found in results, or None"""
+        found = set()
         for qnr in self.qnrs:
             if qnr.encounter_id is not None:
                 encounter = Encounter.query.get(qnr.encounter_id)
                 if encounter.type and len(encounter.type):
-                    return encounter.type[0].code
+                    for item in encounter.type:
+                        found.add(item.code)
+                        # work around issue TN-2941, reporting only first
+                        # as the encounter didn't accurately track
+                        break
+                else:
+                    found.add('online')
+            else:
+                found.add('online')
+        return ','.join(found)
 
     def required_qs(self, qb_id):
         """Return required list (order counts) of Questionnaires for QB"""

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -160,7 +160,7 @@ def questionnaire_status_test():
         'acting_user_id': current_user().id,
         'include_test_role': request.args.get('include_test_role', False),
         'org_id': request.args.get('org_id', 146999),
-        'limit': request.args.get('limit', 10),
+        'limit': int(request.args.get('limit', 10)),
         'research_study_id': int(request.args.get('research_study_id', 0)),
         'lock_key': "adherence_report_throttle",
         'response_format': request.args.get('format', 'csv').lower()


### PR DESCRIPTION
- restore "online" default to entry method (when not paper, interview assisted or staff authenticated)
- add entry method `staff_authenticated` for the login as patient scenario
- calculate all the entry methods for all questionnaire responses on a given visit and when more than one exists, return the one most frequently used and a ratio of that one to all, i.e. `paper 4:5`