### PR TITLE
TN-3175 fix locale code passed to LR to retrieve sub-study content

### DIFF
--- a/portal/eproms_substudy_tailored_content/src/js/Base.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Base.js
@@ -144,7 +144,8 @@ export default {
             this.userId = id;
         },
         getLocale() {
-            return this.locale.replace('_', '-');
+            // LR expects locale code like, en_CA, en_GBs
+            return this.locale.replace('-', '_');
         },
         setLocale(data) {
             if (!data) {


### PR DESCRIPTION
bug found when testing https://jira.movember.com/browse/TN-3175

LF expect locales delimited by `_` as opposed to `-`

see convo [here](https://mo-programs.slack.com/archives/GV6K6SURW/p1658334965733719)

Fix include:
-  fix the locale code passed to LR to retrieve sub-study content