### PR TITLE
Resorting celery task logger imports

### DIFF
--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -255,6 +255,8 @@ def configure_logging(app):  # pragma: no cover
         import portal.sql_logging
 
     level = getattr(logging, app.config['LOG_LEVEL'].upper())
+    from ..tasks import logger as task_logger
+    task_logger.setLevel(level)
     app.logger.setLevel(level)
 
     if app.testing or not app.config.get('LOG_FOLDER'):
@@ -290,6 +292,7 @@ def configure_logging(app):  # pragma: no cover
     )
 
     app.logger.addHandler(info_file_handler)
+    task_logger.addHandler(info_file_handler)
 
     # OAuth library logging tends to be helpful for connection
     # debugging

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -12,6 +12,7 @@ from functools import wraps
 import json
 from traceback import format_exc
 
+from celery.utils.log import get_task_logger
 from flask import current_app
 import redis
 from requests import Request, Session, post
@@ -47,6 +48,8 @@ from .models.user import User, UserRoles
 #   from celery.contrib import rdb
 #   rdb.set_trace()
 # Follow instructions from celery console, i.e. telnet 127.0.0.1 6900
+
+logger = get_task_logger(__name__)
 
 celery = create_celery(create_app())
 LOW_PRIORITY = 'low_priority'


### PR DESCRIPTION
Resorting celery task logger imports, in an attempt to see if this may restore celerybeat health.

(yes, this is a wild guess at the moment, but the only obvious change since updates to the scheduled_jobs stopped functioning and celerybeat started reporting errors)