### PR TITLE
Allow pre-existing extension(s) in questionnaire responses.

### DIFF
--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -641,8 +641,9 @@ def assessment(patient_id, instrument_id):
         # Use FHIR `extension`s to pass these fields to clients.
         extensions = qnr.extensions()
         if extensions:
-            assert('extension' not in qnr.document)  # catch future collisions
-            document['extension'] = extensions
+            if 'extension' not in qnr.document:
+                document['extension'] = []
+            document['extension'].extend(extensions)
 
         documents.append(document)
 


### PR DESCRIPTION
The pre-existing assertion (present as the storage of our internal extensions was destructive) was preventing the necessary use of extensions in QuestionnaireResponse for out-of-band submissions.

Now checking for presence of `extension`s and extending with internal data rather than replace.