### PR TITLE
site preview qnr details for affected patients

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -804,7 +804,6 @@ def present_before_after_state(user_id, external_study_id, before_state):
 
     def visit_from_timeline(qb_name, qb_iteration, timeline_results):
         """timeline results have computed visit name - quick lookup"""
-        #import pdb; pdb.set_trace()
         for visit, name, iteration in timeline_results.values():
             if qb_name == name and qb_iteration == iteration:
                 return visit

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -276,12 +276,15 @@ class QuestionnaireResponse(db.Model):
             QuestionnaireResponse.subject_id == user_id).with_entities(
             QuestionnaireResponse.id,
             QuestionnaireResponse.questionnaire_bank_id,
-            QuestionnaireResponse.qb_iteration)
+            QuestionnaireResponse.qb_iteration,
+            QuestionnaireResponse.document)
 
         return {
             f"qnr {qnr.id}":
-                [name_map[qnr.questionnaire_bank_id], qnr.qb_iteration] for
-            qnr in qnrs}
+                [name_map[qnr.questionnaire_bank_id],
+                 qnr.qb_iteration,
+                 qnr.document["questionnaire"]["reference"].split("/")[-1]]
+            for qnr in qnrs}
 
     @property
     def document_identifier(self):


### PR DESCRIPTION
Further extended `preview-site-update` to detail the visit and questionnaire for each respective questionnaire response that loses its association when transitioning research protocols.

Example run:
```
flask preview-site-update --org_id=146146 --retired="2020-10-21T23:00:00Z"

[...]
173 QuestionnaireResponses for all patients in organization 146146
Instituto Valenciano de Oncologia
  Patients in organization: 34
  Patients negatively affected by change: 13
  Number of those QNRs assigned to a QB before RP change: 173
  Number of those QNRs assigned to a QB after RP change: 150
  Number of QuestionnaireBanks completed before RP change: 40
  Number of QuestionnaireBanks completed after RP change: 20
 Details of patients having lost a QuestionnaireResponse association:
  Patient 3733
    visit: Month 3 questionnaire: ironmisc
    visit: Month 6 questionnaire: ironmisc
  Patient 5881
    visit: Baseline questionnaire: ironmisc
  Patient 5783
    visit: Baseline questionnaire: ironmisc
  Patient 5711
    visit: Baseline questionnaire: ironmisc
  Patient 5534
    visit: Baseline questionnaire: ironmisc
  Patient 5481
    visit: Baseline questionnaire: ironmisc
    visit: Month 9 questionnaire: ironmisc
  Patient 5302
    visit: Baseline questionnaire: ironmisc
    visit: Month 3 questionnaire: ironmisc
  Patient 5270
    visit: Month 3 questionnaire: ironmisc
  Patient 4983
    visit: Month 6 questionnaire: ironmisc
    visit: Month 15 questionnaire: ironmisc
  Patient 4229
    visit: Month 9 questionnaire: ironmisc
    visit: Month 21 questionnaire: ironmisc
  Patient 3936
    visit: Month 24 questionnaire: ironmisc
  Patient 3734
    visit: Month 12 questionnaire: ironmisc
    visit: Month 12 questionnaire: factfpsi
    visit: Month 12 questionnaire: epic26
    visit: Month 12 questionnaire: prems
    visit: Month 24 questionnaire: ironmisc
  Patient 3735
    visit: Month 12 questionnaire: ironmisc
    visit: Month 24 questionnaire: ironmisc
```