### PR TITLE
remove pre-population of today's date in the manual entry completion date fields

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2545,7 +2545,6 @@ export default (function() {
                             assessment_url += "&authored=" + completionDate;
                         }
                     }
-                    console.log("assessment url ", assessment_url);
                     var winLocation = assessment_url;
                     if (still_needed) {
                         winLocation = "/website-consent-script/" + $("#manualEntrySubjectId").val() + "?entry_method=" + method + "&subject_id=" + $("#manualEntrySubjectId").val() +
@@ -2797,7 +2796,6 @@ export default (function() {
                     }
                     //paper entry
                     self.manualEntry.completionDate = "";
-                    //self.setInitManualEntryCompletionDate();
                 });
 
                 self.__convertToNumericField($("#qCompletionDay, #qCompletionYear"));

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2545,7 +2545,7 @@ export default (function() {
                             assessment_url += "&authored=" + completionDate;
                         }
                     }
-                   // console.log("assessment url ", assessment_url);
+                    console.log("assessment url ", assessment_url);
                     var winLocation = assessment_url;
                     if (still_needed) {
                         winLocation = "/website-consent-script/" + $("#manualEntrySubjectId").val() + "?entry_method=" + method + "&subject_id=" + $("#manualEntrySubjectId").val() +
@@ -2796,7 +2796,8 @@ export default (function() {
                         return;
                     }
                     //paper entry
-                    self.setInitManualEntryCompletionDate();
+                    self.manualEntry.completionDate = "";
+                    //self.setInitManualEntryCompletionDate();
                 });
 
                 self.__convertToNumericField($("#qCompletionDay, #qCompletionYear"));
@@ -2815,6 +2816,8 @@ export default (function() {
                         var d = $("#qCompletionDay");
                         var m = $("#qCompletionMonth");
                         var y = $("#qCompletionYear");
+
+                        if (!(d.val() && m.val() && y.val())) return;
 
                         //add true boolean flag to check for future date entry
                         var errorMessage = tnthDates.dateValidator(d.val(), m.val(), y.val(), true);

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -5488,6 +5488,7 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
     margin-bottom: 2px;
     padding: 0;
     font-size: @mobileSize;
+    font-weight: 400;
   }
 }
 #manualEntryVisitContainer {
@@ -5499,21 +5500,35 @@ body.vis-on-callback { /* allow page-specific presentation of content after load
   border: 1px solid @muterColor;
   padding: 8px 16px;
   select {
-    min-width: 160px;
+    min-width: 178px;
+  }
+  .form-group {
+    margin-bottom: 0;
+  }
+  .help-block {
+    font-size: 1em;
   }
 }
 #manualEntryVisitContainer {
   margin-top: 8px;
   margin-bottom: 24px;
   display: flex;
+  flex-wrap: wrap;
   select {
     width: 200px;
     max-width: 100%;
   }
   .info {
-    margin-left: 16px;
+    margin-left: 0;
     margin-top: 24px;
     font-size: @mobileSize;
+  }
+}
+@media (min-width: 567px) {
+  #manualEntryVisitContainer {
+    .info {
+      margin-left: 16px;
+    }
   }
 }
 #manualEntryWarningMessageContainer {

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1332,10 +1332,10 @@
                                             <label class="text-muted manualentry-date-label" for="manualEntryDateFieldsContainer" v-text="getManualEntryQuestionnaireDateLabel()"></label>
                                             <div id="manualEntryDateFieldsContainer" class="flex">
                                                 <div class="flex-item">
-                                                    <input class="form-control" id="qCompletionDay" aria-label="{{_('Completion Day')}}"  data-exempt-from-disabling="true" name="qCompletionDay" placeholder="DD" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Date must be valid and in the required format.')}}" autocomplete="off" data-trigger-event="change" v-model="manualEntry.todayObj.displayDay" required />
+                                                    <input class="form-control" id="qCompletionDay" aria-label="{{_('Completion Day')}}"  data-exempt-from-disabling="true" name="qCompletionDay" placeholder="DD" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Date must be valid and in the required format.')}}" autocomplete="off" data-trigger-event="change" required />
                                                 </div>
                                                 <div class="flex-item" id="qCompletionMonthContainer">
-                                                    <select class="form-control" aria-label="{{_('Month')}}" name="qCompletionMonth" id="qCompletionMonth" data-exempt-from-disabling="true" data-error="{{_('Date must be valid and in the required format.')}}" v-model="manualEntry.todayObj.displayMonth" data-trigger-event="change" required>
+                                                    <select class="form-control" aria-label="{{_('Month')}}" name="qCompletionMonth" id="qCompletionMonth" data-exempt-from-disabling="true" data-error="{{_('Date must be valid and in the required format.')}}" data-trigger-event="change" required>
                                                         <option value="">{{_("Month")}}...</option>
                                                         <option value="01">{{_("January")}}</option>
                                                         <option value="02">{{_("February")}}</option>
@@ -1352,7 +1352,7 @@
                                                     </select>
                                                 </div>
                                                 <div class="flex-item" id="qCompletionYearContainer">
-                                                    <input class="form-control" id="qCompletionYear" name="qCompletionYear" aria-label="{{_('Completion Year')}}" data-exempt-from-disabling="true" placeholder="YYYY" pattern = "(19|20)\d{2}" type="text" maxlength="4" data-error="{{_('Date must be valid and in the required format.')}}" data-trigger-event="change" autocomplete="off" v-model="manualEntry.todayObj.displayYear" required />
+                                                    <input class="form-control" id="qCompletionYear" name="qCompletionYear" aria-label="{{_('Completion Year')}}" data-exempt-from-disabling="true" placeholder="YYYY" pattern = "(19|20)\d{2}" type="text" maxlength="4" data-error="{{_('Date must be valid and in the required format.')}}" data-trigger-event="change" autocomplete="off" required />
                                                 </div>
                                             </div>
                                         {% raw %}

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1315,7 +1315,7 @@
                                                 </label>
                                             </div>
                                         </div>
-                                        <div id="manualEntryCompletionDateContainer" class="form-group" v-show="manualEntry.method == 'paper'">
+                                        <div id="manualEntryCompletionDateContainer" v-show="manualEntry.method == 'paper'">
                                             <div id="manualEntryVisitContainer" v-show="hasTimeline()">
                                                 <div>
                                                     <label class="text-muted" for="qVisit">{{_("Please select a visit")}}</label>
@@ -1330,30 +1330,33 @@
                                                 <div class="info text-muted" v-show="hasSelectedManualEntryVisit()"></div>
                                             </div>
                                             <label class="text-muted manualentry-date-label" for="manualEntryDateFieldsContainer" v-text="getManualEntryQuestionnaireDateLabel()"></label>
-                                            <div id="manualEntryDateFieldsContainer" class="flex">
-                                                <div class="flex-item">
-                                                    <input class="form-control" id="qCompletionDay" aria-label="{{_('Completion Day')}}"  data-exempt-from-disabling="true" name="qCompletionDay" placeholder="DD" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Date must be valid and in the required format.')}}" autocomplete="off" data-trigger-event="change" required />
+                                            <div class="form-group">
+                                                <div id="manualEntryDateFieldsContainer" class="flex">
+                                                    <div class="flex-item">
+                                                        <input class="form-control" id="qCompletionDay" aria-label="{{_('Completion Day')}}"  data-exempt-from-disabling="true" name="qCompletionDay" placeholder="DD" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Date must be valid and in the required format.')}}" autocomplete="off" data-trigger-event="change" required />
+                                                    </div>
+                                                    <div class="flex-item" id="qCompletionMonthContainer">
+                                                        <select class="form-control" aria-label="{{_('Month')}}" name="qCompletionMonth" id="qCompletionMonth" data-exempt-from-disabling="true" data-error="{{_('Date must be valid and in the required format.')}}" data-trigger-event="change" required>
+                                                            <option value="">{{_("Month")}}...</option>
+                                                            <option value="01">{{_("January")}}</option>
+                                                            <option value="02">{{_("February")}}</option>
+                                                            <option value="03">{{_("March")}}</option>
+                                                            <option value="04">{{_("April")}}</option>
+                                                            <option value="05">{{_("May")}}</option>
+                                                            <option value="06">{{_("June")}}</option>
+                                                            <option value="07">{{_("July")}}</option>
+                                                            <option value="08">{{_("August")}}</option>
+                                                            <option value="09">{{_("September")}}</option>
+                                                            <option value="10">{{_("October")}}</option>
+                                                            <option value="11">{{_("November")}}</option>
+                                                            <option value="12">{{_("December")}}</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="flex-item" id="qCompletionYearContainer">
+                                                        <input class="form-control" id="qCompletionYear" name="qCompletionYear" aria-label="{{_('Completion Year')}}" data-exempt-from-disabling="true" placeholder="YYYY" pattern = "(19|20)\d{2}" type="text" maxlength="4" data-error="{{_('Date must be valid and in the required format.')}}" data-trigger-event="change" autocomplete="off" required />
+                                                    </div>
                                                 </div>
-                                                <div class="flex-item" id="qCompletionMonthContainer">
-                                                    <select class="form-control" aria-label="{{_('Month')}}" name="qCompletionMonth" id="qCompletionMonth" data-exempt-from-disabling="true" data-error="{{_('Date must be valid and in the required format.')}}" data-trigger-event="change" required>
-                                                        <option value="">{{_("Month")}}...</option>
-                                                        <option value="01">{{_("January")}}</option>
-                                                        <option value="02">{{_("February")}}</option>
-                                                        <option value="03">{{_("March")}}</option>
-                                                        <option value="04">{{_("April")}}</option>
-                                                        <option value="05">{{_("May")}}</option>
-                                                        <option value="06">{{_("June")}}</option>
-                                                        <option value="07">{{_("July")}}</option>
-                                                        <option value="08">{{_("August")}}</option>
-                                                        <option value="09">{{_("September")}}</option>
-                                                        <option value="10">{{_("October")}}</option>
-                                                        <option value="11">{{_("November")}}</option>
-                                                        <option value="12">{{_("December")}}</option>
-                                                    </select>
-                                                </div>
-                                                <div class="flex-item" id="qCompletionYearContainer">
-                                                    <input class="form-control" id="qCompletionYear" name="qCompletionYear" aria-label="{{_('Completion Year')}}" data-exempt-from-disabling="true" placeholder="YYYY" pattern = "(19|20)\d{2}" type="text" maxlength="4" data-error="{{_('Date must be valid and in the required format.')}}" data-trigger-event="change" autocomplete="off" required />
-                                                </div>
+                                                <div class="help-block with-errors"></div>
                                             </div>
                                         {% raw %}
                                             <div id="manualEntryWarningMessageContainer" class="error-message" v-show="isCompletionDateOutofWindow()" v-html="manualEntry.outofWindowMessage"></div>


### PR DESCRIPTION
As per feedback from https://jira.movember.com/browse/TN-3117

- remove code that pre-populates manual entry completion input date fields with today's date
- fix mobile layout for visit selector and text as per feedback
- fix issue where date validation error message is not being displayed