### PR TITLE
TN-3157 found a more plausible reason for losing track of visit_month

### DIFF
--- a/portal/timeout_lock.py
+++ b/portal/timeout_lock.py
@@ -59,6 +59,11 @@ class TimeoutLock(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.redis.delete(self.key)
+        # To avoid interrupting iterative lock use, return truthy
+        # value to stop exception propagation - see PEP
+        if exc_type is not None:
+            current_app.logger.error(f"{exc_type}: {exc_value}; {traceback}")
+        return True
 
     def is_locked(self):
         """Status check - NOT intended to be combined as an atomic check"""

--- a/portal/trigger_states/empro_states.py
+++ b/portal/trigger_states/empro_states.py
@@ -134,7 +134,8 @@ def users_trigger_state(user_id):
     # if semaphore is locked for user, confirm "inprocess"
     semaphore = TimeoutLock(key=EMPRO_LOCK_KEY.format(user_id=user_id))
     if semaphore and ts.state != "inprocess":
-        current_app.logger.error(f"found {ts.state} w/ semaphore locked?!")
+        current_app.logger.error(
+            f"found {ts.state} for user {ts.user_id} w/ semaphore locked?!")
     return ts
 
 

--- a/portal/trigger_states/empro_states.py
+++ b/portal/trigger_states/empro_states.py
@@ -6,6 +6,7 @@ See also:
 import copy
 from datetime import datetime
 from flask import current_app
+from requests import post
 from smtplib import SMTPRecipientsRefused
 from statemachine import StateMachine, State
 from statemachine.exceptions import TransitionNotAllowed
@@ -21,8 +22,10 @@ from ..models.message import EmailMessage
 from ..models.qb_status import QB_Status
 from ..models.qbd import QBD
 from ..models.questionnaire_bank import QuestionnaireBank
+from ..models.questionnaire_response import QuestionnaireResponse
+from ..models.observation import Observation
 from ..models.user import User
-from ..timeout_lock import LockTimeout, TimeoutLock
+from ..timeout_lock import TimeoutLock
 
 EMPRO_STUDY_ID = 1
 EMPRO_LOCK_KEY = "empro-trigger-state-lock-{user_id}"
@@ -73,42 +76,6 @@ class EMPRO_state(StateMachine):
     fired_events = processed.to(triggered)
     resolve = triggered.to(resolved)
     next_available = resolved.to(due)
-
-
-def enter_user_trigger_critical_section(user_id):
-    """Set semaphore noting users trigger state is actively being processed
-
-    A number of asynchronous tasks are involved in processing a users results
-    and determining their trigger state.  This endpoint is used to set the
-    semaphore used by other parts of the system to determine if results are
-    available or still pending.
-
-    :raises AsyncLockUnavailable: if lock for user is already present
-    :raises TransitionNotAllowed: if user's current trigger state won't allow
-      a transition to the ``inprocess`` state.
-
-    """
-    ts = users_trigger_state(user_id)
-    sm = EMPRO_state(ts)
-    sm.begin_process()
-    # Record the historical transformation via insert.
-    assert ts.visit_month is not None
-    before = ts.visit_month
-    ts.insert(from_copy=True)
-    if ts.visit_month != before:
-        # reload to pick up correct row data post copy
-        current_app.logger.debug(
-            "persist-trigger_states-new from_copy lost state; reload")
-        ts = users_trigger_state(user_id)
-    assert ts.visit_month == before
-    current_app.logger.debug(
-        "persist-trigger_states-new from enter_user_trigger_critical_section()"
-        f" {ts}")
-
-    # Now 'inprocess', obtain the lock to be freed at the conclusion
-    # of `evaluate_triggers()`
-    critical_section = TimeoutLock(key=EMPRO_LOCK_KEY.format(user_id=user_id))
-    critical_section.__enter__()
 
 
 def users_trigger_state(user_id):
@@ -198,7 +165,7 @@ def initiate_trigger(user_id):
     return ts
 
 
-def evaluate_triggers(qnr, override_state=False):
+def evaluate_triggers(qnr):
     """Process state for given QuestionnaireResponse
 
     Complicated set of business rules used to determine trigger state.
@@ -223,23 +190,6 @@ def evaluate_triggers(qnr, override_state=False):
         ts = users_trigger_state(qnr.subject_id)
         sm = EMPRO_state(ts)
 
-        if ts.state == 'processed' and override_state:
-            # go around state machine, setting directly when requested
-            current_app.logger.debug(
-                f"override trigger_states transition from {ts.state} "
-                "to 'inprocess'")
-            ts.state = 'inprocess'
-
-        # typical flow, processing was triggered before SDC handoff
-        # if launched from testing or some catch-up task, initiate now
-        if ts.state != "inprocess":
-            current_app.logger.debug(
-                "evaluate_triggers(): trigger_state transition from "
-                f"{ts.state} to 'inprocess'")
-            enter_user_trigger_critical_section(user_id=qnr.subject_id)
-            # confirm local vars picked up state change
-            assert ts.state == 'inprocess'
-
         # bring together and evaluate available data for triggers
         dm = DomainManifold(qnr)
         ts.triggers = dm.eval_triggers()
@@ -247,15 +197,7 @@ def evaluate_triggers(qnr, override_state=False):
 
         # transition and persist state
         sm.processed_triggers()
-        assert ts.visit_month is not None
-        before = ts.visit_month
         ts.insert(from_copy=True)
-        if ts.visit_month != before:
-            # reload to pick up correct row data post copy
-            current_app.logger.debug(
-                "persist-trigger_states-new from_copy lost state; reload")
-            ts = users_trigger_state(qnr.subject_id)
-        assert ts.visit_month == before
         current_app.logger.debug(
             "persist-trigger_states-new record state change to 'processed' "
             f"from evaluate_triggers() {ts}")
@@ -278,15 +220,9 @@ def evaluate_triggers(qnr, override_state=False):
 
         return ts
 
-    except (TransitionNotAllowed, LockTimeout) as e:
+    except TransitionNotAllowed as e:
         current_app.logger.exception(e)
         raise e
-
-    finally:
-        # All done, release semaphore for this user
-        critical_section = TimeoutLock(key=EMPRO_LOCK_KEY.format(
-            user_id=qnr.subject_id))
-        critical_section.__exit__(None, None, None)
 
 
 def fire_trigger_events():
@@ -302,6 +238,8 @@ def fire_trigger_events():
     'resolved'.
 
     """
+    now = datetime.utcnow()
+
     def send_n_report(em, context, record):
         """Send email, append success/fail w/ context to record"""
         result = {'context': context, 'timestamp': FHIR_datetime.now()}
@@ -318,104 +256,122 @@ def fire_trigger_events():
             result['error'] = msg
             record.append(result)
 
-    # as a job, make sure only running one concurrent instance
+    def process_processed(ts):
+        """Process an individual trigger_states row in the processed state"""
+        # necessary to make deep copy in order to update DB JSON
+        triggers = copy.deepcopy(ts.triggers)
+        triggers['action_state'] = 'not applicable'
+        triggers['actions'] = dict()
+        triggers['actions']['email'] = list()
+
+        # Emails generated for both patient and clinician/staff based
+        # on hard triggers.  Patient gets 'thank you' email regardless.
+        hard_triggers = ts.hard_trigger_list()
+        soft_triggers = ts.soft_trigger_list()
+        pending_emails = []
+        patient = User.query.get(ts.user_id)
+
+        # Patient always gets mail
+        pending_emails.append((
+            patient_email(patient, soft_triggers, hard_triggers),
+            "patient thank you"))
+
+        if hard_triggers:
+            triggers['action_state'] = 'required'
+
+            # In the event of hard_triggers, clinicians/staff get mail
+            for msg in staff_emails(patient, hard_triggers, True):
+                pending_emails.append((msg, "initial staff alert"))
+
+        for em, context in pending_emails:
+            send_n_report(em, context, triggers['actions']['email'])
+
+        # Change state, as this row has been processed.
+        ts.triggers = triggers
+        sm = EMPRO_state(ts)
+        sm.fired_events()
+
+        # Without hard triggers, no further action is necessary
+        if not hard_triggers:
+            sm.resolve()
+
+        current_app.logger.debug(
+            f"persist-trigger_states-change from fire_trigger_events() {ts}")
+
+    def process_pending_actions(ts):
+        """Process a trigger states row needing subsequent action"""
+
+        # Need to consider state == resolved, as the subsequent
+        # EMPRO may have become due, but the previous hasn't yet
+        # received a post intervention QB from staff, noted by
+        # the action_state:
+        if (
+                'action_state' not in ts.triggers or
+                ts.triggers['action_state'] in (
+                'completed', 'missed', 'not applicable',
+                'withdrawn')):
+            return
+
+        if ts.triggers['action_state'] not in ('required', 'overdue'):
+            raise ValueError(
+                f"Invalid action_state {ts.triggers['action_state']} "
+                f"for patient {ts.user_id}")
+
+        patient = User.query.get(ts.user_id)
+
+        # Withdrawn users should never receive reminders, nor staff
+        # about them.
+        qb_status = QB_Status(
+            user=patient, research_study_id=EMPRO_STUDY_ID, as_of_date=now)
+        if qb_status.withdrawn_by(now):
+            triggers = copy.deepcopy(ts.triggers)
+            triggers['action_state'] = 'withdrawn'
+            ts.triggers = triggers
+            current_app.logger.debug(
+                f"persist-trigger_states-change withdrawn clause {ts}")
+            return
+
+        if ts.reminder_due():
+            pending_emails = staff_emails(
+                patient, ts.hard_trigger_list(), False)
+
+            # necessary to make deep copy in order to update DB JSON
+            triggers = copy.deepcopy(ts.triggers)
+            triggers['action_state'] = 'overdue'
+            for em in pending_emails:
+                send_n_report(
+                    em, context="reminder staff alert",
+                    record=triggers['actions']['email'])
+
+            # push updated record back into trigger_states
+            ts.triggers = triggers
+            current_app.logger.debug(
+                f"persist-trigger_states-change reminder_due clause {ts}")
+
+    # Main loop for this task function.  Two locks employed to avoid race
+    # race conditions with other threads updating trigger_states rows.
+    #
+    # As this is a recurring, scheduled job, simply skip over any locked keys
+    # to pick up next run.
+    #
+    # 1. single task concurrency (key='fire_trigger_events')
+    # 2. per user lock also checked elsewhere (key=EMPRO_LOCK_KEY(user_id))
     NEVER_WAIT = 0
     with TimeoutLock(key='fire_trigger_events', timeout=NEVER_WAIT):
         # seek out any pending "processed" work, i.e. triggers recently
         # evaluated
         for ts in TriggerState.query.filter(TriggerState.state == 'processed'):
-            # necessary to make deep copy in order to update DB JSON
-            triggers = copy.deepcopy(ts.triggers)
-            triggers['action_state'] = 'not applicable'
-            triggers['actions'] = dict()
-            triggers['actions']['email'] = list()
-
-            # Emails generated for both patient and clinician/staff based
-            # on hard triggers.  Patient gets 'thank you' email regardless.
-            hard_triggers = ts.hard_trigger_list()
-            soft_triggers = ts.soft_trigger_list()
-            pending_emails = []
-            patient = User.query.get(ts.user_id)
-
-            # Patient always gets mail
-            pending_emails.append((
-                patient_email(patient, soft_triggers, hard_triggers),
-                "patient thank you"))
-
-            if hard_triggers:
-                triggers['action_state'] = 'required'
-
-                # In the event of hard_triggers, clinicians/staff get mail
-                for msg in staff_emails(patient, hard_triggers, True):
-                    pending_emails.append((msg, "initial staff alert"))
-
-            for em, context in pending_emails:
-                send_n_report(em, context, triggers['actions']['email'])
-
-            # Change state, as this row has been processed.
-            ts.triggers = triggers
-            sm = EMPRO_state(ts)
-            sm.fired_events()
-
-            # Without hard triggers, no further action is necessary
-            if not hard_triggers:
-                sm.resolve()
-
-            current_app.logger.debug(
-                f"persist-trigger_states-change from fire_trigger_events() {ts}")
+            with TimeoutLock(
+                    key=EMPRO_LOCK_KEY.format(user_id=ts.user_id), timeout=NEVER_WAIT):
+                process_processed(ts)
         db.session.commit()
 
         # Now seek out any pending actions, such as reminders to staff
-        now = datetime.utcnow()
         for ts in TriggerState.query.filter(
                 TriggerState.state.in_(('triggered', 'resolved'))):
-            # Need to consider state == resolved, as the user may
-            # have a newer EMPRO due, but the previous still hasn't
-            # received a post intervention QB from staff, noted by
-            # the action_state:
-            if (
-                    'action_state' not in ts.triggers or
-                    ts.triggers['action_state'] in (
-                    'completed', 'missed', 'not applicable',
-                    'withdrawn')):
-                continue
-
-            if ts.triggers['action_state'] not in ('required', 'overdue'):
-                raise ValueError(
-                    f"Invalid action_state {ts.triggers['action_state']} "
-                    f"for patient {ts.user_id}")
-
-            patient = User.query.get(ts.user_id)
-
-            # Withdrawn users should never receive reminders, nor staff
-            # about them.
-            qb_status = QB_Status(
-                user=patient, research_study_id=EMPRO_STUDY_ID, as_of_date=now)
-            if qb_status.withdrawn_by(now):
-                triggers = copy.deepcopy(ts.triggers)
-                triggers['action_state'] = 'withdrawn'
-                ts.triggers = triggers
-                current_app.logger.debug(
-                    f"persist-trigger_states-change withdrawn clause {ts}")
-                continue
-
-            if ts.reminder_due():
-                pending_emails = staff_emails(
-                    patient, ts.hard_trigger_list(), False)
-
-                # necessary to make deep copy in order to update DB JSON
-                triggers = copy.deepcopy(ts.triggers)
-                triggers['action_state'] = 'overdue'
-                for em in pending_emails:
-                    send_n_report(
-                        em, context="reminder staff alert",
-                        record=triggers['actions']['email'])
-
-                # push updated record back into trigger_states
-                ts.triggers = triggers
-                current_app.logger.debug(
-                    f"persist-trigger_states-change reminder_due clause {ts}")
-
+            with TimeoutLock(
+                    key=EMPRO_LOCK_KEY.format(user_id=ts.user_id), timeout=NEVER_WAIT):
+                process_pending_actions(ts)
         db.session.commit()
 
 
@@ -526,3 +482,39 @@ def empro_staff_qbd_accessor(qnr):
         result.iteration = triggers['source']['qb_iteration']
         return result
     return qbd_accessor
+
+
+def extract_observations(questionnaire_response_id):
+    """Format and submit QuestionnaireResponse to SDC service; store returned Observations"""
+    qnr = QuestionnaireResponse.query.get(questionnaire_response_id)
+
+    # given asynchronous possibility, require user's EMPRO lock
+    with TimeoutLock(key=EMPRO_LOCK_KEY.format(qnr.subject_id), timeout=60):
+        ts = users_trigger_state(qnr.subject_id)
+        sm = EMPRO_state(ts)
+        sm.begin_process()
+
+        # Record the historical transition via insert, w/ qnr just in case
+        # SDC service isn't available, or some other exception
+        ts.questionnaire_response_id = qnr.id
+        ts.insert(from_copy=True)
+        current_app.logger.debug(
+            "persist-trigger_states-new from enter_user_trigger_critical_section()"
+            f" {ts}")
+
+        qnr_json = qnr.as_sdc_fhir()
+
+        SDC_BASE_URL = current_app.config['SDC_BASE_URL']
+        response = post(f"{SDC_BASE_URL}/$extract", json=qnr_json)
+        response.raise_for_status()
+
+        # Add SDC generated observations to db
+        Observation.parse_obs_bundle(response.json())
+        db.session.commit()
+
+        # With completed scoring, evaluate for triggers
+        evaluate_triggers(qnr)
+
+    # Finally, fire any outstanding actions
+    # NB async locks obtained w/i
+    fire_trigger_events()

--- a/portal/trigger_states/models.py
+++ b/portal/trigger_states/models.py
@@ -66,6 +66,11 @@ class TriggerState(db.Model):
             self.timestamp = None
         db.session.add(self)
         db.session.commit()
+        # following a potential make_transient call, must reload the row
+        # as we intentionally reset the id (to pick up the next in sequence)
+        # and the session.commit() clears all associated object state
+        # see https://github.com/sqlalchemy/sqlalchemy/issues/3640
+        self = db.session.merge(self)
 
     def hard_trigger_list(self):
         """Convenience function to return list of hard trigger domains

--- a/tests/test_trigger_states.py
+++ b/tests/test_trigger_states.py
@@ -8,6 +8,7 @@ from portal.database import db
 from portal.models.audit import Audit
 from portal.trigger_states.empro_domains import DomainTriggers
 from portal.trigger_states.empro_states import (
+    EMPRO_state,
     evaluate_triggers,
     fire_trigger_events,
     initiate_trigger,
@@ -62,6 +63,11 @@ def test_base_eval(
     test_user_id = db.session.merge(test_user).id
     initiate_trigger(test_user_id)
 
+    # mock SDC state transformation
+    ts = users_trigger_state(test_user_id)
+    sm = EMPRO_state(ts)
+    sm.begin_process()
+
     evaluate_triggers(initialized_with_ss_qnr)
     results = users_trigger_state(test_user_id)
 
@@ -91,6 +97,11 @@ def test_2nd_eval(
         db.session.commit()
 
     initiate_trigger(test_user_id)
+
+    # mock SDC state transformation
+    ts = users_trigger_state(test_user_id)
+    sm = EMPRO_state(ts)
+    sm.begin_process()
 
     initialized_with_ss_qnr = db.session.merge(initialized_with_ss_qnr)
     evaluate_triggers(initialized_with_ss_qnr)


### PR DESCRIPTION
Reworked the asynchronous locks to more reliably prevent interruption or race conditions when updating a user's trigger_stats from various threads (jobs, user actions, etc).

Caught another incorrect visit_month scenario with enhanced logging, in the act.  Almost certain the source is behind the trigger_states.insert(from_copy=True) calls, which makes use of SQLAlchemy's `make_transient()` method.

Using `make_transient()` coupled with `db.session.commit()` can lead to unexpected loss of object results.
Now intentionally reloading after any such calls.

See also https://github.com/sqlalchemy/sqlalchemy/issues/3640