### PR TITLE
TN-3137 follow up fix - check for empty CSRF token

### DIFF
--- a/portal/static/js/flask_user/CsrfTokenChecker.js
+++ b/portal/static/js/flask_user/CsrfTokenChecker.js
@@ -111,6 +111,7 @@ var CsrfTokenChecker = window.CsrfTokenChecker = (function() {
      * @return boolean true if valid false if not
      */
     csrfTokenChecker.prototype.checkTokenValidity = function() {
+        if (!this.tokenId) return false;
         if (!this.hasEnoughToProceed()) return false;
         var endTime = Date.now();
         var startTime = this.getStorageTimeOnLoad();


### PR DESCRIPTION
Follow up fix to this story:
https://jira.movember.com/browse/TN-3137

- In addition to checking whether CSRF token has expired, a check should also be made about whether a CSRF token **is present** before an ajax request is made (if absent and ajax request is made, error manifested in `404 error: The CSRF token is missing` )