### PR TITLE
IRONN-132 patch failing staff user query

### DIFF
--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -507,7 +507,7 @@ def generate_and_send_summaries(org_id, research_study_id):
             # email including all respective orgs for given user.
             for user in User.query.join(
                     UserRoles).join(Role).filter(
-                    Role.name.in_(ROLE.STAFF.value)).filter(
+                    Role.name == ROLE.STAFF.value).filter(
                     User.id == UserRoles.user_id).filter(
                     Role.id == UserRoles.role_id).filter(
                     User.deleted_id.is_(None)):


### PR DESCRIPTION
due to recent change in report generation (to support different studies) we exposed a SQLAlchemy issue where a filter on `IN` fails if the parameter contains a single item and isn't structured as a list.

the query being patched was used to locate all staff who should receive emails for the weekly summary report on the global studies.  it was returning 0 users every time due to the failing/bogus `role.name IN ()` clause.