### PR TITLE
Fixup tox config name

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands =
         --ignore tests/test_user_document.py \
         --ignore tests/test_user.py \
     []
-whitelist_externals = /bin/sh
+allowlist_externals = /bin/sh
 
 [testenv:celery_background]
 description = Environment for tests that require celery running in background


### PR DESCRIPTION
Fixup config name for `tox` test runner. 

`whitelist_externals` has been deprecated, replaced with `allowlist_externals`
