### PR TITLE
TN-3077 2FA was interrupting staff account initiation.

### DIFF
--- a/portal/models/login.py
+++ b/portal/models/login.py
@@ -50,6 +50,7 @@ def login_user(user, auth_method=None):
             current_app.config.get("ENABLE_2FA") and
             not current_app.testing and
             not getattr(getattr(request, 'oauth', None), 'user', None) and
+            not user.has_role(ROLE.WRITE_ONLY.value) and
             user.has_role(
                     ROLE.ADMIN.value,
                     ROLE.ANALYST.value,

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -579,7 +579,12 @@ def next_after_login():
         logout(prevent_redirect=True, reason='reverting to invited account')
         invited_user.promote_to_registered(user)
         db.session.commit()
+
+        # on this brand new promoted account, must fake/suppress 2fa or we'll
+        # repeat the cycle as part of the `login_user()` call
+        session['2FA_verified'] = '2FA verified'
         login_user(invited_user, 'password_authenticated')
+
         if preserve_next_across_sessions:
             session['next'] = preserve_next_across_sessions
         assert (invited_user == current_user())


### PR DESCRIPTION
Solve problems with new staff user's coming in on invite link, verifying name & dob, promoting auth details into invited account, etc., by suspending 2FA during this bootstrap process.

NB - this means the initial new staff user interaction WILL require them to validate (name & dob) but will NOT require them 2FA.  It would be a significant change to alter that and so, I hope this is acceptable.