### PR TITLE
UI bug - PI deletion on treating clinician section in profile

### DIFF
--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1005,11 +1005,11 @@
                 <div class="select-list"><select id="clinicianSelector" class="form-control" :disabled="updateInProgress"></select></div>
                 {% raw %}
                     <div class="chips-list" v-if="selectedClinicians.length">
-                        <span class="chip clinician-item" v-bind:class="{inactive: updateInProgress}" v-for="(item, index) in selectedClinicians" :key="item.reference + index" :dataValue="item.reference" @click="removeClinicianEvent" :id="item.reference + '_chip'"
+                        <span class="chip clinician-item" v-bind:class="{inactive: updateInProgress}" v-for="(item, index) in selectedClinicians" :key="item.reference + index" :dataValue="item.reference" :id="item.reference + '_chip'"
                         >
                             <span class="chip-content">
                                 <!-- delete botón is not shown for PI -->
-                                <button type="button" class="chip-icon" v-show="!isPI(item.reference)"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path></svg>
+                                <button type="button" class="chip-icon" v-show="!isPI(item.reference)" @click="removeClinicianEvent"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path></svg>
                                 </button>
                                 <span v-text="item.display"></span>
                                 <span class="decorator-text" v-if="isPI(item.reference)" v-text="getPIIndicatorText()"></span>

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1008,7 +1008,7 @@
                         <span class="chip clinician-item" v-bind:class="{inactive: updateInProgress}" v-for="(item, index) in selectedClinicians" :key="item.reference + index" :dataValue="item.reference" :id="item.reference + '_chip'"
                         >
                             <span class="chip-content">
-                                <!-- delete botón is not shown for PI -->
+                                <!-- delete botón is not shown for PI clinician -->
                                 <button type="button" class="chip-icon" v-show="!isPI(item.reference)" @click="removeClinicianEvent"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" class="v-icon__svg"><path d="M12,2C17.53,2 22,6.47 22,12C22,17.53 17.53,22 12,22C6.47,22 2,17.53 2,12C2,6.47 6.47,2 12,2M15.59,7L12,10.59L8.41,7L7,8.41L10.59,12L7,15.59L8.41,17L12,13.41L15.59,17L17,15.59L13.41,12L17,8.41L15.59,7Z"></path></svg>
                                 </button>
                                 <span v-text="item.display"></span>


### PR DESCRIPTION
Follow up to https://jira.movember.com/browse/TN-3198
Issue found:
User can still delete PI in the Treating Clinician section even though the delete icon isn't showing for UI element.

Cause:
The **on click** event to delete a clinician is attached to the the parent UI element that contains the delete icon. So clicking anywhere on it will invoke the delete clinician event even if the delete icon isn't showing.

Fix:
Attach on click event to delete clinician to the delete icon button itself