### PR TITLE
Hotfix/delted clinicians not in api

### DIFF
--- a/portal/views/clinician.py
+++ b/portal/views/clinician.py
@@ -18,6 +18,7 @@ clinician_api = Blueprint('clinician_api', __name__)
 def clinician_query(acting_user, org_filter=None):
     """Builds a live query for all clinicians the acting user can view"""
     query = User.query.join(UserRoles).filter(
+        User.deleted_id.is_(None)).filter(
         UserRoles.user_id == User.id).join(Role).filter(
         UserRoles.role_id == Role.id).filter(
         Role.name.in_((

--- a/tests/test_trigger_states.py
+++ b/tests/test_trigger_states.py
@@ -14,6 +14,7 @@ from portal.trigger_states.empro_states import (
     users_trigger_state,
 )
 from portal.trigger_states.models import TriggerState
+from portal.views.clinician import clinician_query
 
 
 def test_initial_state(test_user):
@@ -157,6 +158,10 @@ def test_deleted_staff(
 
     user = db.session.merge(user)
     assert [c for c in user.clinicians] == []
+
+    # confirm they don't remain in the "clinicians_query"
+    results = clinician_query(user)
+    assert results.count() == 0
 
 
 def test_fire_reminders(initialized_patient, triggered_ts, staff_rp_org_user):


### PR DESCRIPTION
API used by front-end to collect eligible clinicians needs to filter out deleted users.