### PR TITLE
TN-3164 extend health check to monitor slow celery worker queue

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -63,7 +63,10 @@ from portal.models.user import (
     suppress_email,
     validate_email,
 )
-from portal.tasks import celery_beat_health_check
+from portal.tasks import (
+    celery_beat_health_check,
+    celery_beat_health_check_low_priority_queue,
+)
 
 app = create_app()
 
@@ -445,7 +448,9 @@ def config(config_key):
 
 @app.cli.command()
 def set_celery_beat_healthy():
-    return celery_beat_health_check()
+    return (
+        celery_beat_health_check() and
+        celery_beat_health_check_low_priority_queue())
 
 
 @app.cli.command()

--- a/portal/config/eproms/ScheduledJob.json
+++ b/portal/config/eproms/ScheduledJob.json
@@ -57,10 +57,18 @@
     {
       "active": true,
       "kwargs": null,
-      "name": "Celery Beat Health Check",
+      "name": "Celery Beat Health Check (standard queue)",
       "resourceType": "ScheduledJob",
       "schedule": "*/5 * * * *",
       "task": "celery_beat_health_check"
+    },
+    {
+      "active": true,
+      "kwargs": null,
+      "name": "Celery Beat Health Check (low priority queue)",
+      "resourceType": "ScheduledJob",
+      "schedule": "*/5 * * * *",
+      "task": "celery_beat_health_check_low_priority_queue"
     },
     {
       "active": true,

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -346,12 +346,25 @@ def token_watchdog(**kwargs):
 @celery.task
 @scheduled_task
 def celery_beat_health_check(**kwargs):
-    """Pings the celery beat health check API for monitoring"""
+    """Refreshes self-expiring redis value for /healthcheck of celerybeat"""
 
     rs = redis.StrictRedis.from_url(current_app.config['REDIS_URL'])
     return rs.setex(
         name='last_celery_beat_ping',
         time=current_app.config['LAST_CELERY_BEAT_PING_EXPIRATION_TIME'],
+        value=str(datetime.utcnow()),
+    )
+
+
+@celery.task(queue=LOW_PRIORITY)
+@scheduled_task
+def celery_beat_health_check_low_priority_queue(**kwargs):
+    """Refreshes self-expiring redis value for /healthcheck of celerybeat"""
+
+    rs = redis.StrictRedis.from_url(current_app.config['REDIS_URL'])
+    return rs.setex(
+        name='last_celery_beat_ping_low_priority_queue',
+        time=10*current_app.config['LAST_CELERY_BEAT_PING_EXPIRATION_TIME'],
         value=str(datetime.utcnow()),
     )
 


### PR DESCRIPTION
Adds similar health check functionality (similar to the high-priority check in place) to confirm the low priority job queue is also receiving and running.

QA will require we disable the respective job queues on the system-under-test.