### PR TITLE
TN-3178 don't start indef prior to consent

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -198,6 +198,9 @@ class QB_Status(object):
         for q in qbs:
             if self._current_indef is not None:
                 raise RuntimeError("unexpected second indef qb")
+            if q.relative_start > self.as_of_date:
+                # Don't include if the consent date hasn't arrived
+                continue
             self._current_indef = q
 
     def indef_status(self):

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -406,7 +406,7 @@ class TestQB_Status(TestQuestionnaireSetup):
 
     def test_enrolled_in_metastatic(self):
         """metastatic should include baseline and indefinite"""
-        self.bless_with_basics(local_metastatic='metastatic')
+        self.bless_with_basics(local_metastatic='metastatic', setdate=now)
         user = db.session.merge(self.test_user)
 
         a_s = QB_Status(

--- a/tests/test_qb_timeline.py
+++ b/tests/test_qb_timeline.py
@@ -559,6 +559,34 @@ class TestQbTimeline(TestQuestionnaireBankFixture):
         with pytest.raises(StopIteration):
             next(gen)
 
+    def test_indef_assignment_post_consent(self):
+        org = self.setup_org_qbs(rp_name='v3', include_indef=True)
+        org_id = org.id
+        back7, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=7))
+        self.consent_with_org(org_id=org_id, setdate=back7)
+        user = db.session.merge(self.test_user)
+
+        a_s = QB_Status(
+            user=user,
+            research_study_id=0,
+            as_of_date=nowish)
+        assert a_s.enrolled_in_classification('indefinite')
+
+    def test_indef_assignment_pre_consent(self):
+        org = self.setup_org_qbs(rp_name='v3', include_indef=True)
+        org_id = org.id
+        tomorrow, nowish = associative_backdate(
+            now=now, backdate=relativedelta(days=-1))
+        self.consent_with_org(org_id=org_id, setdate=tomorrow)
+        user = db.session.merge(self.test_user)
+
+        a_s = QB_Status(
+            user=user,
+            research_study_id=0,
+            as_of_date=nowish)
+        assert a_s.enrolled_in_classification('indefinite') is None
+
 
 class Test_QB_StatusCacheKey(TestCase):
 


### PR DESCRIPTION
Now that we allow future consent dates, need to prevent the "special" indefinite QB from being started prior to the passage of the consent moment.