### PR TITLE
In Test environment  - do not show add EMPRO consent UI if user doesn't have email

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -3353,6 +3353,9 @@ export default (function() {
                 if (!this.hasSubStudySubjectOrgs()) {
                     return false;
                 }
+                // no user email
+                if (this.userHasNoEmail()) return false;
+            
                 //adding a test substudy consent should only be allowed in Test environment
                 if (!this.isTestEnvironment()) {
                     //allowed in non-Test environment based on additional check, e.g. user role, patient role, config etc.


### PR DESCRIPTION
Address error discussed in this [thread](https://cirg.slack.com/archives/C5TVC8KQE/p1666115509616429) 

- to prevent 500 error from being raised, the fix is to prevent the UI to add EMPRO consent from displaying if the user doesn't have email.

NOTE: the add EMPRO consent UI is not available in Production.  This is present in the Test environment for testing purpose.