### PR TITLE
TN-3150 continued - found overlooked changes needed.

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -537,7 +537,7 @@ def patient_research_study_status(patient, ignore_QB_status=False):
             'errors': [],
         }
         results[rs] = rs_status
-        if rs == EMPRO_RS_ID and len(patient.clinicians) == 0:
+        if rs == EMPRO_RS_ID and len([c for c in patient.clinicians]) == 0:
             # Enforce biz rule - must have clinician on file.
             trace("no clinician; not eligible")
             rs_status['eligible'] = False

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -118,7 +118,7 @@ def adherence_report(
             if row['status'] == "Expired":
                 row['status'] = "Not Yet Available"
             # TN-3101 include clinician even if not started on EMPRO
-            if research_study_id == EMPRO_RS_ID and len(patient.clinicians) > 0:
+            if research_study_id == EMPRO_RS_ID and len([c for c in patient.clinicians]) > 0:
                 row['clinician'] = ';'.join(
                     clinician.display_name for clinician in
                     patient.clinicians)
@@ -144,7 +144,7 @@ def adherence_report(
                 ts_reporting = TriggerStatesReporting(patient_id=patient.id)
 
                 # Add clinician and trigger data for EMPRO reports
-                if len(patient.clinicians) > 0:
+                if len([c for c in patient.clinicians]) > 0:
                     row['clinician'] = ';'.join(
                         clinician.display_name for clinician in
                         patient.clinicians)


### PR DESCRIPTION
TN-3150 (don't include deleted clinicians) required a change in access to user.clinicians; no longer a simple relationship but now a hybrid property.

Found 3 overlooked refactor points.  All of these cause a server error when hit.