### PR TITLE
TN-3118 consume and pass on `actual` date assessment was completed

### DIFF
--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1828,14 +1828,14 @@ def present_assessment(instruments=None):
       - name: authored
         in: query
         description: Override QuestionnaireResponse.authored with given
-          datetime. Optionally set to value within desired visit if "actual"
+          datetime. Optionally set to value within desired visit if `actual`
           date is outside
         required: false
         type: string
         format: date-time
       - name: actual
         in: query
-        description: "Actual" date of completion, to be used exclusively
+        description: actual date of completion, to be used exclusively
          outside of visit [start-expires) dates.  In such an event, `authored`
          should be set to valid datetime within desired visit
         required: false

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1827,16 +1827,17 @@ def present_assessment(instruments=None):
         type: integer
       - name: authored
         in: query
-        description: Override QuestionnaireResponse.authored with given datetime.
-          Optionally set to value within desired visit if "actual" date is outside
+        description: Override QuestionnaireResponse.authored with given
+          datetime. Optionally set to value within desired visit if "actual"
+          date is outside
         required: false
         type: string
         format: date-time
       - name: actual
         in: query
-        description: "Actual" date of completion, to be used exclusively outside
-         of visit [start-expires) dates.  In such an event, `authored` should be
-         set to valid datetime within desired visit
+        description: "Actual" date of completion, to be used exclusively
+         outside of visit [start-expires) dates.  In such an event, `authored`
+         should be set to valid datetime within desired visit
         required: false
         type: string
         format: date-time

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1827,7 +1827,16 @@ def present_assessment(instruments=None):
         type: integer
       - name: authored
         in: query
-        description: Override QuestionnaireResponse.authored with given datetime
+        description: Override QuestionnaireResponse.authored with given datetime.
+          Optionally set to value within desired visit if "actual" date is outside
+        required: false
+        type: string
+        format: date-time
+      - name: actual
+        in: query
+        description: "Actual" date of completion, to be used exclusively outside
+         of visit [start-expires) dates.  In such an event, `authored` should be
+         set to valid datetime within desired visit
         required: false
         type: string
         format: date-time
@@ -1880,6 +1889,7 @@ def present_assessment(instruments=None):
         "resume_identifier": ",".join(resume_identifiers),
         "subject_id": request.args.get('subject_id'),
         "authored": request.args.get('authored'),
+        "actual": request.args.get('actual'),
         "entry_method": request.args.get('entry_method'),
     }
     # Clear empty querystring params


### PR DESCRIPTION
for use exclusively when outside assessment was completed outside visit date boundaries.