### PR TITLE
elongate the handling time for an ajax request, also elongate the

### DIFF
--- a/portal/static/js/ajaxWorker.js
+++ b/portal/static/js/ajaxWorker.js
@@ -1,4 +1,5 @@
 var requestAttempts = 0;
+var WORKER_REQUEST_TIMEOUT_INTERVAL = 5000;
 function sendRequest(url, params, callback) { //XHR request in pure JavaScript
     requestAttempts++;
     var xhr;
@@ -15,7 +16,7 @@ function sendRequest(url, params, callback) { //XHR request in pure JavaScript
         if (requestAttempts < 3) {
             setTimeout(function() {
                 sendRequest(url, params, callback);
-            }, 2000);
+            }, WORKER_REQUEST_TIMEOUT_INTERVAL);
             return;
         }
         requestAttempts = 0;
@@ -46,6 +47,7 @@ function sendRequest(url, params, callback) { //XHR request in pure JavaScript
             function(dataItem){ return encodeURIComponent(dataItem) + '=' + encodeURIComponent(params.data[dataItem]) }
         ).join('&'));
     }
+    xhr.timeout = params.timeout || WORKER_REQUEST_TIMEOUT_INTERVAL;
     xhr.open("GET", url, true);
     if (!params.cache) {
         xhr.setRequestHeader("cache-control", "no-cache");

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -22,9 +22,11 @@ export default { /*global $ */
     },
     "sendRequest": function(url, method, userId, params, callback) {
         if (!url) { return false; }
+        var REQUEST_TIMEOUT_INTERVAL = 5000;
         var defaultParams = {type: method ? method : "GET", url: url, attempts: 0, max_attempts: MAX_ATTEMPTS, contentType: "application/json; charset=utf-8", dataType: "json", sync: false, timeout: 5000, data: null, useWorker: false, async: true};
         params = params || defaultParams;
         params = $.extend({}, defaultParams, params);
+        params.timeout = params.timeout || REQUEST_TIMEOUT_INTERVAL;
         params.async = params.sync ? false: params.async;
         var self = this;
         var fieldHelper = this.FieldLoaderHelper, targetField = params.targetField || null;
@@ -75,7 +77,7 @@ export default { /*global $ */
                 (function(self, url, method, userId, params, callback) {
                     setTimeout(function() {
                         self.sendRequest(url, method, userId, params, callback);
-                    }, 3000); //retry after 3 seconds
+                    }, REQUEST_TIMEOUT_INTERVAL); //retry after 5 seconds
                 })(self, url, method, userId, params, callback);
             } else {
                 fieldHelper.showError(targetField);


### PR DESCRIPTION
Address recent occurrences of timed out Ajax call errors as seen in logs.

Changes include:

- Elongate the time that an Ajax request can take before terminating to **5** seconds (it was 3 seconds previously)
- Elongate the wait time between each Ajax request retry to **5** seconds (it was 2)