### PR TITLE
manual entry - today's date/time completion date correction

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2834,7 +2834,7 @@ export default (function() {
                             self.pad(today.getMonth()+1) === self.pad(m.val()) &&
                             self.pad(today.getDate()) === self.pad(d.val())
                         );
-                        // if today's date is entered, just sent in today's date/time
+                        // if today's date is entered, just sent in today's date/time (GMT)
                         if (isToday) self.manualEntry.completionDate = new Date().toISOString();
                         else {
                             var gmtDateObj = tnthDates.getDateObj(y.val(), m.val(), d.val(), 12, 0, 0);

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2559,7 +2559,7 @@ export default (function() {
             setManualEntryDateToToday: function() {
                 this.manualEntry.todayObj = this.modules.tnthDates.getTodayDateObj();
                 //set initial completion date as GMT date/time for today based on user timezone
-                this.manualEntry.completionDate = this.modules.tnthDates.getDateWithTimeZone((this.manualEntry.todayObj.date).setHours(12,0,0,0));
+                this.manualEntry.completionDate = (new Date()).toISOString();
             },
             setInitManualEntryCompletionDate: function() {
                 //set initial completion date as GMT date/time for today based on user timezone
@@ -2827,8 +2827,19 @@ export default (function() {
                             return false;
                         }
 
-                        var gmtDateObj = tnthDates.getDateObj(y.val(), m.val(), d.val(), 12, 0, 0);
-                        self.manualEntry.completionDate = self.modules.tnthDates.getDateWithTimeZone(gmtDateObj, "system");
+                        var today = new Date();
+                        // check if the entered completion date is the same as today's date
+                        var isToday = (
+                            (today.getFullYear()+"") === (y.val()+"") &&
+                            self.pad(today.getMonth()+1) === self.pad(m.val()) &&
+                            self.pad(today.getDate()) === self.pad(d.val())
+                        );
+                        // if today's date is entered, just sent in today's date/time
+                        if (isToday) self.manualEntry.completionDate = new Date().toISOString();
+                        else {
+                            var gmtDateObj = tnthDates.getDateObj(y.val(), m.val(), d.val(), 12, 0, 0);
+                            self.manualEntry.completionDate = self.modules.tnthDates.getDateWithTimeZone(gmtDateObj, "system");
+                        }
 
                         //check if date is within the selected visit and display message when applicable
                         self.setOutofWindowDateMessage();


### PR DESCRIPTION
part of https://jira.movember.com/browse/IRONN-53
As discussed in Slack [thread](https://cirg.slack.com/archives/C5MH9NVKQ/p1650470515742509)

For questionnaire manual entry:
When user enters the completion date that is the same as today's date, today's date/time will be submitted, instead of setting it to `12:00:00` as before.