### PR TITLE
TN-3056 audit message clarity when deleting EMPRO consent

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -962,6 +962,8 @@ def delete_user_consents(user_id):
       - ServiceToken: []
 
     """
+    from portal.trigger_states.empro_states import EMPRO_STUDY_ID
+
     current_app.logger.debug('delete user consent called w/: {}'.format(
         request.json))
     user = get_user(user_id, 'edit')
@@ -980,9 +982,12 @@ def delete_user_consents(user_id):
     if not remove_uc:
         abort(404, "matching user consent not found")
 
+    audit_comment = 'Deleted consent agreement'
+    if research_study_id == EMPRO_STUDY_ID:
+        audit_comment = 'Deleted EMPRO consent agreement'
     remove_uc.deleted = Audit(
         user_id=current_user().id, subject_id=user_id,
-        comment="Deleted consent agreement", context='consent')
+        comment=audit_comment, context='consent')
     remove_uc.status = 'deleted'
     # The deleted consent may have altered the cached assessment
     # status, even the qb assignments - force re-eval by invalidating now


### PR DESCRIPTION
When deleting EMPRO consent, audit message now makes that clear:
``` Deleted EMPRO consent agreement```