### PR TITLE
TN-3100 allow empro consent to be editable for test patient in prod

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -3175,7 +3175,10 @@ export default (function() {
                 }
                 //adding a test substudy consent should only be allowed in Test environment
                 if (!this.isTestEnvironment()) {
-                    return false;
+                    //allowed in non-Test environment based on additional check, e.g. user role, patient role, config etc.
+                    if (!this.isConsentEditable()) {
+                        return false;
+                    }
                 }
                 //should only show add substudy consent row if the subject is a patient and the user is a staff/staff admin
                 return this.hasCurrentConsent() && !this.hasSubStudyConsent() && this.isSubjectPatient() && this.isStaff();


### PR DESCRIPTION
https://jira.movember.com/browse/TN-3100
Allow editing of EMPRO consent for a test patient account if logged-in user has role as specified in`CONSENT_EDIT_PERMISSIBLE_ROLES` 