### PR TITLE
TN-1939 validate optional `status` param sent to consent API

### DIFF
--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -145,6 +145,8 @@ class UserConsent(db.Model):
         for attr in ('staff_editable', 'include_in_reports',
                      'send_reminders', 'status', 'research_study_id'):
             if attr in data:
+                if attr == 'status' and data.get(attr) not in status_types:
+                    raise ValueError(f"ill defined user_consent.status: {data.get(attr)}")
                 setattr(obj, attr, data.get(attr))
 
         return obj

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -136,6 +136,19 @@ class TestUserConsent(TestCase):
         assert consent.acceptance_date.replace(
             microsecond=0) == consent.acceptance_date
 
+    def test_post_bogus_status_user_consent(self):
+        self.shallow_org_tree()
+        org1 = Organization.query.filter(Organization.id > 0).first()
+        data = {'organization_id': org1.id, 'agreement_url': self.url,
+                'staff_editable': True, 'send_reminders': False, 'status': "bogus"}
+
+        self.login()
+        response = self.client.post(
+            '/api/user/{}/consent'.format(TEST_USER_ID),
+            json=data,
+        )
+        assert response.status_code == 400
+
     def test_post_user_consent_dates(self):
         self.shallow_org_tree()
         org1 = Organization.query.filter(Organization.id > 0).first()


### PR DESCRIPTION
Now raising 400 with sane message, rather than generating a 500 server error when consent API was given a bogus `status` value.