### PR TITLE
TN-3188 hide "pending work in base study" error in clinician intervention questionnaire

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -571,7 +571,7 @@ def patient_research_study_status(patient, ignore_QB_status=False):
             if results[0]['ready']:
                 # Clear ready status when base has pending work
                 rs_status['ready'] = False
-                rs_status['errors'].append('Participant has pending questionnaire in main IRONMAN study')
+                rs_status['errors'].append('Pending work in base study')
             elif not patient.email_ready():
                 # Avoid errors from automated emails, that is, email required
                 rs_status['ready'] = False

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -571,7 +571,7 @@ def patient_research_study_status(patient, ignore_QB_status=False):
             if results[0]['ready']:
                 # Clear ready status when base has pending work
                 rs_status['ready'] = False
-                rs_status['errors'].append('Pending work in base study')
+                rs_status['errors'].append('Participant has pending questionnaire in main IRONMAN study')
             elif not patient.email_ready():
                 # Avoid errors from automated emails, that is, email required
                 rs_status['ready'] = False

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -269,10 +269,7 @@ export default (function() {
             },
             computedOptionalCoreData: function() {
                 return this.optionalCoreData;
-            },
-            subStudyStaffEligible: function() {
-                return this.subjectResearchStudyStatuses[EPROMS_SUBSTUDY_ID] && this.subjectResearchStudyStatuses[EPROMS_SUBSTUDY_ID]["intervention_qnr_eligible"];
-            },
+            }
         },
         methods: {
             registerDependencies: function() {
@@ -636,9 +633,6 @@ export default (function() {
             },
             isSubStudyPatient: function() {
                 return this.computedIsSubStudyPatient;
-            },
-            isSubStudyStaffEligible: function() {
-                return this.subStudyStaffEligible;
             },
             hasSubStudyStatusErrors: function() {
                 return this.hasResearchStudyStatusErrors(EPROMS_SUBSTUDY_ID);
@@ -1511,11 +1505,32 @@ export default (function() {
                      });
                 });
             },
+            isPostTxQuestionnaireEligible: function() {
+                const objResearchStudy = this.getResearchStudyStatus(EPROMS_SUBSTUDY_ID);
+                return (
+                  objResearchStudy &&
+                  objResearchStudy["intervention_qnr_eligible"]
+                );
+            },
             shouldShowSubstudyPostTx: function() {
                 return this.isSubStudyPatient() && (this.isPostTxActionRequired() || this.hasPrevSubStudyPostTx());
             },
             shouldDisableSubstudyPostTx: function() {
-                return this.isSubStudyTriggersResolved() || !this.isSubStudyStaffEligible();
+                return (
+                  !this.isPostTxQuestionnaireEligible() ||
+                  this.isSubStudyTriggersResolved()
+                );
+            },
+            hasPostTxQuestionnaireErrors: function() {
+              // see API /api/patient/[id]/research_study
+              // USE intervention_qnr_eligible flag returned from the API to determine whether to display error(s) related to post tx questionnaire eligibility
+              // the flag is set to FALSE if there is any associated error
+              // NOTE: intervention_qnr_eligible flag is still TRUE even if there is any pending IRONMAN main study questionnaire
+              // that makes sense as staff can still fill in post tx questionnaire
+              return (
+                !this.isPostTxQuestionnaireEligible() &&
+                this.hasSubStudyStatusErrors()
+              );
             },
             getPostTxActionStatus: function() {
                 if (!this.subStudyTriggers.data || !this.subStudyTriggers.data.action_state) {

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -980,7 +980,7 @@
                     <span>{{_("Action status:")}}</span>
                     <span class="text error-message" v-text="getPostTxActionStatus()"></span>
                 </div>
-                <div class="study-error error-message" v-show="shouldDisableSubstudyPostTx() && hasSubStudyStatusErrors()">
+                <div class="study-error error-message" v-show="shouldDisableSubstudyPostTx() && hasPostTxQuestionnaireErrors()">
                     <span class="glyphicon glyphicon-alert warning icon" aria-hidden="true"></span>
                     <span v-html="getSubStudyStatusErrors()" ></span>
                 </div>


### PR DESCRIPTION
address https://jira.movember.com/browse/TN-3188
Use `intervention_qnr_eligible` flag returned from `/api/patient/[id]/research_study` to determine whether to display error(s) in the clinician intervention questionnaire section of the patient profile page.
**Note** the flag is TRUE even if there is pending work in base study.  See example [here](https://eproms-test.cirg.washington.edu/api/patient/3982/research_study).  So that specific error will not display on the UI.