### PR TITLE
Hotfix/deleted clinician names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ portal/static/css/*.css
 # nodeJS virtual environment and files
 node_env/
 portal/node_modules/
+portal/static/js/dist/*.txt
 
 # auto-generated JS eslint config when linting JS files (via command eslint) at development
 portal/static/js/.eslintrc.js

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -78,8 +78,8 @@ def render_patients_list(
             patient.current_qb = qb_status['visit_name']
             if research_study_id == EMPRO_RS_ID:
                 patient.clinician = '; '.join(
-                    (clinician_name_map[c.id] for c in
-                     patient.clinicians))
+                    (clinician_name_map.get(c.id, "<deleted>") for c in
+                     patient.clinicians)) or "<deleted>"
                 patient.action_state = qb_status['action_state'].title() \
                     if qb_status['action_state'] else ""
             patients_list.append(patient)


### PR DESCRIPTION
Need a workaround to deleted clinicians, or a 500 is generated when viewing /patients/substudy

If a clinician has been deleted, display <deleted> in lieu of their name.