### PR TITLE
Bugfix/patient list sorting error

### DIFF
--- a/portal/static/js/src/bootstrapTableExtensions.js
+++ b/portal/static/js/src/bootstrapTableExtensions.js
@@ -1,0 +1,13 @@
+import {dateSorter, alphanumericSorter} from "./modules/Utility.js";
+
+/*
+ * global variables, can be used in custom sort in datatable, e.g. patient list
+ */
+var tnthTables = window.tnthTables = {
+    dateSorter : dateSorter,
+    alphanumericSorter: alphanumericSorter
+};
+/*
+ * function used by bootstrap datatable extension lib
+ */
+var alphanum = window.alphanum = alphanumericSorter;

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -431,3 +431,12 @@ export function convertArrayToObject (array, key) {
     }, {});
     return array;
 }
+
+export function dateSorter(a, b) {
+    return new Date(a) - new Date(b);
+}
+export function alphanumericSorter(a, b) {
+    return a.toString().localeCompare(b.toString(), "en", { numeric: true });
+    //The localeCompare() method returns 1 if a reference string comes before, -1 it comes after or 0 if the reference string is the same as the given string.
+    //see relevant discussion here, https://stackoverflow.com/questions/4340227/sort-mixed-alpha-numeric-array
+}

--- a/portal/templates/admin/admin_base.html
+++ b/portal/templates/admin/admin_base.html
@@ -1,8 +1,8 @@
 {%- extends "layout.html" -%}
 {% block additional_scripts %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jasny-bootstrap/3.1.3/js/jasny-bootstrap.min.js"></script>
+<script src="{{ url_for('static', filename='js/dist/bootstrapTableExtensions.bundle.js') }}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.11.1/extensions/export/bootstrap-table-export.min.js"></script>
-<script src="https://cdn.rawgit.com/myadzel/6405e60256df579eda8c/raw/e24a756e168cb82d0798685fd3069a75f191783f/alphanum.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/hhurz/tableExport.jquery.plugin@v1.10.1/tableExport.js" async></script>
 <script src="{{ url_for('static', filename='js/vendor/bootstrap_table_filter_control.js') }}"></script>
 <script src="{{ url_for('static', filename='js/vendor/bootstrap_datatables_extension.js') }}"></script>

--- a/portal/webpack.common.js
+++ b/portal/webpack.common.js
@@ -10,6 +10,7 @@ module.exports = {
         "account": JsSrcPath+"/accountCreation.js",
         "admin": JsSrcPath+"/admin.js",
         "assessmentReport": JsSrcPath+"/assessmentReport.js",
+        "bootstrapTableExtensions": JsSrcPath+"/bootstrapTableExtensions.js",
         "CookieMonster": JsSrcPath+"/CookieMonster.js",
         "coredata": JsSrcPath+"/coredata.js",
         "initialQueries": JsSrcPath+"/initialQueries.js",


### PR DESCRIPTION
https://jira.movember.com/browse/TN-3115
address JS error occurred when sorting columns (e.g. consent date, study id) that use custom sort function, which possible affected the rendering of patient list table

Changes include:

- remove script tag linking to `https://cdn.rawgit.com/myadzel/6405e60256df579eda8c/raw/e24a756e168cb82d0798685fd3069a75f191783f/alphanum.js` as it is no longer present
- create `alphanum` function used by bootstrap extension lib, that was present in the aforementioned JS file that is no longer available  See error:
<img width="1178" alt="Screen Shot 2022-01-05 at 9 10 30 AM" src="https://user-images.githubusercontent.com/12942714/148262520-cbe85d8a-32ae-44b9-bbe1-a2e9720b2782.png">
-  create date sorting function that consentDate column used as custom sort function `tnthTables.dateSorter` (tnthTables.js probably existed at some point, but I can't seem to find when it was removed)
