### PR TITLE
TN-3117 out of window proms UI changes

### DIFF
--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -307,7 +307,7 @@ export default { /*global $ */
             return false;
         }
         roleType = roleType || "patient";
-        this.sendRequest(`/api/${roleType}/${userId}/research_study`, "GET", userId, params, 
+        this.sendRequest(`/api/${roleType}/${userId}/research_study`, "GET", userId, params,
         function(data) {
             if (!data || data.error || !data.research_study) {
                 callback({"error": data.error});
@@ -340,7 +340,7 @@ export default { /*global $ */
                 callback({"error": true});
                 return false;
             }
-            
+
             if (params.retryAttempt < params.maxTryAttempts &&
                 //if the trigger data has not been processed, try again until maximum number of attempts has been reached
                 EMPRO_TRIGGER_PROCCESSED_STATES.indexOf(String(data.state).toLowerCase()) === -1) {
@@ -498,7 +498,7 @@ export default { /*global $ */
                     var expired = tnthDates.getDateDiff(String(item.expires)); /*global tnthDates */
                     return (
                         String(orgId) === String(item.organization_id) &&
-                        String(params.research_study_id) === String(item.research_study_id) && 
+                        String(params.research_study_id) === String(item.research_study_id) &&
                         !item.deleted && !(expired > 0) && String(item.status) === "suspended");
                 });
             }
@@ -682,14 +682,14 @@ export default { /*global $ */
         var self = this;
         callback = callback || function() {};
         this.sendRequest("/api/patient/" + userId + "/procedure", "GET", userId, {sync: true}, function(data) {
-            if (!data || data.error) { 
+            if (!data || data.error) {
                 callback();
                 return false;
             }
             var treatmentData = self.hasTreatment(data);
             if (!treatmentData) {
                 callback();
-                return false; 
+                return false;
             }
             if (String(treatmentData.code) === String(SYSTEM_IDENTIFIER_ENUM.CANCER_TREATMENT_CODE)){
                 self.deleteProc(treatmentData.id, targetField, true, callback);
@@ -1082,6 +1082,24 @@ export default { /*global $ */
         params.data = JSON.stringify(data);
         this.sendRequest("/api/patient/" + userId + "/assessment", "POST", userId, params, function(data) {
             callback({data: data});
+        });
+    },
+    "assessmentTimeline": function(userId, params, callback) {
+        callback = callback || function() {};
+        if (!userId) {
+            callback({error: i18next.t("User id is required.")});
+            return false;
+        }
+        this.sendRequest("/api/patient/" + userId + "/timeline", "GET", userId, params, function(data) {
+            if (data) {
+                if (!data.error) {
+                    callback(data);
+                } else {
+                    callback({"error": i18next.t("Error occurred retrieving assessment timeline.")});
+                }
+            } else {
+                callback({"error": i18next.t("no data returned")});
+            }
         });
     },
     "assessmentList": function(userId, params, callback) {

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -1095,7 +1095,7 @@ export default { /*global $ */
                 if (!data.error) {
                     callback(data);
                 } else {
-                    callback({"error": i18next.t("Error occurred retrieving assessment timeline.")});
+                    callback({"error": i18next.t("Error occurred retrieving assessment list.")});
                 }
             } else {
                 callback({"error": i18next.t("no data returned")});

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -401,14 +401,6 @@ var tnthDates =  { /*global i18next */
      * helper function that returns local timezone in text
      */
     getTimeZoneDisplay: function() {
-        var localTimezone = "";
-        try {
-            localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        } catch(e) {
-            console.log("Intl object not supported ", e);
-            localTimezone = "";
-        }
-        if (localTimezone) return localTimezone;
         return new Date().toLocaleDateString(undefined, {day:"2-digit",timeZoneName: "long" }).substring(4);
     }
 };

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -396,6 +396,20 @@ var tnthDates =  { /*global i18next */
         var d1 = !this.isDateObj(targetDate) ? new Date(targetDate) : targetDate;
         var d2 = !this.isDateObj(comparedDate) ? new Date(comparedDate) : comparedDate;
         return (d1.getTime() > d2.getTime());
+    },
+    /*
+     * helper function that returns local timezone in text
+     */
+    getTimeZoneDisplay: function() {
+        var localTimezone = "";
+        try {
+            localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        } catch(e) {
+            console.log("Intl object not supported ", e);
+            localTimezone = "";
+        }
+        if (localTimezone) return localTimezone;
+        return new Date().toLocaleDateString(undefined, {day:"2-digit",timeZoneName: "long" }).substring(4);
     }
 };
 export default tnthDates;

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -348,27 +348,50 @@ var tnthDates =  { /*global i18next */
      * @param targetDate, a date string or Date object
      * @param startDate, a date string or Date object
      * @param endDate, a date string or Date object
+     * @param startDateInclusive, boolean indicating whether comparison against startdate is inclusive,
+     * i.e. startDate == targetDate
+     * @param endDateInclusive, boolean indicating whether comparison against enddate is inclusive,
+     * i.e. endDate == targetDate
      */
-    isBetweenDates: function(targetDate, startDate, endDate) {
+    isBetweenDates: function(targetDate, startDate, endDate, startDateInclusive, endDateInclusive) {
         if (!targetDate) return false;
         var d1 = !this.isDateObj(targetDate) ? new Date(targetDate) : targetDate;
         var d2 = !this.isDateObj(startDate) ? new Date(startDate) : startDate;
         var d3 = !this.isDateObj(endDate) ? new Date(endDate) : endDate;
-        return (d1.getTime() >= d2.getTime()) && (d1.getTime() < d3.getTime());
+        var startDateComparison = startDateInclusive ? (d1.getTime() >= d2.getTime()) : (d1.getTime() > d2.getTime());
+        var endDateComparison = endDateInclusive ? (d1.getTime() <= d3.getTime()) : (d1.getTime() < d3.getTime());
+        return startDateComparison && endDateComparison;
     },
+    /*
+     * helper function for subtracting day(s) from a date string or a Date object
+     * @param targetDate, a date string or Date object from which day(s) will be subtracted
+     * @param numOfDays, a number representing the number of days
+     */
     minusDate: function(targetDate, numOfDays) {
         if (!numOfDays) numOfDays = 0;
         var dateOffset = (24*60*60*1000) * numOfDays; //day in miliseconds
         targetDate = !this.isDateObj(targetDate) ? new Date(targetDate) : targetDate;
         return targetDate.setTime(targetDate.getTime() - dateOffset);
     },
-    isLessThanDate: function(targetDate, comparedDate) {
+    /*
+     * helper function for determing if a target date string or Date object is less than a given comparison date
+     * @param targetDate a date string or Date object that is used to determine whether it is less than the comparison date
+     * @param comparedDate, a date string or Date object used to compare to target date
+     * @param inclusive boolean, determines whether to allow comparison to be inclusive, i.e. targetDate == comparedDate
+     */
+    isLessThanDate: function(targetDate, comparedDate, inclusive) {
         if (!targetDate) return false;
         var d1 = !this.isDateObj(targetDate) ? new Date(targetDate) : targetDate;
         var d2 = !this.isDateObj(comparedDate) ? new Date(comparedDate) : comparedDate;
-        return (d1.getTime() < d2.getTime());
+        return inclusive ? (d1.getTime() <= d2.getTime()) : (d1.getTime() < d2.getTime());
     },
-    isGreaterThanDate: function(targetDate, comparedDate) {
+    /*
+     * helper function for determing if a target date string or Date object is greater than a given comparison date
+     * @param targetDate a date string or Date object that is used to determine whether it is greater than the comparison date
+     * @param comparedDate, a date string or Date object used to compare to target date
+     * @param inclusive boolean, determines whether to allow comparison to be inclusive, i.e. targetDate == comparedDate
+     */
+    isGreaterThanDate: function(targetDate, comparedDate, inclusive) {
         if (!targetDate) return false;
         var d1 = !this.isDateObj(targetDate) ? new Date(targetDate) : targetDate;
         var d2 = !this.isDateObj(comparedDate) ? new Date(comparedDate) : comparedDate;

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -258,6 +258,10 @@ var tnthDates =  { /*global i18next */
                 nd = this.displayDateString(month, day, year);
                 nd = nd + " " + hours + ":" + minutes + ":" + seconds;
                 break;
+            case "d M y hh:mm":
+                nd = this.displayDateString(month, day, year);
+                nd = nd + " " + hours + ":" + minutes;
+                break;
             case "d M y":
                 nd = this.displayDateString(month, day, year);
                 break;

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -340,8 +340,14 @@ var tnthDates =  { /*global i18next */
             errorMessage = i18next.t("Missing value.");
         }
         return errorMessage;
+    },
+    isBetweenDates: function(targetDate, startDate, endDate) {
+        if (!targetDate) return false;
+        var d1 = new Date(targetDate);
+        var d2 = new Date(startDate);
+        var d3 = new Date(endDate);
+        return (d1.getTime() >= d2.getTime()) && (d1.getTime() <= d3.getTime());
     }
 };
 export default tnthDates;
 export var validateDateInputFields = tnthDates.validateDateInputFields; /* generic validation function for global use */
-

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -341,11 +341,17 @@ var tnthDates =  { /*global i18next */
         }
         return errorMessage;
     },
+    /*
+     * helper method for determining whether a date  is between dates
+     * @param targetDate, a date string or Date object
+     * @param startDate, a date string or Date object
+     * @param endDate, a date string or Date object
+     */
     isBetweenDates: function(targetDate, startDate, endDate) {
         if (!targetDate) return false;
-        var d1 = new Date(targetDate);
-        var d2 = new Date(startDate);
-        var d3 = new Date(endDate);
+        var d1 = !this.isDateObj(targetDate) ? new Date(targetDate) : targetDate;
+        var d2 = !this.isDateObj(startDate) ? new Date(startDate) : startDate;
+        var d3 = !this.isDateObj(endDate) ? new Date(endDate) : endDate;
         return (d1.getTime() >= d2.getTime()) && (d1.getTime() <= d3.getTime());
     }
 };

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -292,7 +292,9 @@ var tnthDates =  { /*global i18next */
          * param is a date object - calculating UTC date using Date object's timezoneOffset method
          * the method return offset in minutes, so need to convert it to miliseconds - adding the resulting offset will be the UTC date/time
          */
+        if (!dObj) return "";
         format = format || "system";
+        if (!this.isDateObj(dObj)) dObj = new Date(dObj);
         var utcDate = new Date(dObj.getTime() + (dObj.getTimezoneOffset()) * 60 * 1000);
         return this.formatDateString(utcDate, format);  //I believe this is a valid python date format, will save it as GMT date/time NOTE, conversion already occurred, so there will be no need for backend to convert it again
     },
@@ -342,7 +344,7 @@ var tnthDates =  { /*global i18next */
         return errorMessage;
     },
     /*
-     * helper method for determining whether a date is between dates
+     * helper method for determining whether a date is greater than or equal to start date and less than end date
      * @param targetDate, a date string or Date object
      * @param startDate, a date string or Date object
      * @param endDate, a date string or Date object
@@ -352,7 +354,25 @@ var tnthDates =  { /*global i18next */
         var d1 = !this.isDateObj(targetDate) ? new Date(targetDate) : targetDate;
         var d2 = !this.isDateObj(startDate) ? new Date(startDate) : startDate;
         var d3 = !this.isDateObj(endDate) ? new Date(endDate) : endDate;
-        return (d1.getTime() >= d2.getTime()) && (d1.getTime() <= d3.getTime());
+        return (d1.getTime() >= d2.getTime()) && (d1.getTime() < d3.getTime());
+    },
+    minusDate: function(targetDate, numOfDays) {
+        if (!numOfDays) numOfDays = 0;
+        var dateOffset = (24*60*60*1000) * numOfDays; //day in miliseconds
+        targetDate = !this.isDateObj(targetDate) ? new Date(targetDate) : targetDate;
+        return targetDate.setTime(targetDate.getTime() - dateOffset);
+    },
+    isLessThanDate: function(targetDate, comparedDate) {
+        if (!targetDate) return false;
+        var d1 = !this.isDateObj(targetDate) ? new Date(targetDate) : targetDate;
+        var d2 = !this.isDateObj(comparedDate) ? new Date(comparedDate) : comparedDate;
+        return (d1.getTime() < d2.getTime());
+    },
+    isGreaterThanDate: function(targetDate, comparedDate) {
+        if (!targetDate) return false;
+        var d1 = !this.isDateObj(targetDate) ? new Date(targetDate) : targetDate;
+        var d2 = !this.isDateObj(comparedDate) ? new Date(comparedDate) : comparedDate;
+        return (d1.getTime() > d2.getTime());
     }
 };
 export default tnthDates;

--- a/portal/static/js/src/modules/TnthDate.js
+++ b/portal/static/js/src/modules/TnthDate.js
@@ -342,7 +342,7 @@ var tnthDates =  { /*global i18next */
         return errorMessage;
     },
     /*
-     * helper method for determining whether a date  is between dates
+     * helper method for determining whether a date is between dates
      * @param targetDate, a date string or Date object
      * @param startDate, a date string or Date object
      * @param endDate, a date string or Date object

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2619,14 +2619,19 @@ export default (function() {
                     }
                     /*
                      * gather list of visits where a visit:
+                     * isn't completed
                      * isn't in the future
                      */
                     self.manualEntry.timeline = data.timeline.filter(function(item) {
                         var visit = item.visit;
                         var oStartDate = new Date(item.at);
                         var today = new Date();
+                        var isCompleted = data.timeline.filter(function(item) {
+                            return (String(item.visit).toLowerCase() === String(visit).toLowerCase()) &&
+                            String(item.status).toLowerCase() === "completed"
+                        }).length > 0;
                         var isFuture = oStartDate.setHours(0, 0, 0, 0) > today.setHours(0, 0, 0, 0);
-                        return String(item.status).toLowerCase() === "due" && !isFuture;
+                        return String(item.status).toLowerCase() === "due" && !isCompleted && !isFuture;
                     }).map(function(item) {
                         item.startDate = item.at;
                         item.endDate = item.expires;

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -244,14 +244,6 @@ export default (function() {
             }
         },
         computed: {
-            propManualEntryErrorMessage: {
-                set: function(newValue) {
-                    this.manualEntry.message = newValue;
-                },
-                get: function() {
-                    return this.manualEntry.message;
-                }
-            },
             computedIsSubStudyPatient: function() {
                 //will re-compute when the dependent prop, this.subjectReseachStudies, updates
                 return this.subjectReseachStudies.indexOf(EPROMS_SUBSTUDY_ID) !== -1;
@@ -2594,7 +2586,13 @@ export default (function() {
                 $("#manualEntryMessageContainer").html(message);
             },
             hasTimeline: function() {
-                return this.manualEntry.timeline && this.manualEntry.timeline.length > 0;
+                if (!this.manualEntry.timeline) return false;
+                //an option is disabled and thus cannot be selected if the visit has been completed
+                var disabledOptions = this.manualEntry.timeline.filter(function(item) {
+                    return item.completed;
+                });
+                if (disabledOptions.length === this.manualEntry.timeline.length) return false;
+                return this.manualEntry.timeline.length > 0;
             },
             hasSelectedManualEntryVisit: function() {
                 if (!this.manualEntry.method || this.manualEntry.method !== "paper") return true;
@@ -2652,10 +2650,10 @@ export default (function() {
                         $("#manualEntryVisitContainer .info").html(
                             i18next.t("The {visit} visit<br/> begins on <b>{startdate}</b><br/>and ends on <b>{enddate}</b>")
                             .replace("{visit}", selectedOption.text())
-                            .replace("{startdate}",self.getFormattedManualEntryVisitDate(
-                                new Date(selectedOption.attr("data-startdate"))))
-                            .replace("{enddate}", self.getFormattedManualEntryVisitDate(
-                                new Date(selectedOption.attr("data-enddate"))))
+                            .replace("{startdate}",self.modules.tnthDates.formatDateString(
+                                new Date(selectedOption.attr("data-startdate")), "d M y hh:mm:ss"))
+                            .replace("{enddate}", self.modules.tnthDates.formatDateString(
+                                new Date(selectedOption.attr("data-enddate")), "d M y hh:mm:ss"))
                         );
                         self.manualEntry.selectedTimeline = {
                             "visit": selectedOption.text(),
@@ -2727,7 +2725,7 @@ export default (function() {
             },
             setOutofWindowDateMessage: function() {
                 if (this.isCompletionDateOutofWindow()) {
-                    this.manualEntry.outofWindowMessage = i18next.t("The date, <b>{date}</b>, is outside the window for the selected visit. If the date entered is correct, please continue.").replace("{date}", this.modules.tnthDates.formatDateString(new Date(this.manualEntry.completionDate), "iso"));
+                    this.manualEntry.outofWindowMessage = i18next.t("The date, <b>{date}</b>, is outside the window for the selected visit. If the date entered is correct, please continue.").replace("{date}", this.modules.tnthDates.formatDateString(new Date(this.manualEntry.completionDate), "d M y hh:mm:ss"));
                     return;
                 }
                 this.manualEntry.outofWindowMessage = "";

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2652,7 +2652,7 @@ export default (function() {
                                 "startDate":selectedOption.attr("data-startdate"),
                                 "endDate":  selectedOption.attr("data-enddate")
                             };
-                        } else self.manualEntry.selectedTimeline = {};
+                        } else self.resetManualEntryVisitFields();
                         self.setOutofWindowDateMessage();
                     });
                 });

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -171,8 +171,8 @@ export default (function() {
                 data: [], hasP3PReport: false
             },
             manualEntry: {
+                init: false,
                 loading: false,
-                initloading: false,
                 method: "",
                 consentDate: "",
                 completionDate: "",
@@ -2531,54 +2531,39 @@ export default (function() {
             initProcedureSection: function() {
                 ProcApp.initViaTemplate();
             },
-            manualEntryModalVis: function(hide) {
-                if (hide) {
-                    /*
-                     * TODO, need to find out why IE is raising vue error here
-                     */
-                    this.manualEntry.loading = true;
-                    $("#manualEntryLoader").show();
-                    $("#manualEntryButtonsContainer").hide();
-                } else {
-                    this.manualEntry.loading = false;
-                    $("#manualEntryLoader").hide();
-                    $("#manualEntryButtonsContainer").show();
-                }
-            },
             continueToAssessment: function(method, completionDate, assessment_url) {
                 if (!assessment_url) {
                     this.manualEntry.errorMessage = i18next.t("The user does not have a valid assessment link.");
                     return false;
                 }
                 var self = this, still_needed = false, subjectId = this.subjectId;
-                this.modules.tnthAjax.getStillNeededCoreData(subjectId, true, function(data) {
+                this.manualEntry.loading = true;
+                this.modules.tnthAjax.getStillNeededCoreData(subjectId, false, function(data) {
                     still_needed = data && data.still_needed && data.still_needed.length;
-                }, method);
-                if (/\?/.test(assessment_url)) { //passing additional query params
-                    assessment_url += "&entry_method=" + method;
-                } else {
-                    assessment_url += "?entry_method=" + method;
-                }
-                if (method === "paper") {
-                    if (self.isCompletionDateOutofWindow()) {
-                        assessment_url += "&authored=" + self.getOutOfWindowAuthoredDate();
-                        assessment_url +="&actual=" + completionDate;
+                    if (/\?/.test(assessment_url)) { //passing additional query params
+                        assessment_url += "&entry_method=" + method;
                     } else {
-                        assessment_url += "&authored=" + completionDate;
+                        assessment_url += "?entry_method=" + method;
                     }
-                }
-                console.log("assessment url ", assessment_url);
-                var winLocation = assessment_url;
-                if (still_needed) {
-                    winLocation = "/website-consent-script/" + $("#manualEntrySubjectId").val() + "?entry_method=" + method + "&subject_id=" + $("#manualEntrySubjectId").val() +
-                    "&redirect_url=" + encodeURIComponent(assessment_url);
-                }
-                this.manualEntryModalVis(true);
-                window.location = winLocation;
-                setTimeout(function(callback) {
-                    callback = callback || function() {};
-                    if (callback) { callback(); }
-                }, 5000, self.manualEntryModalVis);
+                    if (method === "paper") {
+                        if (self.isCompletionDateOutofWindow()) {
+                            assessment_url += "&authored=" + self.getOutOfWindowAuthoredDate();
+                            assessment_url +="&actual=" + completionDate;
+                        } else {
+                            assessment_url += "&authored=" + completionDate;
+                        }
+                    }
+                    console.log("assessment url ", assessment_url);
+                    var winLocation = assessment_url;
+                    if (still_needed) {
+                        winLocation = "/website-consent-script/" + $("#manualEntrySubjectId").val() + "?entry_method=" + method + "&subject_id=" + $("#manualEntrySubjectId").val() +
+                        "&redirect_url=" + encodeURIComponent(assessment_url);
+                    }
+                    window.location = winLocation;
+                    setTimeout(function() {
+                        self.manualEntry.loading = false;
+                    },150);
+                }, method);
             },
             setManualEntryDateToToday: function() {
                 this.manualEntry.todayObj = this.modules.tnthDates.getTodayDateObj();
@@ -2632,8 +2617,21 @@ export default (function() {
                     if (!data && data.timeline && data.timeline.length) {
                         return ;
                     }
+                    /*
+                     * gather list of visits where a visit:
+                     * isn't completed
+                     * isn't in the future
+                     */
                     self.manualEntry.timeline = data.timeline.filter(function(item) {
-                        return String(item.status).toLowerCase() === "due";
+                        var visit = item.visit;
+                        var oStartDate = new Date(item.at);
+                        var today = new Date();
+                        var isFuture = oStartDate.setHours(0, 0, 0, 0) > today.setHours(0, 0, 0, 0);
+                        var isCompleted = data.timeline.filter(function(item) {
+                            return String(item.visit).toLowerCase() === String(visit).toLowerCase() &&
+                            String(item.status).toLowerCase() === "completed";
+                        }).length > 0;
+                        return String(item.status).toLowerCase() === "due" && !isCompleted && !isFuture;
                     }).map(function(item) {
                         item.startDate = item.at;
                         item.endDate = item.expires;
@@ -2641,31 +2639,33 @@ export default (function() {
                     });
                     if (!self.hasTimeline()) return;
                     $("#manualEntryVisitSelector").on("change", function() {
-                        if ($(this).val()) {
-                            var selectedOption = $(this).find("option:selected");
-                            $("#manualEntryVisitContainer .info").html(i18next.t("The {visit} visit<br/> begins on <b>{startdate}</b><br/>and ends on <b>{enddate}</b>")
+                        if (!$(this).val()) {
+                            self.manualEntry.selectedTimeline = {};
+                            return;
+
+                        }
+                        var selectedOption = $(this).find("option:selected");
+                        // display start and end dates for the visit in local date/time
+                        $("#manualEntryVisitContainer .info").html(
+                            i18next.t("The {visit} visit<br/> begins on <b>{startdate}</b><br/>and ends on <b>{enddate}</b>")
                             .replace("{visit}", selectedOption.text())
                             .replace("{startdate}",self.getFormattedManualEntryVisitDate(
                                 new Date(selectedOption.attr("data-startdate"))))
                             .replace("{enddate}", self.getFormattedManualEntryVisitDate(
                                 new Date(selectedOption.attr("data-enddate"))))
-                            );
-                            self.manualEntry.selectedTimeline = {
-                                "visit": selectedOption.text(),
-                                "startDate":selectedOption.attr("data-startdate"),
-                                "endDate":  selectedOption.attr("data-enddate")
-                            };
-                            self.setOutofWindowDateMessage();
-                        } else {
-                            self.resetManualEntryVisitFields();
-                            self.setOutofWindowDateMessage();
-                        }
+                        );
+                        self.manualEntry.selectedTimeline = {
+                            "visit": selectedOption.text(),
+                            "startDate":selectedOption.attr("data-startdate"),
+                            "endDate":  selectedOption.attr("data-enddate")
+                        };
+                        self.setOutofWindowDateMessage();
                     });
                 });
             },
             getManualEntryQuestionnaireDateLabel: function() {
                 if (this.hasTimeline()) {
-                    return i18next.t("When did the patient actually fill in the paper form");
+                    return i18next.t("When did the patient actually fill in the paper form?");
                 }
                 return i18next.t("Questionnaire completion date");
             },
@@ -2677,16 +2677,19 @@ export default (function() {
                 if (!this.isCompletionDateOutofWindow()) {
                     return this.manualEntry.completedDate;
                 }
-                /***
-                - if the completion date comes before the visit starts, use the picked visit’s start as the authored
-                - if the completion date comes after the visit starts, use the end of the visit date minus one day as the authored
-                ***/
+                /*
+                 * if the completion date comes BEFORE the visit starts,
+                 * use the picked visit’s start as the authored date
+                 * if the completion date comes AFTER the visit ends,
+                 * use the end of the visit date MINUS one day as the authored date
+                 */
                 var startDate = this.getFormattedManualEntryVisitDate(
                     this.manualEntry.selectedTimeline.startDate);
-                if (this.modules.tnthDates.isLessThanDate(this.manualEntry.completionDate, startDate)) {
+                if (this.modules.tnthDates.isLessThanDate(this.getFormattedManualEntryVisitDate(this.manualEntry.completionDate), startDate)) {
                     return this.modules.tnthDates.formatDateString(this.manualEntry.selectedTimeline.startDate, "system");
                 }
-                return this.modules.tnthDates.formatDateString(this.manualEntry.selectedTimeline.endDate, "system");
+                return this.modules.tnthDates.getDateWithTimeZone(
+                    this.modules.tnthDates.minusDate(this.manualEntry.selectedTimeline.endDate, 1), "system");
             },
             isCompletionDateOutofWindow: function() {
                 if (this.manualEntry.errorMessage ||
@@ -2713,7 +2716,7 @@ export default (function() {
                     ),
                     this.getFormattedManualEntryVisitDate(
                         this.manualEntry.selectedTimeline.endDate
-                    ));
+                    ), true, false);
                 if (!isBetweenDate) {
                     return true;
                 }
@@ -2721,9 +2724,6 @@ export default (function() {
             },
             setOutofWindowDateMessage: function() {
                 if (this.isCompletionDateOutofWindow()) {
-                    console.log("completion date? ", this.manualEntry.completionDate)
-                    console.log("start date ", this.manualEntry.selectedTimeline.startDate)
-                    console.log("end date ", this.manualEntry.selectedTimeline.endDate)
                     this.manualEntry.outofWindowMessage = i18next.t("The date, <b>{date}</b>, is outside the window for the selected visit. If the date entered is correct, please continue.").replace("{date}", this.modules.tnthDates.formatDateString(new Date(this.manualEntry.completionDate), "iso"));
                     return;
                 }
@@ -2738,7 +2738,7 @@ export default (function() {
                     }
                 });
                 $("#manualEntryModal").on("show.bs.modal", function() {
-                    self.manualEntry.initloading = true;
+                    self.manualEntry.init = true;
                     self.manualEntry.method = "";
                     self.resetManualEntryFormValidationError();
                     //set visits
@@ -2748,7 +2748,7 @@ export default (function() {
                     self.modules.tnthAjax.getConsent(subjectId, {sync: true}, function(data) { //get consent date
                         var dataArray = [];
                         if (!data || !data.consent_agreements || data.consent_agreements.length === 0) {
-                            self.manualEntry.initloading = false;
+                            self.manualEntry.init = false;
                             return false;
                         }
                         dataArray = data.consent_agreements.sort(function(a, b) {
@@ -2778,7 +2778,7 @@ export default (function() {
                         }
                         //set completion date once consent date/time has been set
                         self.setInitManualEntryCompletionDate();
-                        setTimeout(function() { self.manualEntry.initloading = false;}, 150);
+                        setTimeout(function() { self.manualEntry.loading = false;}, 1000);
                     });
                 });
 
@@ -2825,8 +2825,7 @@ export default (function() {
                         var gmtDateObj = tnthDates.getDateObj(y.val(), m.val(), d.val(), 12, 0, 0);
                         self.manualEntry.completionDate = self.modules.tnthDates.getDateWithTimeZone(gmtDateObj, "system");
 
-
-                        //check if date is within the selected visit
+                        //check if date is within the selected visit and display message when applicable
                         self.setOutofWindowDateMessage();
 
                         //add check for consent date
@@ -2860,42 +2859,9 @@ export default (function() {
                     var method = String(self.manualEntry.method), completionDate = self.manualEntry.completionDate;
                     var linkUrl = "/api/present-needed?subject_id=" + $("#manualEntrySubjectId").val();
                     if (method === "") { return false; }
-                    if (method !== "paper") {
-                        self.resetManualEntryFormValidationError();
-                        self.continueToAssessment(method, completionDate, linkUrl);
-                        return false;
-                    }
-                    self.manualEntryModalVis(true);
-                    self.modules.tnthAjax.getCurrentQB(subjectId, completionDate, null, function(data) {
-                        var errorMessage = "";
-                        if (data.error) {
-                            errorMessage = i18next.t("Server error occurred checking questionnaire window");
-                        }
-                        //check questionnaire time windows
-                        if (!data.questionnaire_bank || !Object.keys(data.questionnaire_bank).length) {
-                            errorMessage = i18next.t("Invalid completion date. Date of completion is outside the days allowed.");
-                        }
-                        if (errorMessage) {
-                            self.setManualEntryErrorMessage(errorMessage);
-                            self.manualEntryModalVis();
-                            //use computed property to assign value to error message here,
-                            //IE is throwing error if it is not done this way, not exactly sure why still
-                            self.propManualEntryErrorMessage = errorMessage;
-                            return false;
-                        }
-                        self.resetManualEntryFormValidationError();
-                        self.continueToAssessment(method, completionDate, linkUrl);
-                    });
+                    self.resetManualEntryFormValidationError();
+                    self.continueToAssessment(method, completionDate, linkUrl);
                 });
-
-                /* disabling this to accomodate entry of survey responses on paper */
-                // self.modules.tnthAjax.assessmentStatus(subjectId, function(data) {
-                //     if (!data.error && (data.assessment_status).toUpperCase() === "COMPLETED" &&
-                //         parseInt(data.outstanding_indefinite_work) === 0) {
-                //         $("#assessmentLink").attr("disabled", true);
-                //         $("#enterManualInfoContainer").text(i18next.t("All available questionnaires have been completed."));
-                //     }
-                // });
             },
             updateRolesData: function(event) {
                 var visibleRoles = $("#rolesGroup input:checkbox:checked:visible");

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2565,7 +2565,6 @@ export default (function() {
                         assessment_url +="&visit=" + self.manualEntry.selectedTimeline.visit;
                     }
                 }
-                console.log("assessment url ", assessment_url)
                 var winLocation = assessment_url;
                 if (still_needed) {
                     winLocation = "/website-consent-script/" + $("#manualEntrySubjectId").val() + "?entry_method=" + method + "&subject_id=" + $("#manualEntrySubjectId").val() +
@@ -2612,7 +2611,7 @@ export default (function() {
             hasSelectedManualEntryVisit: function() {
                 if (!this.manualEntry.method || this.manualEntry.method !== "paper") return true;
                 if (!this.hasTimeline()) return true;
-                return this.hasTimeline() && Object.keys(this.manualEntry.selectedTimeline).length > 0;
+                return Object.keys(this.manualEntry.selectedTimeline).length > 0;
             },
             resetManualEntryVisitFields: function() {
                  //reset selected visit and associated timeline info

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2784,7 +2784,7 @@ export default (function() {
                         self.manualEntry.completionDate = self.modules.tnthDates.getDateWithTimeZone(gmtDateObj, "system");
 
 
-                        //check is date is within the selected visit
+                        //check if date is within the selected visit
                         self.setOutofWindowDateMessage();
 
                         //add check for consent date

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2626,15 +2626,18 @@ export default (function() {
                         var visit = item.visit;
                         var oStartDate = new Date(item.at);
                         var today = new Date();
+                        var isFuture = oStartDate.setHours(0, 0, 0, 0) > today.setHours(0, 0, 0, 0);
+                        return String(item.status).toLowerCase() === "due" && !isFuture;
+                    }).map(function(item) {
+                        var visit = item.visit;
                         var isCompleted = data.timeline.filter(function(item) {
                             return (String(item.visit).toLowerCase() === String(visit).toLowerCase()) &&
                             String(item.status).toLowerCase() === "completed"
                         }).length > 0;
-                        var isFuture = oStartDate.setHours(0, 0, 0, 0) > today.setHours(0, 0, 0, 0);
-                        return String(item.status).toLowerCase() === "due" && !isCompleted && !isFuture;
-                    }).map(function(item) {
+                        item.completed = isCompleted;
                         item.startDate = item.at;
                         item.endDate = item.expires;
+                        item.display = isCompleted ? (item.visit + " " + i18next.t("(complete)")) : item.visit;
                         return item;
                     });
                     if (!self.hasTimeline()) return;

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2619,7 +2619,6 @@ export default (function() {
                     }
                     /*
                      * gather list of visits where a visit:
-                     * isn't completed
                      * isn't in the future
                      */
                     self.manualEntry.timeline = data.timeline.filter(function(item) {
@@ -2627,11 +2626,7 @@ export default (function() {
                         var oStartDate = new Date(item.at);
                         var today = new Date();
                         var isFuture = oStartDate.setHours(0, 0, 0, 0) > today.setHours(0, 0, 0, 0);
-                        var isCompleted = data.timeline.filter(function(item) {
-                            return String(item.visit).toLowerCase() === String(visit).toLowerCase() &&
-                            String(item.status).toLowerCase() === "completed";
-                        }).length > 0;
-                        return String(item.status).toLowerCase() === "due" && !isCompleted && !isFuture;
+                        return String(item.status).toLowerCase() === "due" && !isFuture;
                     }).map(function(item) {
                         item.startDate = item.at;
                         item.endDate = item.expires;

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2560,7 +2560,7 @@ export default (function() {
             setManualEntryDateToToday: function() {
                 this.manualEntry.todayObj = this.modules.tnthDates.getTodayDateObj();
                 //set initial completion date as GMT date/time for today based on user timezone
-                this.manualEntry.completionDate = this.manualEntry.todayObj.gmtDate;
+                this.manualEntry.completionDate = this.modules.tnthDates.getDateWithTimeZone((this.manualEntry.todayObj.date).setHours(12,0,0,0));
             },
             setInitManualEntryCompletionDate: function() {
                 //set initial completion date as GMT date/time for today based on user timezone
@@ -2648,12 +2648,13 @@ export default (function() {
                         var selectedOption = $(this).find("option:selected");
                         // display start and end dates for the visit in local date/time
                         $("#manualEntryVisitContainer .info").html(
-                            i18next.t("The {visit} visit<br/> begins on <b>{startdate}</b><br/>and ends on <b>{enddate}</b>")
+                            i18next.t("The {visit} visit<br/> begins on <b>{startdate}</b><br/>and ends on <b>{enddate}</b><br/><span class='small'>( {timezone} )</span>")
                             .replace("{visit}", selectedOption.text())
                             .replace("{startdate}",self.modules.tnthDates.formatDateString(
                                 new Date(selectedOption.attr("data-startdate")), "d M y hh:mm:ss"))
                             .replace("{enddate}", self.modules.tnthDates.formatDateString(
                                 new Date(selectedOption.attr("data-enddate")), "d M y hh:mm:ss"))
+                            .replace("{timezone}", self.modules.tnthDates.getTimeZoneDisplay())
                         );
                         self.manualEntry.selectedTimeline = {
                             "visit": selectedOption.text(),
@@ -2725,7 +2726,9 @@ export default (function() {
             },
             setOutofWindowDateMessage: function() {
                 if (this.isCompletionDateOutofWindow()) {
-                    this.manualEntry.outofWindowMessage = i18next.t("The date, <b>{date}</b>, is outside the window for the selected visit. If the date entered is correct, please continue.").replace("{date}", this.modules.tnthDates.formatDateString(new Date(this.manualEntry.completionDate), "d M y hh:mm:ss"));
+                    this.manualEntry.outofWindowMessage = i18next.t("The date, <b>{date}</b> <span class='small'>( {timezone} )</span>, is outside the window for the selected visit. If the date entered is correct, please continue.")
+                    .replace("{date}", this.modules.tnthDates.formatDateString(new Date(this.manualEntry.completionDate), "d M y hh:mm:ss"))
+                    .replace("{timezone}",this.modules.tnthDates.getTimeZoneDisplay());
                     return;
                 }
                 this.manualEntry.outofWindowMessage = "";

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2664,7 +2664,7 @@ export default (function() {
                 return i18next.t("Questionnaire completion date");
             },
             setOutofWindowDateMessage: function() {
-                if (!this.hasTimeline() || !this.hasSelectedManualEntryVisit()) {
+                if (this.manualEntry.errorMessage || !this.hasTimeline() || !this.hasSelectedManualEntryVisit()) {
                     this.manualEntry.outofWindowMessage = "";
                     return;
                 }
@@ -2776,6 +2776,7 @@ export default (function() {
                         if (errorMessage) {
                             self.manualEntry.errorMessage = errorMessage;
                             self.setManualEntryErrorMessage(errorMessage);
+                            self.setOutofWindowDateMessage();
                             $("#meSubmit").attr("disabled", true);
                             return false;
                         }

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2545,7 +2545,7 @@ export default (function() {
                             assessment_url += "&authored=" + completionDate;
                         }
                     }
-                    console.log("assessment url ", assessment_url);
+                   // console.log("assessment url ", assessment_url);
                     var winLocation = assessment_url;
                     if (still_needed) {
                         winLocation = "/website-consent-script/" + $("#manualEntrySubjectId").val() + "?entry_method=" + method + "&subject_id=" + $("#manualEntrySubjectId").val() +

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2651,9 +2651,9 @@ export default (function() {
                             i18next.t("The {visit} visit<br/> begins on <b>{startdate}</b><br/>and ends on <b>{enddate}</b><br/><span class='small'>( {timezone} )</span>")
                             .replace("{visit}", selectedOption.text())
                             .replace("{startdate}",self.modules.tnthDates.formatDateString(
-                                new Date(selectedOption.attr("data-startdate")), "d M y hh:mm:ss"))
+                                new Date(selectedOption.attr("data-startdate")), "d M y hh:mm"))
                             .replace("{enddate}", self.modules.tnthDates.formatDateString(
-                                new Date(selectedOption.attr("data-enddate")), "d M y hh:mm:ss"))
+                                new Date(selectedOption.attr("data-enddate")), "d M y hh:mm"))
                             .replace("{timezone}", self.modules.tnthDates.getTimeZoneDisplay())
                         );
                         self.manualEntry.selectedTimeline = {
@@ -2727,7 +2727,7 @@ export default (function() {
             setOutofWindowDateMessage: function() {
                 if (this.isCompletionDateOutofWindow()) {
                     this.manualEntry.outofWindowMessage = i18next.t("The date, <b>{date}</b> <span class='small'>( {timezone} )</span>, is outside the window for the selected visit. If the date entered is correct, please continue.")
-                    .replace("{date}", this.modules.tnthDates.formatDateString(new Date(this.manualEntry.completionDate), "d M y hh:mm:ss"))
+                    .replace("{date}", this.modules.tnthDates.formatDateString(new Date(this.manualEntry.completionDate), "d M y hh:mm"))
                     .replace("{timezone}",this.modules.tnthDates.getTimeZoneDisplay());
                     return;
                 }

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -5485,11 +5485,18 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
   margin-top: 1em;
   label {
     position: relative;
-    margin-bottom: 4px;
+    margin-bottom: 2px;
     padding: 0;
+    font-size: @mobileSize;
   }
 }
+#manualEntryCompletionDateContainer {
+  border: 1px solid @muterColor;
+  padding-left: 8px;
+  padding-right: 8px;
+}
 #manualEntryVisitContainer {
+  margin-top: 8px;
   margin-bottom: 24px;
   display: flex;
   select {
@@ -5504,8 +5511,11 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
 }
 #manualEntryWarningMessageContainer {
   margin-top: 8px;
+  margin-bottom: 8px;
+  font-size: 0.95em;
   &:empty {
     margin-top: 0;
+    margin-bottom: 0;
   }
 }
 #emailBodyModal .body-content {

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -5480,12 +5480,32 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
     flex-wrap: wrap
   }
 }
+#manualEntryVisitContainer,
 #manualEntryCompletionDateContainer {
   margin-top: 1em;
   label {
     position: relative;
-    top: 2px;
     margin-bottom: 4px;
+    padding: 0;
+  }
+}
+#manualEntryVisitContainer {
+  margin-bottom: 24px;
+  display: flex;
+  select {
+    width: 200px;
+    max-width: 100%;
+  }
+  .info {
+    margin-left: 16px;
+    margin-top: 24px;
+    font-size: @mobileSize;
+  }
+}
+#manualEntryWarningMessageContainer {
+  margin-top: 8px;
+  &:empty {
+    margin-top: 0;
   }
 }
 #emailBodyModal .body-content {

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -5490,6 +5490,11 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
     font-size: @mobileSize;
   }
 }
+#manualEntryVisitContainer {
+  label {
+    margin-bottom: 6px;
+  }
+}
 #manualEntryCompletionDateContainer {
   border: 1px solid @muterColor;
   padding: 8px 16px;

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -5492,8 +5492,10 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
 }
 #manualEntryCompletionDateContainer {
   border: 1px solid @muterColor;
-  padding-left: 8px;
-  padding-right: 8px;
+  padding: 8px 16px;
+  select {
+    min-width: 160px;
+  }
 }
 #manualEntryVisitContainer {
   margin-top: 8px;

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1294,10 +1294,10 @@
                                     <h4 class="modal-title">{{ _("Enter questionnaire manually on patient's behalf") }}</h4>
                                 </div>
                                 <div class="modal-body">
-                                    <div id="manualEntryBodyLoader" v-show="manualEntry.initloading">
+                                    <div id="manualEntryBodyLoader" v-show="!manualEntry.init">
                                         <i class="fa fa-spinner fa-spin fa-2x loading-message"></i>
                                     </div>
-                                    <div id="manualEntryMain" v-show="!manualEntry.initloading">
+                                    <div id="manualEntryMain" v-show="manualEntry.init">
                                         <p class="text-left">{{ _("Select the method in which the questionnaire will be completed:") }}</p>
                                         <input type="hidden" id="manualEntryConsentDate" v-model="manualEntry.consentDate" />
                                         <input type="hidden" id="qCompletionDate" v-model="manualEntry.completionDate" />
@@ -1326,7 +1326,7 @@
                                                         :data-enddate="item.endDate" v-text="item.visit"></option>
                                                     </select>
                                                 </div>
-                                                <div class="info text-muted"></div>
+                                                <div class="info text-muted" v-show="hasSelectedManualEntryVisit()"></div>
                                             </div>
                                             <label class="text-muted manualentry-date-label" for="manualEntryDateFieldsContainer" v-text="getManualEntryQuestionnaireDateLabel()"></label>
                                             <div id="manualEntryDateFieldsContainer" class="flex">
@@ -1355,7 +1355,7 @@
                                                 </div>
                                             </div>
                                         {% raw %}
-                                            <div id="manualEntryWarningMessageContainer" class="error-message" v-show="hasTimeline()" v-html="manualEntry.outofWindowMessage"></div>
+                                            <div id="manualEntryWarningMessageContainer" class="error-message" v-show="isCompletionDateOutofWindow()" v-html="manualEntry.outofWindowMessage"></div>
                                             <div id="manualEntryMessageContainer" class="error-message help-block with-errors">{{manualEntry.errorMessage}}</div>
                                         {% endraw %}
                                         </div>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1328,7 +1328,7 @@
                                                 </div>
                                                 <div class="info text-muted"></div>
                                             </div>
-                                            <label class="text-muted manualentry-date-label" for="manualEntryDateFieldsContainer">{{_("Questionnaire completion date")}}</label>
+                                            <label class="text-muted manualentry-date-label" for="manualEntryDateFieldsContainer" v-text="getManualEntryQuestionnaireDateLabel()"></label>
                                             <div id="manualEntryDateFieldsContainer" class="flex">
                                                 <div class="flex-item">
                                                     <input class="form-control" id="qCompletionDay" aria-label="{{_('Completion Day')}}"  data-exempt-from-disabling="true" name="qCompletionDay" placeholder="DD" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Date must be valid and in the required format.')}}" autocomplete="off" data-trigger-event="change" v-model="manualEntry.todayObj.displayDay" required />
@@ -1355,7 +1355,7 @@
                                                 </div>
                                             </div>
                                         {% raw %}
-                                            <div id="manualEntryWarningMessageContainer" class="error-message" v-show="hasTimeline()"></div>
+                                            <div id="manualEntryWarningMessageContainer" class="error-message" v-show="hasTimeline()" v-text="manualEntry.outofWindowMessage"></div>
                                             <div id="manualEntryMessageContainer" class="error-message help-block with-errors">{{manualEntry.errorMessage}}</div>
                                         {% endraw %}
                                         </div>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1322,8 +1322,9 @@
                                                     <select class="form-control" id="manualEntryVisitSelector">
                                                         <option value="">{{_("Select")}}</option>
                                                         <option v-for="item in manualEntry.timeline" :value="item.visit"
+                                                        :disabled="item.completed"
                                                         :data-startdate="item.startDate"
-                                                        :data-enddate="item.endDate" v-text="item.visit"></option>
+                                                        :data-enddate="item.endDate" v-text="item.display"></option>
                                                     </select>
                                                 </div>
                                                 <div class="info text-muted" v-show="hasSelectedManualEntryVisit()"></div>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1318,7 +1318,7 @@
                                         <div id="manualEntryCompletionDateContainer" class="form-group" v-show="manualEntry.method == 'paper'">
                                             <div id="manualEntryVisitContainer" v-show="hasTimeline()">
                                                 <div>
-                                                    <label class="text-muted" for="qVisit">{{_("Visit")}}</label>
+                                                    <label class="text-muted" for="qVisit">{{_("Please select a visit")}}</label>
                                                     <select class="form-control" id="manualEntryVisitSelector">
                                                         <option value="">{{_("Select")}}</option>
                                                         <option v-for="item in manualEntry.timeline" :value="item.visit"

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1355,7 +1355,7 @@
                                                 </div>
                                             </div>
                                         {% raw %}
-                                            <div id="manualEntryWarningMessageContainer" class="error-message" v-show="hasTimeline()" v-text="manualEntry.outofWindowMessage"></div>
+                                            <div id="manualEntryWarningMessageContainer" class="error-message" v-show="hasTimeline()" v-html="manualEntry.outofWindowMessage"></div>
                                             <div id="manualEntryMessageContainer" class="error-message help-block with-errors">{{manualEntry.errorMessage}}</div>
                                         {% endraw %}
                                         </div>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1316,7 +1316,19 @@
                                             </div>
                                         </div>
                                         <div id="manualEntryCompletionDateContainer" class="form-group" v-show="manualEntry.method == 'paper'">
-                                            <label class="text-muted" for="manualEntryDateFieldsContainer">{{_("Questionnaire completion date")}}</label>
+                                            <div id="manualEntryVisitContainer" v-show="hasTimeline()">
+                                                <div>
+                                                    <label class="text-muted" for="qVisit">{{_("Visit")}}</label>
+                                                    <select class="form-control" id="manualEntryVisitSelector">
+                                                        <option value="">{{_("Select")}}</option>
+                                                        <option v-for="item in manualEntry.timeline" :value="item.visit"
+                                                        :data-startdate="item.startDate"
+                                                        :data-enddate="item.endDate" v-text="item.visit"></option>
+                                                    </select>
+                                                </div>
+                                                <div class="info text-muted"></div>
+                                            </div>
+                                            <label class="text-muted manualentry-date-label" for="manualEntryDateFieldsContainer">{{_("Questionnaire completion date")}}</label>
                                             <div id="manualEntryDateFieldsContainer" class="flex">
                                                 <div class="flex-item">
                                                     <input class="form-control" id="qCompletionDay" aria-label="{{_('Completion Day')}}"  data-exempt-from-disabling="true" name="qCompletionDay" placeholder="DD" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Date must be valid and in the required format.')}}" autocomplete="off" data-trigger-event="change" v-model="manualEntry.todayObj.displayDay" required />
@@ -1343,6 +1355,7 @@
                                                 </div>
                                             </div>
                                         {% raw %}
+                                            <div id="manualEntryWarningMessageContainer" class="error-message" v-show="hasTimeline()"></div>
                                             <div id="manualEntryMessageContainer" class="error-message help-block with-errors">{{manualEntry.errorMessage}}</div>
                                         {% endraw %}
                                         </div>
@@ -1353,7 +1366,7 @@
                                         <i class="fa fa-spinner fa-spin fa-2x loading-message"></i>
                                     </div>
                                     <div id="manualEntryButtonsContainer" v-show="!manualEntry.loading">
-                                        <a href="#" id="meSubmit" class="btn btn-default" v-bind:disabled="(!manualEntry.method) || manualEntry.errorMessage">{{_("OK")}}</a>
+                                        <a href="#" id="meSubmit" class="btn btn-default" v-bind:disabled="(!manualEntry.method) || manualEntry.errorMessage || !hasSelectedManualEntryVisit()">{{_("OK")}}</a>
                                         <button type="button" class="btn btn-default" data-dismiss="modal">{{_("Cancel")}}</button>
                                     </div>
                                 </div>


### PR DESCRIPTION
https://jira.movember.com/browse/TN-3117

- a new required Visit field is added to the manual entry modal
- If the entered questionnaire completion date is not within the time window of the selected visit, a warning message will appear and tell user as such.  However, the user **will not** be prevented to continue. Dates displayed to the user will be in **local** date/time (down to the minutes)
- a new `actual` (date actually completed) query string is passed on to the backend api when applicable 
- `actual` date is determined if the date comes after the visit starts, the end date of the visit minus one day is passed along; if the date comes before the visit starts, the start date of the visit is passed along
example url that will be passed on from the frontend: ` /api/present-needed?subject_id=3067&entry_method=paper&authored=2022-01-21T01:16:59Z&actual=2022-01-20T01:16:59Z`