### PR TITLE
Bugfix - visibility of EMPRO report section in patient profile

### DIFF
--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -1124,14 +1124,15 @@ export default { /*global $ */
             }
         });
     },
-    "assessmentReport": function(userId, instrumentId, callback) {
+    "assessmentReport": function(userId, instrumentId, callback, params) {
         callback = callback || function() {};
+        params = params || {};
         if (!userId || !instrumentId) {
             callback({error: i18next.t("User id and instrument Id are required.")});
             return false;
         }
         let storageReportKey = `assessmentReport_${instrumentId}_${userId}`;
-        if (sessionStorage.getItem(storageReportKey)) {
+        if (params.cache && sessionStorage.getItem(storageReportKey)) {
             var data = JSON.parse(sessionStorage.getItem(storageReportKey));
             callback(data);
             return true;

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -55,7 +55,6 @@ export default (function() {
             this.registerDependencies();
             this.getOrgTool();
             this.setUserSettings();
-            this.setSubjectResearchStudies();
             this.onBeforeSectionsLoad();
             this.setCurrentUserOrgs();
             this.initStartTime = new Date();
@@ -92,9 +91,12 @@ export default (function() {
                     var checkFinished = self.initChecks.length === 0;
                     if (checkFinished || (elapsedTime >= 5)) {
                         clearInterval(self.initIntervalId);
-                        self.initSections(function() {
-                            self.onSectionsDidLoad();
-                            self.handleOptionalCoreData();});
+                        //set subject substudy status before initializing sections as the visibilities of some of the sections are dependent on that
+                        self.setSubjectResearchStudies(function() {
+                            self.initSections(function() {
+                                self.onSectionsDidLoad();
+                                self.handleOptionalCoreData();});
+                            });
                     }
                 }, 30);
             });
@@ -570,13 +572,15 @@ export default (function() {
                     this.mode = acoContainer.getAttribute("data-account") === "patient" ? "createPatientAccount": "createUserAccount";
                 }
             },
-            setSubjectResearchStudies: function() {
+            setSubjectResearchStudies: function(callback) {
+                callback = callback||function() {};
                 let roleType = this.isSubjectPatient() ? "patient": "staff";
                 this.modules.tnthAjax.getUserResearchStudies(this.subjectId, roleType, "", data => {
                     if (data) {
                         this.subjectResearchStudyStatuses = data;
                         this.subjectReseachStudies = Object.keys(data).map(item => parseInt(item));
                     }
+                    callback();
                 });
             },
             getOrgTool: function(callback) {
@@ -1382,7 +1386,7 @@ export default (function() {
                         }
                         this.setSubStudyAssessmentData(data.entry);
                         $(`#${CONTAINER_ID}`).html(`<a href="/patients/${this.subjectId}/longitudinal-report/${EPROMS_SUBSTUDY_QUESTIONNAIRE_IDENTIFIER}" id="btnLongitudinalReport" class="btn btn-tnth-primary">${i18next.t("View {title} Report").replace("{title}", EPROMS_SUBSTUDY_SHORT_TITLE)}</a>`);
-                });
+                }, {cache: false});
             },
             setSubStudyTriggers: function(callback, params) {
                 callback = callback || function() {};

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -91,7 +91,8 @@ export default (function() {
                     var checkFinished = self.initChecks.length === 0;
                     if (checkFinished || (elapsedTime >= 5)) {
                         clearInterval(self.initIntervalId);
-                        //set subject substudy status before initializing sections as the visibilities of some of the sections are dependent on that
+                        //setting subject substudy status BEFORE initializing each section in profile
+                        //as the visibilities of some of the sections are dependent on it
                         self.setSubjectResearchStudies(function() {
                             self.initSections(function() {
                                 self.onSectionsDidLoad();


### PR DESCRIPTION
Address story: https://jira.movember.com/browse/TN-3159
See [slack convo](https://cirg.slack.com/archives/C5MH9NVKQ/p1653337089406969)
The visibility of the EMPRO longitudinal report section in the patient profile page is determined by the followings:
- whether the subject is in the sub-study,
- and whether the subject has completed an EMPRO questionnaire

Fixes therefore include:
- Ensure the ajax call to determine whether the subject is in the sub-study is completed **BEFORE** the visibility of the EMPRO longitudinal report section is set.
- Ensure that the questionnaire assessment data is obtained without caching