### PR TITLE
TN-3150 user.clinicians should not include deleted

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1260,7 +1260,7 @@ class User(db.Model, UserMixin):
         from .user_consent import latest_consent
         from .research_study import EMPRO_RS_ID
         consent = latest_consent(self, EMPRO_RS_ID)
-        if consent and len(self.clinicians) == 0:
+        if consent and len([c for c in self.clinicians]) == 0:
             try:
                 pi = User.query.filter(User.roles.any(
                     name=ROLE.PRIMARY_INVESTIGATOR.value)).filter(

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -291,7 +291,7 @@ class User(db.Model, UserMixin):
         db.ForeignKey('audit.id', use_alter=True,
                       name='user_deceased_audit_id_fk'), nullable=True)
     practitioner_id = db.Column(db.ForeignKey('practitioners.id'))
-    clinicians = db.relationship(
+    _clinicians = db.relationship(
         'User',
         secondary="user_clinicians",
         primaryjoin=id == UserClinician.patient_id,
@@ -433,6 +433,10 @@ class User(db.Model, UserMixin):
         return [
             c for c in self._consents
             if c.expires > now and c.deleted_id is None]
+
+    @hybrid_property
+    def clinicians(self):
+        return (c for c in self._clinicians if c.deleted_id is None)
 
     @property
     def display_name(self):
@@ -1261,7 +1265,7 @@ class User(db.Model, UserMixin):
                 pi = User.query.filter(User.roles.any(
                     name=ROLE.PRIMARY_INVESTIGATOR.value)).filter(
                     User.organizations.any(id=consent.organization_id)).one()
-                self.clinicians.append(pi)
+                self._clinicians.append(pi)
                 db.session.commit()
             except NoResultFound:
                 current_app.logger.error(
@@ -1316,9 +1320,9 @@ class User(db.Model, UserMixin):
             if clinician.id in remove_if_not_requested:
                 remove_if_not_requested.pop(clinician.id)
             if clinician not in self.clinicians:
-                self.clinicians.append(clinician)
+                self._clinicians.append(clinician)
         for clinician in remove_if_not_requested.values():
-            self.clinicians.remove(clinician)
+            self._clinicians.remove(clinician)
 
     def update_orgs(self, org_list, acting_user, excuse_top_check=False):
         """Update user's organizations

--- a/tests/test_coredata.py
+++ b/tests/test_coredata.py
@@ -5,7 +5,6 @@ import pytest
 
 from portal.extensions import db
 from portal.models.coredata import Coredata, configure_coredata
-from portal.models.organization import Organization
 from portal.models.role import ROLE
 from tests import TEST_USER_ID
 
@@ -15,18 +14,6 @@ PRIVACY = 'privacy_policy'
 WEB_TOU = 'website_terms_of_use'
 SUBJ_CONSENT = 'subject_website_consent'
 STORED_FORM = 'stored_website_consent_form'
-
-
-@pytest.fixture
-def staff_user(test_user, promote_user):
-    promote_user(role_name=ROLE.STAFF.value)
-    return test_user
-
-
-@pytest.fixture
-def patient_user(test_user, promote_user):
-    promote_user(role_name=ROLE.PATIENT.value)
-    return test_user
 
 
 @pytest.fixture

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -166,7 +166,6 @@ class TestDemographics(TestCase):
         assert user.organizations[0].name == org_name
         assert user.organizations[1].name == org2_name
         assert user.practitioner_id == pract_id
-        assert len(user.clinicians) == 2
         assert set([c.id for c in user.clinicians]) == set(
             (TEST_USER_ID, pi_id))
 
@@ -349,8 +348,8 @@ class TestDemographics(TestCase):
         pi_id = pi.id
         user = db.session.merge(self.test_user)
 
-        user.clinicians.append(pi)
-        user.clinicians.append(user)
+        user._clinicians.append(pi)
+        user._clinicians.append(user)
 
         just_the_pi = {
             "resourceType": "Patient",
@@ -364,8 +363,8 @@ class TestDemographics(TestCase):
 
         assert response.status_code == 200
         user = db.session.merge(self.test_user)
-        assert len(user.clinicians) == 1
-        assert user.clinicians[0] == pi
+        assert len([c for c in user.clinicians]) == 1
+        assert [c for c in user.clinicians][0] == pi
 
     def test_demographics_delete_ref(self):
         # existing careProvider should get removed


### PR DESCRIPTION
Needed to move to a SQLAlchemy @hybrid_property in order to filter out any related clinicians that have been deleted.