### PR TITLE
TN-3101 correct default (prior to initiation) status for EMPRO questionnaires

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -1270,7 +1270,7 @@ def qb_status_visit_name(user_id, research_study_id, as_of_date):
     assert isinstance(as_of_date, datetime)
 
     default_status = (
-        "Not yet available" if research_study_id == EMPRO_RS_ID
+        "Not Yet Available" if research_study_id == EMPRO_RS_ID
         else OverallStatus.expired)
     results = {
         'status': default_status,

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -1255,7 +1255,8 @@ def qb_status_visit_name(user_id, research_study_id, as_of_date):
     ``QB_StatusCacheKey.current()`` for as_of_date parameter, to avoid
     a new lookup with each passing moment.
 
-    If no data is available for the user, returns
+    If no data is available for the user, `status` of `Not Yet Available` for
+    the EMPRO study, `expired` for all others, as part of:
      {'status': 'expired', 'visit_name': None, 'action_state': 'not applicable'}
 
     :returns: dictionary with key/values for:

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -1269,8 +1269,11 @@ def qb_status_visit_name(user_id, research_study_id, as_of_date):
     assert isinstance(research_study_id, int)
     assert isinstance(as_of_date, datetime)
 
+    default_status = (
+        "Not yet available" if research_study_id == EMPRO_RS_ID
+        else OverallStatus.expired)
     results = {
-        'status': OverallStatus.expired,
+        'status': default_status,
         'visit_name': None,
         'action_state': 'not applicable'
     }

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -113,7 +113,11 @@ def adherence_report(
         # if no current, try previous (as current may be expired)
         last_viable = qb_stats.current_qbd(
             even_if_withdrawn=True) or qb_stats.prev_qbd
-        if last_viable:
+        if not last_viable:
+            # Global study default pre-started is Expired.  See TN-3101
+            if row['status'] == "Expired":
+                row['status'] = "Not Yet Available"
+        else:
             row['qb'] = last_viable.questionnaire_bank.name
             row['visit'] = visit_name(last_viable)
             if row['status'] == 'Completed':

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -114,7 +114,7 @@ def adherence_report(
         last_viable = qb_stats.current_qbd(
             even_if_withdrawn=True) or qb_stats.prev_qbd
         if not last_viable:
-            # Global study default pre-started is Expired.  See TN-3101
+            # Global study default pre-started is Expired. See TN-3101
             if row['status'] == "Expired":
                 row['status'] = "Not Yet Available"
         else:


### PR DESCRIPTION
For EMPRO patients, specifically those shown in the /substudy list, use a default status of "Not yet available" rather than the global study default "expired".

Note - this is intended to go out as a hotfix.