### PR TITLE
TN-3114 check for user before checking for roles

### DIFF
--- a/portal/views/patch_flask_user.py
+++ b/portal/views/patch_flask_user.py
@@ -67,7 +67,7 @@ def patch_forgot_password():
 
         # Do NOT allow non registered to change password
         non_registered_roles = set(current_app.config['PRE_REGISTERED_ROLES'])
-        current_roles = {r.name for r in user.roles}
+        current_roles = {r.name for r in user.roles} if user else set()
         disjoint = current_roles.isdisjoint(non_registered_roles)
 
         if disjoint and user:


### PR DESCRIPTION
PR #4145 introduced this regression - just noticed in error logs today, and fixed.

Require user to look for pre-registered roles.