### PR TITLE
TN-3048 /api/patient/<>/research_study extended for `staff_eligible`

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -510,7 +510,7 @@ def patient_research_study_status(patient, ignore_QB_status=False):
          have been met, such as assigned clinician if applicable.
      - ready: set True or False based on complex rules.  True means pending
          work user can immediately do.  NOT determined w/ ``ignore_QB_status``
-     - staff_eligible: if false, staff controls should be disabled.
+     - intervention_qnr_eligible: if false, staff controls should be disabled.
          True means no criteria found preventing outstanding staff work.
      - errors: list of strings detailing anything preventing user from being
          "ready"
@@ -527,7 +527,7 @@ def patient_research_study_status(patient, ignore_QB_status=False):
         rs_status = {
             'eligible': True,
             'ready': False,
-            'staff_eligible': True,
+            'intervention_qnr_eligible': True,
             'errors': [],
         }
         results[rs] = rs_status
@@ -535,7 +535,7 @@ def patient_research_study_status(patient, ignore_QB_status=False):
             # Enforce biz rule - must have clinician on file.
             trace("no clinician; not eligible")
             rs_status['eligible'] = False
-            rs_status['staff_eligible'] = False
+            rs_status['intervention_qnr_eligible'] = False
             rs_status['errors'].append("No clinician")
 
         if ignore_QB_status:

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -510,6 +510,8 @@ def patient_research_study_status(patient, ignore_QB_status=False):
          have been met, such as assigned clinician if applicable.
      - ready: set True or False based on complex rules.  True means pending
          work user can immediately do.  NOT determined w/ ``ignore_QB_status``
+     - staff_eligible: if false, staff controls should be disabled.
+         True means no criteria found preventing outstanding staff work.
      - errors: list of strings detailing anything preventing user from being
          "ready"
 
@@ -525,6 +527,7 @@ def patient_research_study_status(patient, ignore_QB_status=False):
         rs_status = {
             'eligible': True,
             'ready': False,
+            'staff_eligible': True,
             'errors': [],
         }
         results[rs] = rs_status
@@ -532,6 +535,7 @@ def patient_research_study_status(patient, ignore_QB_status=False):
             # Enforce biz rule - must have clinician on file.
             trace("no clinician; not eligible")
             rs_status['eligible'] = False
+            rs_status['staff_eligible'] = False
             rs_status['errors'].append("No clinician")
 
         if ignore_QB_status:

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -271,7 +271,10 @@ export default (function() {
             },
             computedOptionalCoreData: function() {
                 return this.optionalCoreData;
-            }
+            },
+            subStudyStaffEligible: function() {
+                return this.subjectResearchStudyStatuses[EPROMS_SUBSTUDY_ID] && this.subjectResearchStudyStatuses[EPROMS_SUBSTUDY_ID]["staff_eligible"];
+            },
         },
         methods: {
             registerDependencies: function() {
@@ -633,6 +636,9 @@ export default (function() {
             },
             isSubStudyPatient: function() {
                 return this.computedIsSubStudyPatient;
+            },
+            isSubStudyStaffEligible: function() {
+                return this.subStudyStaffEligible;
             },
             hasSubStudyStatusErrors: function() {
                 return this.hasResearchStudyStatusErrors(EPROMS_SUBSTUDY_ID);
@@ -1501,7 +1507,10 @@ export default (function() {
                 });
             },
             shouldShowSubstudyPostTx: function() {
-                return this.isSubStudyPatient() && ((!this.hasSubStudyStatusErrors() && this.isPostTxActionRequired()) || this.hasPrevSubStudyPostTx());
+                return this.isSubStudyPatient() && (this.isPostTxActionRequired() || this.hasPrevSubStudyPostTx());
+            },
+            shouldDisableSubstudyPostTx: function() {
+                return this.isSubStudyTriggersResolved() || !this.isSubStudyStaffEligible();
             },
             getPostTxActionStatus: function() {
                 if (!this.subStudyTriggers.data || !this.subStudyTriggers.data.action_state) {

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -273,7 +273,7 @@ export default (function() {
                 return this.optionalCoreData;
             },
             subStudyStaffEligible: function() {
-                return this.subjectResearchStudyStatuses[EPROMS_SUBSTUDY_ID] && this.subjectResearchStudyStatuses[EPROMS_SUBSTUDY_ID]["staff_eligible"];
+                return this.subjectResearchStudyStatuses[EPROMS_SUBSTUDY_ID] && this.subjectResearchStudyStatuses[EPROMS_SUBSTUDY_ID]["intervention_qnr_eligible"];
             },
         },
         methods: {

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -908,7 +908,7 @@
                     post intervention questionnaire section
                     NOTE:
                     will display triggers when present in the last determined trigger state
-                    will be in a disabled state if the action state is "completed" or staff_eligible flag is set to false
+                    will be in a disabled state if the action state is "completed" or intervention_qnr_eligible flag is set to false
                 -->
                 <div id="questionsSection" class="content" :class="{disabled: shouldDisableSubstudyPostTx(), active: shouldShowSubstudyPostTx()}" v-show="shouldShowSubstudyPostTx()">
                     <div class="question" v-for="item in postTxQuestionnaire.questions" :linkId="item.linkId" :dataType="item.type" :text="item.text" >

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -907,10 +907,10 @@
                 <!--
                     post intervention questionnaire section
                     NOTE:
-                    will display triggers were present in the last determined trigger state
-                    will be in a disabled state if the action state is "completed"
+                    will display triggers when present in the last determined trigger state
+                    will be in a disabled state if the action state is "completed" or staff_eligible flag is set to false
                 -->
-                <div id="questionsSection" class="content" :class="{disabled: isSubStudyTriggersResolved() || hasSubStudyStatusErrors(), active: shouldShowSubstudyPostTx()}" v-show="shouldShowSubstudyPostTx()">
+                <div id="questionsSection" class="content" :class="{disabled: shouldDisableSubstudyPostTx(), active: shouldShowSubstudyPostTx()}" v-show="shouldShowSubstudyPostTx()">
                     <div class="question" v-for="item in postTxQuestionnaire.questions" :linkId="item.linkId" :dataType="item.type" :text="item.text" >
                         <!-- question text -->
                         <span class="title" :class="item.type" v-text="item.text"></span>
@@ -980,7 +980,7 @@
                     <span>{{_("Action status:")}}</span>
                     <span class="text error-message" v-text="getPostTxActionStatus()"></span>
                 </div>
-                <div class="study-error error-message" v-show="hasSubStudyStatusErrors()">
+                <div class="study-error error-message" v-show="shouldDisableSubstudyPostTx() && hasSubStudyStatusErrors()">
                     <span class="glyphicon glyphicon-alert warning icon" aria-hidden="true"></span>
                     <span v-html="getSubStudyStatusErrors()" ></span>
                 </div>

--- a/portal/views/research_study.py
+++ b/portal/views/research_study.py
@@ -50,6 +50,7 @@ def rs_for_patient(user_id):
                 required:
                   - eligible
                   - ready
+                  - staff_eligible
                 properties:
                   eligible:
                     type: boolean
@@ -57,6 +58,10 @@ def rs_for_patient(user_id):
                   ready:
                     type: boolean
                     description: true if patient is ready for given study
+                  staff_eligible:
+                    type: boolean
+                    description: when false, controls for staff intervention should
+                      be disabled.
       401:
         description:
           if missing valid OAuth token or if the authorized user lacks

--- a/portal/views/research_study.py
+++ b/portal/views/research_study.py
@@ -60,8 +60,8 @@ def rs_for_patient(user_id):
                     description: true if patient is ready for given study
                   staff_eligible:
                     type: boolean
-                    description: when false, controls for staff intervention should
-                      be disabled.
+                    description: when false, controls for staff intervention
+                      should be disabled.
       401:
         description:
           if missing valid OAuth token or if the authorized user lacks

--- a/portal/views/research_study.py
+++ b/portal/views/research_study.py
@@ -50,7 +50,7 @@ def rs_for_patient(user_id):
                 required:
                   - eligible
                   - ready
-                  - staff_eligible
+                  - intervention_qnr_eligible
                 properties:
                   eligible:
                     type: boolean
@@ -58,7 +58,7 @@ def rs_for_patient(user_id):
                   ready:
                     type: boolean
                     description: true if patient is ready for given study
-                  staff_eligible:
+                  intervention_qnr_eligible:
                     type: boolean
                     description: when false, controls for staff intervention
                       should be disabled.


### PR DESCRIPTION
Front end was erroneously disabling the control for a staff follow up on EMPRO trigger, once the patient has subsequent global study work pending.

The `/api/patient/<>/research_study` API now includes an additional `staff_eligible` boolean.  Only when that is false does the control for staff follow up need to be disabled.