### PR TITLE
Traefik Ingress

### DIFF
--- a/docker/docker-compose.static-ingress.yaml
+++ b/docker/docker-compose.static-ingress.yaml
@@ -1,0 +1,9 @@
+# docker-compose override to expose web container port (80) to local VM
+# listens on the local VM at http://localhost:${EXTERNAL_PORT}
+---
+version: "3.9"
+services:
+  web:
+    ports:
+      # map container port 80 to host port configured by ${EXTERNAL_PORT}
+      - "127.0.0.1:${EXTERNAL_PORT:-8080}:80"

--- a/docker/docker-compose.traefik-ingress.yaml
+++ b/docker/docker-compose.traefik-ingress.yaml
@@ -1,0 +1,26 @@
+# docker-compose ingress overrides for traefik
+---
+version: "3.9"
+services:
+  web:
+    labels:
+      - "traefik.enable=true"
+      # Traefik will route requests with Host matching the SERVER_NAME environment variable (see .env)
+      - "traefik.http.routers.portal-${COMPOSE_PROJECT_NAME}.rule=Host(`${SERVER_NAME}`)"
+
+      - "traefik.http.routers.portal-${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.portal-${COMPOSE_PROJECT_NAME}.tls=true"
+      - "traefik.http.routers.portal-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
+    networks:
+      - ingress
+      # TODO rename to internal
+      # internal network
+      - default
+    environment:
+      PREFERRED_URL_SCHEME: https
+
+networks:
+  # ingress network
+  ingress:
+    name: external_web
+    external: "true"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -20,6 +20,8 @@ x-service-base: &service_base
 services:
   web:
     <<: *service_base
+    # TODO remove `ports` section
+    # NB `ports` now has its own override: docker-compose.static-ingress.yaml
     ports:
       - target: ${PORT:-8008}
         published: ${EXTERNAL_PORT:-8080}


### PR DESCRIPTION
- Add docker-compose override to allow config via Traefik
  - Set `SERVER_NAME` in `.env` to match DNS Hostname (eg `eproms.ubu.ivanc.dev.cirg.uw.edu`)
- Add docker-compose override for exposing port (current apache deploy method)
  - `ports:` section will be removed from docker-compose.yaml at a later date
