### PR TITLE
Feature/audit request extend timeout

### DIFF
--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -78,7 +78,7 @@ export default { /*global $ */
                 (function(self, url, method, userId, params, callback) {
                     setTimeout(function () {
                       self.sendRequest(url, method, userId, params, callback);
-                    }, RETRY_INTERVAL); //retry after 5
+                    }, RETRY_INTERVAL); //retry after 5 seconds
                 })(self, url, method, userId, params, callback);
             } else {
                 fieldHelper.showError(targetField);

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -23,7 +23,6 @@ export default { /*global $ */
     "sendRequest": function(url, method, userId, params, callback) {
         if (!url) { return false; }
         var REQUEST_TIMEOUT_INTERVAL = 5000; // default timed out at 5 seconds
-        var RETRY_INTERVAL = 5000; // wait 5 seconds before retry
         var defaultParams = {type: method ? method : "GET", url: url, attempts: 0, max_attempts: MAX_ATTEMPTS, contentType: "application/json; charset=utf-8", dataType: "json", sync: false, timeout: REQUEST_TIMEOUT_INTERVAL, data: null, useWorker: false, async: true};
         params = params || defaultParams;
         params = $.extend({}, defaultParams, params);
@@ -78,7 +77,7 @@ export default { /*global $ */
                 (function(self, url, method, userId, params, callback) {
                     setTimeout(function () {
                       self.sendRequest(url, method, userId, params, callback);
-                    }, RETRY_INTERVAL); //retry after 5 seconds
+                    }, REQUEST_TIMEOUT_INTERVAL); //retry after 5 seconds
                 })(self, url, method, userId, params, callback);
             } else {
                 fieldHelper.showError(targetField);

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -22,8 +22,8 @@ export default { /*global $ */
     },
     "sendRequest": function(url, method, userId, params, callback) {
         if (!url) { return false; }
-        var REQUEST_TIMEOUT_INTERVAL = 10000; // default timed out at 10 seconds
-        var RETRY_INTERVAL = 10000; // wait 10 seconds before retry
+        var REQUEST_TIMEOUT_INTERVAL = 5000; // default timed out at 5 seconds
+        var RETRY_INTERVAL = 5000; // wait 5 seconds before retry
         var defaultParams = {type: method ? method : "GET", url: url, attempts: 0, max_attempts: MAX_ATTEMPTS, contentType: "application/json; charset=utf-8", dataType: "json", sync: false, timeout: REQUEST_TIMEOUT_INTERVAL, data: null, useWorker: false, async: true};
         params = params || defaultParams;
         params = $.extend({}, defaultParams, params);
@@ -78,7 +78,7 @@ export default { /*global $ */
                 (function(self, url, method, userId, params, callback) {
                     setTimeout(function () {
                       self.sendRequest(url, method, userId, params, callback);
-                    }, RETRY_INTERVAL); //retry after 10
+                    }, RETRY_INTERVAL); //retry after 5
                 })(self, url, method, userId, params, callback);
             } else {
                 fieldHelper.showError(targetField);

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -22,7 +22,7 @@ export default { /*global $ */
     },
     "sendRequest": function(url, method, userId, params, callback) {
         if (!url) { return false; }
-        var REQUEST_TIMEOUT_INTERVAL = 10 * 1000; // default timed out at 30 seconds
+        var REQUEST_TIMEOUT_INTERVAL = 10 * 1000; // default timed out at 10 seconds
         var RETRY_INTERVAL = 5000; // wait 5 seconds before retry
         var defaultParams = {type: method ? method : "GET", url: url, attempts: 0, max_attempts: MAX_ATTEMPTS, contentType: "application/json; charset=utf-8", dataType: "json", sync: false, timeout: REQUEST_TIMEOUT_INTERVAL, data: null, useWorker: false, async: true};
         params = params || defaultParams;

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -22,8 +22,8 @@ export default { /*global $ */
     },
     "sendRequest": function(url, method, userId, params, callback) {
         if (!url) { return false; }
-        var REQUEST_TIMEOUT_INTERVAL = 10 * 1000; // default timed out at 10 seconds
-        var RETRY_INTERVAL = 5000; // wait 5 seconds before retry
+        var REQUEST_TIMEOUT_INTERVAL = 10000; // default timed out at 10 seconds
+        var RETRY_INTERVAL = 10000; // wait 10 seconds before retry
         var defaultParams = {type: method ? method : "GET", url: url, attempts: 0, max_attempts: MAX_ATTEMPTS, contentType: "application/json; charset=utf-8", dataType: "json", sync: false, timeout: REQUEST_TIMEOUT_INTERVAL, data: null, useWorker: false, async: true};
         params = params || defaultParams;
         params = $.extend({}, defaultParams, params);
@@ -78,7 +78,7 @@ export default { /*global $ */
                 (function(self, url, method, userId, params, callback) {
                     setTimeout(function () {
                       self.sendRequest(url, method, userId, params, callback);
-                    }, RETRY_INTERVAL); //retry after 5 seconds
+                    }, RETRY_INTERVAL); //retry after 10
                 })(self, url, method, userId, params, callback);
             } else {
                 fieldHelper.showError(targetField);

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -22,8 +22,9 @@ export default { /*global $ */
     },
     "sendRequest": function(url, method, userId, params, callback) {
         if (!url) { return false; }
-        var REQUEST_TIMEOUT_INTERVAL = 5000;
-        var defaultParams = {type: method ? method : "GET", url: url, attempts: 0, max_attempts: MAX_ATTEMPTS, contentType: "application/json; charset=utf-8", dataType: "json", sync: false, timeout: 5000, data: null, useWorker: false, async: true};
+        var REQUEST_TIMEOUT_INTERVAL = 10 * 1000; // default timed out at 30 seconds
+        var RETRY_INTERVAL = 5000; // wait 5 seconds before retry
+        var defaultParams = {type: method ? method : "GET", url: url, attempts: 0, max_attempts: MAX_ATTEMPTS, contentType: "application/json; charset=utf-8", dataType: "json", sync: false, timeout: REQUEST_TIMEOUT_INTERVAL, data: null, useWorker: false, async: true};
         params = params || defaultParams;
         params = $.extend({}, defaultParams, params);
         params.timeout = params.timeout || REQUEST_TIMEOUT_INTERVAL;
@@ -75,9 +76,9 @@ export default { /*global $ */
         }).fail(function(xhr) {
             if (params.attempts < params.max_attempts) {
                 (function(self, url, method, userId, params, callback) {
-                    setTimeout(function() {
-                        self.sendRequest(url, method, userId, params, callback);
-                    }, REQUEST_TIMEOUT_INTERVAL); //retry after 5 seconds
+                    setTimeout(function () {
+                      self.sendRequest(url, method, userId, params, callback);
+                    }, RETRY_INTERVAL); //retry after 5 seconds
                 })(self, url, method, userId, params, callback);
             } else {
                 fieldHelper.showError(targetField);

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2994,7 +2994,8 @@ export default (function() {
                 var self = this, errorMessage = "";
                 $("#profileAuditLogTable").html(Utility.getLoaderHTML());
                 $("#profileAuditLogTable .loading-message-indicator").show();
-                this.modules.tnthAjax.auditLog(this.subjectId, {useWorker:true}, function(data) {
+                // set request times out at 5 minutes
+                this.modules.tnthAjax.auditLog(this.subjectId, {useWorker:true, timeout: 5 * 60 * 1000}, function(data) {
                     if (data.error) {
                         errorMessage = i18next.t("Error retrieving data from server");
                     }


### PR DESCRIPTION
address issue https://jira.movember.com/browse/IRONN-86
Extend timeout for audit Ajax request, noting that some can take up to almost 30 seconds.  For example see: https://eproms.truenth.org/profile/4 which has more than 3000 audit records.

Changes include:

- extend maximum timeout for an audit Ajax request to 5 minutes to confront accounts that may have tons of audit records


