### PR TITLE
IRONN-45 add CLI to delete post withdrawn qnrs

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -99,6 +99,24 @@ class QBT(db.Model):
                 vn, name_map[i.qb_id], i.qb_iteration]
         return results
 
+    @staticmethod
+    def withdrawn_qbd(user_id, research_study_id):
+        """Returns active QBD at time of user's withdrawal if applicable
+
+        :returns: a QBD representing the visit active at point of withdrawal
+          from given study, or None if n/a
+        """
+        qbt = QBT.query.filter(QBT.user_id == user_id).filter(
+            QBT.research_study_id == research_study_id).filter(
+            QBT.status == OverallStatus.withdrawn).first()
+        if not qbt:
+            return None
+        return QBD(
+            relative_start=None,
+            iteration=qbt.qb_iteration,
+            recur_id=qbt.qb_recur_id,
+            qb_id=qbt.qb_id)
+
 
 class AtOrderedList(list):
     """Specialize ``list`` to maintain insertion order and ``at`` attribute

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -104,7 +104,8 @@ class QBT(db.Model):
         """Returns active QBD at time of user's withdrawal if applicable
 
         :returns: a QBD representing the visit active at point of withdrawal
-          from given study, or None if n/a
+          from given study, using `relative_start` to hold date-time of
+          withdrawal; or None if n/a
         """
         qbt = QBT.query.filter(QBT.user_id == user_id).filter(
             QBT.research_study_id == research_study_id).filter(
@@ -112,7 +113,7 @@ class QBT(db.Model):
         if not qbt:
             return None
         return QBD(
-            relative_start=None,
+            relative_start=qbt.at,
             iteration=qbt.qb_iteration,
             recur_id=qbt.qb_recur_id,
             qb_id=qbt.qb_id)

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -59,7 +59,7 @@ class QuestionnaireResponse(db.Model):
         db.ForeignKey('questionnaire_banks.id'), nullable=True)
     qb_iteration = db.Column(db.Integer(), nullable=True)
 
-    encounter = db.relationship("Encounter", cascade='delete')
+    encounter = db.relationship("Encounter")
     questionnaire_bank = db.relationship("QuestionnaireBank")
 
     # Fields derived from document content


### PR DESCRIPTION
As per support story IRONN-45, questionnaire responses submitted beyond the visit when a user is withdrawn need to be deleted from the system.

A rather delicate, complicated process, new CLI function `remove-post-withdrawn-qnrs` does just that, including an audit row to track the change.