### PR TITLE
TN-3151 increase job frequency for EMPRO triggers

### DIFF
--- a/portal/config/eproms/ScheduledJob.json
+++ b/portal/config/eproms/ScheduledJob.json
@@ -225,7 +225,7 @@
       "kwargs": null,
       "name": "IRONMAN EMPRO Trigger Reminder Emails",
       "resourceType": "ScheduledJob",
-      "schedule": "1 4 * * *",
+      "schedule": "1 4,16 * * *",
       "task": "process_triggers_task"
     }
   ],

--- a/portal/config/eproms/ScheduledJob.json
+++ b/portal/config/eproms/ScheduledJob.json
@@ -225,7 +225,7 @@
       "kwargs": null,
       "name": "IRONMAN EMPRO Trigger Reminder Emails",
       "resourceType": "ScheduledJob",
-      "schedule": "1 4,16 * * *",
+      "schedule": "1 4,10,16,22 * * *",
       "task": "process_triggers_task"
     }
   ],


### PR DESCRIPTION
up schedule to run EMPRO trigger job 2x per day, to avoid potential extra day between events.