### PR TITLE
TN-3157 potential fix; enhance trigger states logging

### DIFF
--- a/portal/trigger_states/models.py
+++ b/portal/trigger_states/models.py
@@ -47,7 +47,8 @@ class TriggerState(db.Model):
 
     def __repr__(self):
         return (
-            "TriggerState on user {0.user_id}: {0.state}".format(self))
+            f"TriggerState on user {self.user_id}: {self.state} "
+            f"month: {self.visit_month}")
 
     def insert(self, from_copy=False):
         """Shorthand to create/persist a new row as defined


### PR DESCRIPTION
TN-3157 happened due to a failure to persist the correct visit month in a trigger_states transition.

This PR includes a one line code change (shifting the `db.session.commit()` out of a first month only clause in `initiate_trigger()`, so we always persist new or changed trigger_states rows from that function), as they should always be saved, and may potentially be the source bug behind the issue.

All other changes are to better capture trigger_states transitions and persistence in a manner that should be easier to locate in the logs, should the problem persist. 