### PR TITLE
IRONN-130-Spain-v5-all-orgs

### DIFF
--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -3792,34 +3792,6 @@
         },
         {
           "research_protocols": [
-			{"name": "IRONMAN v3"}
-          ],
-          "url": "http://us.truenth.org/identity-codes/research-protocol"
-        }
-      ],
-      "id": 146103,
-      "identifier": [
-        {
-          "system": "http://pcctc.org/",
-          "use": "secondary",
-          "value": "146-103"
-        }
-      ],
-      "language": "es_ES",
-      "name": "Hospital Universitario Virgen de la Victoria",
-      "partOf": {
-        "reference": "api/organization/29000"
-      },
-      "resourceType": "Organization"
-    },
-    {
-      "extension": [
-        {
-          "timezone": "Europe/Madrid",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        },
-        {
-          "research_protocols": [
             {"name": "IRONMAN v3", "retired_as_of": "2020-10-21T23:00:00Z"},
             {"name": "IRONMAN v5"}
           ],
@@ -4110,7 +4082,8 @@
         },
         {
           "research_protocols": [
-			{"name": "IRONMAN v3"}
+            {"name": "IRONMAN v3", "retired_as_of": "2020-10-21T23:00:00Z"},
+            {"name": "IRONMAN v5"}
           ],
           "url": "http://us.truenth.org/identity-codes/research-protocol"
         }
@@ -4138,7 +4111,7 @@
         },
         {
           "research_protocols": [
-			{"name": "IRONMAN v3"}
+			{"name": "IRONMAN v5"}
           ],
           "url": "http://us.truenth.org/identity-codes/research-protocol"
         }

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -4111,7 +4111,8 @@
         },
         {
           "research_protocols": [
-			{"name": "IRONMAN v5"}
+            {"name": "IRONMAN v3", "retired_as_of": "2022-03-01T23:00:00Z"},
+            {"name": "IRONMAN v5"}
           ],
           "url": "http://us.truenth.org/identity-codes/research-protocol"
         }

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -4082,7 +4082,7 @@
         },
         {
           "research_protocols": [
-            {"name": "IRONMAN v3", "retired_as_of": "2020-10-21T23:00:00Z"},
+            {"name": "IRONMAN v3", "retired_as_of": "2023-01-06T20:00:00Z"},
             {"name": "IRONMAN v5"}
           ],
           "url": "http://us.truenth.org/identity-codes/research-protocol"
@@ -4111,7 +4111,7 @@
         },
         {
           "research_protocols": [
-            {"name": "IRONMAN v3", "retired_as_of": "2022-03-01T23:00:00Z"},
+            {"name": "IRONMAN v3", "retired_as_of": "2023-01-06T20:00:00Z"},
             {"name": "IRONMAN v5"}
           ],
           "url": "http://us.truenth.org/identity-codes/research-protocol"


### PR DESCRIPTION
1. Moves "Instituto Valenciano de Oncologia" (146-146) to v5 effective 2020-10-21T23:00:00Z . This will need a dry-run @pbugni .
2. Switches "Hospital Universitario Miguel Servet (Zaragoza)" (146-180) to v5, effective for all time (this was a new site added March '22 - they accidentally asked for v3 at that time).
3. Removes a redundant org config for "Hospital Universitario Virgen de la Victoria". The removed config is at v3, which is incorrect. The remaining config has the valid transition to v5; this config was later in the file, and it appears that it overrode the prior/bad config, fortunately (at least, as I read https://eproms.truenth.org/api/organization?tree_view=true today).

https://jira.movember.com/browse/IRONN-130