### PR TITLE
bugfix: TN-3195  Filter list by site org filter bug

### DIFF
--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -893,8 +893,9 @@ import {EPROMS_MAIN_STUDY_ID, EPROMS_SUBSTUDY_ID} from "./data/common/consts.js"
             },
             onOrgListSelectFilter: function() {
                 this.setTablePreference(this.userId, this.tableIdentifier, null, null, null, function () {
-                  // wait for table filter preference is saved before reloading the page
-                  // so the backend can present patient list based on that preference
+                  // callback from setting the filter preference
+                  // this ensures that the table filter preference is saved before reloading the page
+                  // so the backend can present patient list based on that saved preference
                   setTimeout(function () {
                     this.showLoader();
                     location.reload();


### PR DESCRIPTION
Address https://jira.movember.com/browse/TN-3195
Behavior observed in Production:
Select organization(s) from the _Filter List By Site_  on the patient list does not result in filtered list on refresh.  Another refresh is needed to see it.

Possible Cause:
The timing is so that the patient list is served up by the backend prior to the filter preference having completed saving.

Fix:
Code updated to ensure that the frontend Ajax call to set the table filter preference should complete **before** refreshing the patient list.  This so that the backend can present the patient list based on that saved filter preference.