### PR TITLE
TN-3014, indefinite withdrawn special status handling

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -212,6 +212,12 @@ class QB_Status(object):
         self._response_lookup()
         if self.overall_status == OverallStatus.withdrawn:
             status = OverallStatus.withdrawn
+            # Special circumstance for completed/partial withdrawn (TN-3014)
+            if self._partial_indef:
+                status = OverallStatus.partially_completed
+            if self.completed_indef.issuperset(self._required_indef):
+                status = OverallStatus.completed
+
         elif self._partial_indef:
             status = OverallStatus.in_progress
         elif self._completed_indef.issuperset(self._required_indef):

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -66,6 +66,7 @@ def adherence_report(
     patients = patients_query(
         acting_user=acting_user,
         include_test_role=include_test_role,
+        filter_by_ids=[4450],
         requested_orgs=requested_orgs)
     data = []
     current, total = 0, patients.count()


### PR DESCRIPTION
When a user is withdrawn, the indefinite QB requires special status handling.
If withdrawn and completed:
  status = completed
if withdrawn and in_progress:
  status = partially_completed
otherwise if withdrawn, indef status = withdrawn.