### PR TITLE
TN-3161 erroneous inclusion of global withdrawn patients in EMPRO adherence

### DIFF
--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -201,6 +201,8 @@ def consent_withdrawal_dates(user, research_study_id):
 
     prior_acceptance = None
     for consent in user.all_consents:
+        if consent.research_study_id != research_study_id:
+            continue
         if not withdrawal_date and (
                 consent.status == 'suspended' and not consent.deleted_id):
             withdrawal_date = consent.acceptance_date


### PR DESCRIPTION
TN-3161 displays a symptom of an overlooked bug in `consent_withdrawal_dates()`.  In the case of no current consent, the lookup for a previous row with status `suspended` did NOT consider the research_study_id.

This thwarted the check to see if a patient should be included in a given adherence report, as it was incorrectly returning withdrawn dates from the global study, when evaluating the EMPRO study.