### PR TITLE
TN-3164 enhance healthcheck

### DIFF
--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -96,7 +96,9 @@ class BaseConfig(object):
         os.environ['CELERYD_MAX_TASKS_PER_CHILD']) if os.environ.get(
         'CELERYD_MAX_TASKS_PER_CHILD') else None
 
-    LAST_CELERY_BEAT_PING_EXPIRATION_TIME = 60 * 15  # 15 mins, in seconds
+    FIFTEEN_MINS = 60 * 15  # 15 mins, in seconds
+    LAST_CELERY_BEAT_PING_EXPIRATION_TIME = os.environ.get(
+        "LAST_CELERY_BEAT_PING_EXPIRATION_TIME", FIFTEEN_MINS)
     CACHE_TYPE = 'redis'
     CACHE_REDIS_URL = REDIS_URL
     DOGPILE_CACHE_REGIONS = [

--- a/portal/views/healthcheck.py
+++ b/portal/views/healthcheck.py
@@ -4,6 +4,7 @@ from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
 from flask import Blueprint, current_app
 import redis
+from redis.exceptions import ConnectionError
 from sqlalchemy import text
 
 from ..database import db
@@ -18,16 +19,20 @@ healthcheck_blueprint = Blueprint('healthcheck', __name__)
 def celery_beat_ping():
     """Periodically called by a celery beat task
 
-    Updates the last time we recieved a call to this API.
+    Updates the last time we received a call to this API.
     This allows us to monitor whether celery beat tasks are running
     """
-    rs = redis.StrictRedis.from_url(current_app.config['REDIS_URL'])
-    rs.setex(
-        name='last_celery_beat_ping',
-        time=current_app.config['LAST_CELERY_BEAT_PING_EXPIRATION_TIME'],
-        value=str(datetime.utcnow()),
-    )
-    return 'PONG'
+    try:
+        rs = redis.StrictRedis.from_url(current_app.config['REDIS_URL'])
+        rs.setex(
+            name='last_celery_beat_ping',
+            time=current_app.config['LAST_CELERY_BEAT_PING_EXPIRATION_TIME'],
+            value=str(datetime.utcnow()),
+        )
+        return 'PONG'
+    except ConnectionError as ce:
+        current_app.logger.exception(ce)
+        return None
 
 ##############################
 # Healthcheck functions below
@@ -58,18 +63,22 @@ def celery_available():
 
 def celery_beat_available():
     """Determines whether celery beat is available"""
-    rs = redis.from_url(current_app.config['REDIS_URL'])
+    try:
+        rs = redis.from_url(current_app.config['REDIS_URL'])
 
-    # Celery beat feeds scheduled jobs (a la cron) to the respective
-    # job queues (standard and low priority).  As a monitor, a job
-    # exists in each queue to set a respective value in redis with
-    # an expiration.
+        # Celery beat feeds scheduled jobs (a la cron) to the respective
+        # job queues (standard and low priority).  As a monitor, a job
+        # exists in each queue to set a respective value in redis with
+        # an expiration.
 
-    # If those redis values are present, we assume celery_beat and
-    # both queues are functioning properly.
-    last_celery_beat_ping = rs.get('last_celery_beat_ping')
-    last_celery_beat_ping_low_priority_queue = rs.get(
-        'last_celery_beat_ping_low_priority_queue')
+        # If those redis values are present, we assume celery_beat and
+        # both queues are functioning properly.
+        last_celery_beat_ping = rs.get('last_celery_beat_ping')
+        last_celery_beat_ping_low_priority_queue = rs.get(
+            'last_celery_beat_ping_low_priority_queue')
+    except ConnectionError:
+        return False, "Redis connection failed"
+
     if last_celery_beat_ping and last_celery_beat_ping_low_priority_queue:
         return True, 'Celery beat is available.'
 
@@ -99,8 +108,8 @@ def redis_available():
     # Ping redis. If it succeeds we assume redis
     # is available. Otherwise we assume
     # it's not available
-    rs = redis.from_url(current_app.config["REDIS_URL"])
     try:
+        rs = redis.from_url(current_app.config["REDIS_URL"])
         rs.ping()
         return True, 'Redis is available.'
     except Exception as e:


### PR DESCRIPTION
testing exposed down services (such as redis or celery) generate exceptions (which do effectively trigger alerts and log filters) but fail to return accurate health lead additional exception handling within healthchecks to capture and return state when redis is down.

worth noting, when celery is down, healthcheck hangs, but monitoring services such as icinga would catch such a deadlock.