### PR TITLE
scope error on logging statement, interrupting EMPRO trigger task

### DIFF
--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -255,8 +255,6 @@ def configure_logging(app):  # pragma: no cover
         import portal.sql_logging
 
     level = getattr(logging, app.config['LOG_LEVEL'].upper())
-    from ..tasks import logger as task_logger
-    task_logger.setLevel(level)
     app.logger.setLevel(level)
 
     if app.testing or not app.config.get('LOG_FOLDER'):
@@ -292,7 +290,6 @@ def configure_logging(app):  # pragma: no cover
     )
 
     app.logger.addHandler(info_file_handler)
-    task_logger.addHandler(info_file_handler)
 
     # OAuth library logging tends to be helpful for connection
     # debugging

--- a/portal/trigger_states/empro_states.py
+++ b/portal/trigger_states/empro_states.py
@@ -344,8 +344,8 @@ def fire_trigger_events():
             if not hard_triggers:
                 sm.resolve()
 
-        current_app.logger.debug(
-            f"persist-trigger_states-change from fire_trigger_events() {ts}")
+            current_app.logger.debug(
+                f"persist-trigger_states-change from fire_trigger_events() {ts}")
         db.session.commit()
 
         # Now seek out any pending actions, such as reminders to staff


### PR DESCRIPTION
The log statement isn't nested w/i the for loop, but one level out at the point of commit, causing these errors seen in the docker logs:

```
celeryworkerslow_1  | {"written_at": "2022-05-23T16:01:00.019Z", "written_ts": 1653321660019708000, "msg": "Task portal.tasks.process_triggers_task[a274233b-17a6-455d-80dd-a4a72cf353b7] succeeded in 0.014829255640506744s: 'Unexpected exception in `process_triggers_task` on 148 : local variable \\'ts\\' referenced before assignment'", "type": "log", "logger": "celery.app.trace", "thread": "MainThread", "level": "INFO", "module": "trace", "line_no": 124, "correlation_id": "d10db52c-d896-11ec-9b28-0242ac120006"}
```

Was a bit of a mystery as to why this didn't get picked up in our log watcher - presumably as the log level shows as INFO - which doesn't agree with [the source code logging such as ERROR](https://github.com/uwcirg/truenth-portal/blob/develop/portal/tasks.py#L81).  Looks like the "local" `logger` was improperly configured and such log messages were all going in the bit bucket.  Second commit here makes consistent use of `current_app.logger` known to be functional. 