### PR TITLE
Bugfix/pi in profile page

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2938,9 +2938,19 @@ export default (function() {
                 $(event.target).prop("checked", true);
                 return;
               }
-              var visibleRoles = $(
-                "#rolesGroup input:checkbox:checked:visible"
-              );
+              // if primary investigator is checked
+              if ($(event.target).val() === "primary_investigator" &&
+                  $(event.target).is(":checked")) {
+                if (piRoleChecked && !requiredRolesChecked) {
+                  // display warning if the PI role is checked but the other required roles, e.g. staff, aren't
+                  $(".delete-roles-error").html(
+                    REQUIRED_PI_ROLES_WARNING_MESSAGE
+                  );
+                }
+              }
+                var visibleRoles = $(
+                  "#rolesGroup input:checkbox:checked:visible"
+                );
               /*
                * check if a role is selected
                */
@@ -2948,6 +2958,8 @@ export default (function() {
                 //make sure at least one role among role elements that are visible is selected
                 //admin, staff admin functionality
                 $(".put-roles-error").html("A role must be selected.");
+                // prevent the last role from being un-checked until user selects another
+                $(event.target).prop("checked", true);
                 return false;
               }
               var isChecked = $(event.target).is(":checked");

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2938,7 +2938,7 @@ export default (function() {
                 $(event.target).prop("checked", true);
                 return;
               }
-              // if primary investigator is checked
+              // if primary investigator is checked and all other roles are un-checked
               if ($(event.target).val() === "primary_investigator" &&
                   $(event.target).is(":checked")) {
                 if (piRoleChecked && !requiredRolesChecked) {

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2939,8 +2939,7 @@ export default (function() {
                 return;
               }
               // if primary investigator is checked and all other roles are un-checked
-              if ($(event.target).val() === "primary_investigator" &&
-                  $(event.target).is(":checked")) {
+              if ($("#rolesGroup [value='primary_investigator']").is(":checked")) {
                 if (piRoleChecked && !requiredRolesChecked) {
                   // display warning if the PI role is checked but the other required roles, e.g. staff, aren't
                   $(".delete-roles-error").html(


### PR DESCRIPTION
https://jira.movember.com/browse/TN-3217
Follow up fix to the comment
Scenario tested:
- User **unchecked** all staff roles (staff, admin staff, clinician and primary investigator roles)
- check only the Primary Investigator role on the profile page.

The fix is to display warning to user, note this will still result in Primary Investigator role being select, what to do here?  Do you auto-check one of the required roles? (i.e. staff, admin staff or clinician)?