### PR TITLE
TN-3190 correct display of <deleted> clinicians

### DIFF
--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -78,8 +78,8 @@ def render_patients_list(
             patient.current_qb = qb_status['visit_name']
             if research_study_id == EMPRO_RS_ID:
                 patient.clinician = '; '.join(
-                    (clinician_name_map.get(c.id, "<deleted>") for c in
-                     patient.clinicians)) or "<deleted>"
+                    (clinician_name_map.get(c.id, "not in map") for c in
+                     patient.clinicians)) or ""
                 patient.action_state = qb_status['action_state'].title() \
                     if qb_status['action_state'] else ""
             patients_list.append(patient)


### PR DESCRIPTION
Although primarily a symptom of fake test data (due to outdated assignment of plain staff as clinicians), clean up how deleted clinicians are displayed in the `/patients/substudy` list.
 
1. without a current clinician, use empty string, not `<deleted>`.
2. Include text should we ever again find a clinician w/o a "name in map", as picked up from test-only data on test system.