### PR TITLE
TN-3217 PI role account creation - prevent invalid role combo

### DIFF
--- a/portal/static/js/src/data/common/consts.js
+++ b/portal/static/js/src/data/common/consts.js
@@ -2,9 +2,27 @@ export var EPROMS_MAIN_STUDY_ID = 0;
 export var EPROMS_SUBSTUDY_ID = 1;
 export var EPROMS_SUBSTUDY_SHORT_TITLE = "EMPRO";
 export var EPROMS_SUBSTUDY_TITLE = i18next.t("IRONMAN EMPRO study");
-export var EMPRO_TRIGGER_PROCCESSED_STATES = ["processed", "triggered", "resolved"];
-export var EMPRO_TRIGGER_UNPROCCESSED_STATES = ["due", "inprocess", "unstarted"];
+export var EMPRO_TRIGGER_PROCCESSED_STATES = [
+  "processed",
+  "triggered",
+  "resolved",
+];
+export var EMPRO_TRIGGER_UNPROCCESSED_STATES = [
+  "due",
+  "inprocess",
+  "unstarted",
+];
 export var EPROMS_SUBSTUDY_QUESTIONNAIRE_IDENTIFIER = "ironman_ss";
 export var EMPRO_POST_TX_QUESTIONNAIRE_IDENTIFIER = "ironman_ss_post_tx";
 //pre-existing translated text
-export var DEFAULT_SERVER_DATA_ERROR = i18next.t("Error retrieving data from server");
+export var DEFAULT_SERVER_DATA_ERROR = i18next.t(
+  "Error retrieving data from server"
+);
+export var REQUIRED_PI_ROLES = ["staff", "staff_admin", "clinician"];
+export var REQUIRED_PI_ROLES_WARNING_MESSAGE =
+  i18next.t(`<p>An account with a Primary Investigator role must also have at least ONE of the following roles:</p>
+            <ul>
+                <li><b>Staff</b></li>
+                <li><b>Admin Staff</b></li>
+                <li><b>Clinician</b></li>
+            </ul>`);

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -8,12 +8,14 @@ import ClinicalQuestions from "./modules/ClinicalQuestions.js";
 import Consent from "./modules/Consent.js";
 import {sortArrayByField} from "./modules/Utility.js";
 import {
-    EPROMS_SUBSTUDY_ID,
-    EPROMS_SUBSTUDY_TITLE,
-    EPROMS_SUBSTUDY_QUESTIONNAIRE_IDENTIFIER,
-    EPROMS_SUBSTUDY_SHORT_TITLE,
-    EMPRO_POST_TX_QUESTIONNAIRE_IDENTIFIER,
-    EMPRO_TRIGGER_UNPROCCESSED_STATES
+  EPROMS_SUBSTUDY_ID,
+  EPROMS_SUBSTUDY_TITLE,
+  EPROMS_SUBSTUDY_QUESTIONNAIRE_IDENTIFIER,
+  EPROMS_SUBSTUDY_SHORT_TITLE,
+  EMPRO_POST_TX_QUESTIONNAIRE_IDENTIFIER,
+  EMPRO_TRIGGER_UNPROCCESSED_STATES,
+  REQUIRED_PI_ROLES,
+  REQUIRED_PI_ROLES_WARNING_MESSAGE,
 } from "./data/common/consts.js";
 
 /*
@@ -2914,55 +2916,96 @@ export default (function() {
                 });
             },
             updateRolesData: function(event) {
-                var visibleRoles = $("#rolesGroup input:checkbox:checked:visible");
-                /*
-                 * check if a role is selected
-                 */
-                if (!visibleRoles.length) {
-                    //make sure at least one role among role elements that are visible is selected
-                    //admin, staff admin functionality
-                    $(".put-roles-error").html("A role must be selected.");
-                    return false;
-                }
-                var isChecked = $(event.target).is(":checked");
-                var changedRole = event.target.value;
-                var roles = [];
-                var self = this;
-                $(".put-roles-error").html("");
-                $("#rolesGroup").addClass("loading");
-                this.modules.tnthAjax.getRoles(this.subjectId, function(data) {
-                    var dataRoles = [];
-                    if (data.roles) {
-                        dataRoles = data.roles.map(function(role) {
-                            return role.name;
-                        });
-                        if (!isChecked) {
-                            //removed from existing role list
-                            dataRoles = dataRoles.filter(function(role){
-                                return role !== changedRole;
-                            });
-                        } else {
-                            //combine checked role with existing roles
-                            dataRoles = [...dataRoles, changedRole];
-                            //remove duplicate role(s)
-                            dataRoles = dataRoles.filter(function(value, index) {
-                                return dataRoles.indexOf(value) === index;
-                            });
-                        }
+              // check required roles for PI role
+              var piRoleChecked = $(
+                "#rolesGroup [value='primary_investigator']"
+              ).is(":checked");
+              var requiredRolesChecked = REQUIRED_PI_ROLES.filter((role) =>
+                $("#rolesGroup [value='" + role + "']").is(":checked")
+              ).length > 0;
+              if (
+                $(event.target).is(":checked") ||
+                !piRoleChecked ||
+                requiredRolesChecked ||
+                REQUIRED_PI_ROLES.indexOf($(event.target).val()) === -1
+              ) {
+                $(".delete-roles-error").html("");
+              } else {
+                // not allow to continue if the PI role is checked but the other required roles, e.g. staff, aren't
+                $(".delete-roles-error").html(
+                  REQUIRED_PI_ROLES_WARNING_MESSAGE
+                );
+                $(event.target).prop("checked", true);
+                return;
+              }
+              var visibleRoles = $(
+                "#rolesGroup input:checkbox:checked:visible"
+              );
+              /*
+               * check if a role is selected
+               */
+              if (!visibleRoles.length) {
+                //make sure at least one role among role elements that are visible is selected
+                //admin, staff admin functionality
+                $(".put-roles-error").html("A role must be selected.");
+                return false;
+              }
+              var isChecked = $(event.target).is(":checked");
+              var changedRole = event.target.value;
+              var roles = [];
+              var self = this;
+              $(".put-roles-error").html("");
+              $("#rolesGroup").addClass("loading");
+              this.modules.tnthAjax.getRoles(
+                this.subjectId,
+                function (data) {
+                  var dataRoles = [];
+                  if (data.roles) {
+                    dataRoles = data.roles.map(function (role) {
+                      return role.name;
+                    });
+                    if (!isChecked) {
+                      //removed from existing role list
+                      dataRoles = dataRoles.filter(function (role) {
+                        return role !== changedRole;
+                      });
+                    } else {
+                      //combine checked role with existing roles
+                      dataRoles = [...dataRoles, changedRole];
+                      //remove duplicate role(s)
+                      dataRoles = dataRoles.filter(function (value, index) {
+                        return dataRoles.indexOf(value) === index;
+                      });
                     }
-                    roles = dataRoles.map(function(role) {
-                        return {
-                            "name": role
-                        }
-                    });
-                    self.modules.tnthAjax.putRoles(self.subjectId, {"roles": roles}, $(event.target), function() {
-                        $("#rolesGroup").removeClass("loading");
-                         /*
-                        * refresh user roles list since it has been uploaded
-                        */
-                        self.initUserRoles({clearCache: true});
-                    });
-                }, {"clearCache": true});
+                  }
+                  roles = dataRoles.map(function (role) {
+                    return {
+                      name: role,
+                    };
+                  });
+                  $("#rolesGroup [type='checkbox']").attr("disabled", true);
+                  self.modules.tnthAjax.putRoles(
+                    self.subjectId,
+                    { roles: roles },
+                    $(event.target),
+                    function () {
+                      $("#rolesGroup").removeClass("loading");
+                      setTimeout(function() {
+                        $("#rolesGroup [type='checkbox']").attr(
+                          "disabled",
+                          false
+                        );
+                      }, 250);
+                      
+                      /*
+                       * refresh user roles list since it has been uploaded
+                       */
+                      self.initUserRoles({ clearCache: true });
+                    }
+                  );
+                },
+                { clearCache: true }
+              );
             },
             updateRolesUI: function(roles) {
                 if (!roles) return;


### PR DESCRIPTION
https://jira.movember.com/browse/TN-3217

Description of the changes:

- When the role of Primary Investigator is checked - in account creation page or profile page, the UI will display warning about other required role(s), e.g. Staff, Admin Staff, and Clinician (see example screenshot).
- The user will be prevented from continuing unless ONE of those required roles is checked.

Example screenshot:
![Screen Shot 2023-01-24 at 12 04 49 PM](https://user-images.githubusercontent.com/12942714/214397750-7b168a87-e2ec-4665-a889-505d6e4244bf.png)
