### PR TITLE
TN-3159 follow up bug fix: EMPRO post intervention report trigger date display and datepicker start date

### DIFF
--- a/portal/eproms_substudy_tailored_content/package-lock.json
+++ b/portal/eproms_substudy_tailored_content/package-lock.json
@@ -4797,9 +4797,9 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1444,7 +1444,7 @@ export default (function() {
                                 completedDate,
                                 i18next.t(
                                     this.modules.tnthDates.formatDateString(completedDate, "d M y hh:mm")+" <span class='small muted'>({timezone})</span>"
-                                ).replace('{timezone}', this.modules.tnthDates.getTimeZoneDisplay()),
+                                ).replace('{timezone}', this.modules.tnthDates.getTimeZoneDisplay()), //local date/time and time zone display
                                 lastTriggerItem.state,
                                 lastTriggerItem.triggers];
                             callback();

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1432,14 +1432,19 @@ export default (function() {
                                 }
                             }
                             let completedDate = lastTriggerItem.triggers.source && lastTriggerItem.triggers.source.authored ? lastTriggerItem.triggers.source.authored : lastTriggerItem.timestamp;
+                            completedDate = new Date(completedDate); //convert to local date/time
                             [
                                 this.subStudyTriggers.domains,
                                 this.subStudyTriggers.date,
+                                this.subStudyTriggers.displaydate,
                                 this.subStudyTriggers.state,
                                 this.subStudyTriggers.data
                             ] = [
                                 domains,
-                                this.modules.tnthDates.formatDateString(completedDate),
+                                completedDate,
+                                i18next.t(
+                                    this.modules.tnthDates.formatDateString(completedDate, "d M y hh:mm")+" <span class='small muted'>({timezone})</span>"
+                                ).replace('{timezone}', this.modules.tnthDates.getTimeZoneDisplay()),
                                 lastTriggerItem.state,
                                 lastTriggerItem.triggers];
                             callback();
@@ -1608,13 +1613,14 @@ export default (function() {
                                 self.setPrevPostTxResponses(self.subStudyTriggers.data.resolution.qnr_id);
                             }
                             if (self.isSubStudyTriggersResolved()) return;
+
                             //initialize datepicker
                             $(`${containerIdentifier} .data-datepicker`).datepicker(
                                 {
                                     "format": "dd M yyyy",
                                     "forceParse": false,
                                     "autoclose": true,
-                                    startDate: new Date(self.subStudyTriggers.date), //restrict entry so date entered cannot be before the trigger date
+                                    startDate: self.subStudyTriggers.date, //restrict entry so date entered cannot be before the trigger date
                                     endDate: new Date()}
                             ).on("changeDate", self.onResponseChangeFieldEvent);
                         });

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -884,7 +884,7 @@
                 <!-- display trigger areas if indicated -->
                 <div id="triggersSection" v-if="hasSubStudyTriggers()">
                     <h5 class="muted" v-show="!isSubStudyTriggersResolved()">{{_("Actions Required (for Clinicians/Site Staff)")}}</h5>
-                    <div class="item">{{_("EMPRO questionnaire completed on:")}} <span class="text" v-text="subStudyTriggers.date"></span></div>
+                    <div class="item">{{_("EMPRO questionnaire completed on:")}} <span class="text" v-html="subStudyTriggers.displaydate"></span></div>
                     <div class="item">{{_("ACTION REQUIRED for high distress areas:")}}
                         <ul class="list">
                             <li v-for="item in subStudyTriggers.domains" v-text="item.replace(/_/g, ' ')" class="text"></li>


### PR DESCRIPTION
Follow fix to https://jira.movember.com/browse/TN-3159

Changes include:
-  convert trigger date to local datetime and display local timezone (see attached)
![interventionReportDate](https://user-images.githubusercontent.com/12942714/172264497-db476918-d346-4b14-90ed-943ec4c8487a.png)

- use converted local trigger date/time for start date of datepicker
