### PR TITLE
TN-3205 new CLI `update-qnr` to manually correct a QNR

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -495,8 +495,7 @@ def update_qnr_authored(qnr_id, authored, actor):
     """Modify authored date on given Questionnaire Response ID"""
     qnr = QuestionnaireResponse.query.get(qnr_id)
     if not qnr:
-        raise ValueError(
-            "Questionnaire Response {qnr_id} not found".format(qnr_id))
+        raise ValueError(f"Questionnaire Response {qnr_id} not found")
 
     acting_user = get_actor(actor, editable_ids=[qnr.subject_id])
     document = copy.deepcopy(qnr.document)
@@ -526,6 +525,67 @@ def update_qnr_authored(qnr_id, authored, actor):
         "{new_authored}".format(
             qnr_id=qnr_id, old_authored=old_authored,
             new_authored=new_authored))
+    auditable_event(
+        message=message,
+        context="assessment",
+        user_id=acting_user.id,
+        subject_id=qnr.subject_id)
+    print(message)
+
+
+@click.option('--qnr_id', help="Questionnaire Response ID", required=True)
+@click.option(
+    '--link_id',
+    required=True,
+    help="linkId to correct, format example: irondemog.27")
+@click.option(
+    '--actor',
+    required=True,
+    help='email address of user taking this action, for audit trail'
+)
+@click.option(
+    '--replacement',
+    required=False,
+    help='email address of user taking this action, for audit trail'
+)
+@click.option(
+    '--noop',
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help='no op, simply echo current value'
+)
+@app.cli.command()
+def update_qnr(qnr_id, link_id, actor, noop, replacement):
+    """Modify given linkId in given Questionnaire Response ID"""
+    qnr = QuestionnaireResponse.query.get(qnr_id)
+    if not qnr:
+        raise ValueError(f"Questionnaire Response {qnr_id} not found")
+
+    old_value = qnr.link_id(link_id)
+    if noop:
+        print(f"'{json.dumps(old_value)}'")
+        return
+
+    new_value = json.loads(replacement)
+    acting_user = get_actor(actor, editable_ids=[qnr.subject_id])
+    document = copy.deepcopy(qnr.document)
+    if set(old_value.keys()) != set(new_value.keys()):
+        raise ValueError("inconsistent dictionary keys; can't continue")
+    if old_value["text"] != new_value["text"]:
+        raise ValueError("question text doesn't match existing; can't continue")
+    if old_value["linkId"] != new_value["linkId"]:
+        raise ValueError("linkId doesn't match; can't continue")
+
+    questions = qnr.replace_link_id(link_id, new_value)
+    document["group"]["question"] = questions
+    qnr.document = document
+    assert qnr in db.session
+    db.session.commit()
+
+    message = (
+        f"Updated QNR {qnr_id} {link_id} answer from {old_value['answer']}"
+        f" to {new_value['answer']}")
     auditable_event(
         message=message,
         context="assessment",

--- a/manage.py
+++ b/manage.py
@@ -546,14 +546,14 @@ def update_qnr_authored(qnr_id, authored, actor):
 @click.option(
     '--replacement',
     required=False,
-    help='email address of user taking this action, for audit trail'
+    help='JSON snippet for `answer` replacement.  Use --noop result as template'
 )
 @click.option(
     '--noop',
     is_flag=True,
     show_default=True,
     default=False,
-    help='no op, simply echo current value'
+    help='no op, echo current value for requested linkId'
 )
 @app.cli.command()
 def update_qnr(qnr_id, link_id, actor, noop, replacement):
@@ -564,7 +564,9 @@ def update_qnr(qnr_id, link_id, actor, noop, replacement):
 
     old_value = qnr.link_id(link_id)
     if noop:
-        print(f"'{json.dumps(old_value)}'")
+        if replacement:
+            raise ValueError("--noop & --replacement are mutually exclusive")
+        click.echo(f"'{json.dumps(old_value)}'")
         return
 
     new_value = json.loads(replacement)
@@ -591,7 +593,7 @@ def update_qnr(qnr_id, link_id, actor, noop, replacement):
         context="assessment",
         user_id=acting_user.id,
         subject_id=qnr.subject_id)
-    print(message)
+    click.echo(message)
 
 
 @click.option('--subject_id', type=int, multiple=True, help="Subject user ID", required=True)

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -385,6 +385,36 @@ class QuestionnaireResponse(db.Model):
 
         return results
 
+    def link_id(self, link_id):
+        """Return linkId JSON as defined in QuestionnaireResponse
+
+        :param link_id: i.e. irondemog_v3.10
+        :return: JSON for requested linkId
+        """
+        for question in self.document["group"]["question"]:
+            if question["linkId"] == link_id:
+                return question
+
+    def replace_link_id(self, link_id, replacement):
+        """Return modified questions for linkId with given JSON
+
+        NB the changes returned here must be assigned to a *copy* of
+        self.document["group"]["question"] in order to persist.  This
+        method does NOT modify the QNR.
+
+        :param link_id: i.e. irondemog_v3.10
+        :return: modified self.document["group"]["question"], with requested
+         replacement in place of existing for given linkId
+        """
+        questions = []
+        for question in self.document["group"]["question"]:
+            if question["linkId"] == link_id:
+                questions.append(replacement)
+                continue
+            questions.append(replacement)
+        assert len(questions) == len(self.document["group"]["question"])
+        return questions
+
     def as_sdc_fhir(self):
         """
         Return QuestionnaireResponse FHIR in structure expected by SDC $extract service


### PR DESCRIPTION
example use follows.  to view current value for a requested linkId within the given QuestionnaireResponse.id, include the `--noop` flag:

```
$  flask update-qnr --qnr_id 19490 --link_id irondemog_v3.27 --actor pbugni@gmail.com --noop
'{"text": "Are you Hispanic or Latino?", "answer": [{"valueString": "No"}, {"valueCoding": {"code": "irondemog_v3.27.2", "system": "https://eproms.truenth.org/api/codings/assessment"}}], "linkId": "irondemog_v3.27"}'
```

scrape and edit the above result, and include with the `--replacement` flag, to update the record:

```
$ flask update-qnr --qnr_id 19490 --link_id irondemog_v3.27 --actor pbugni@gmail.com --replacement 
'{"text": "Are you Hispanic or Latino?", "answer": [{"valueString": "Yes"}, {"valueCoding": {"code": "irondemog_v3.27.1", "system": "https://eproms.truenth.org/api/codings/assessment"}}], "linkId": "irondemog_v3.27"}'
```

finally, an example w/o a current answer:

```
$ flask update-qnr --qnr_id 16960 --link_id irondemog_v3.27 --actor pbugni@gmail.com --noop
'{"text": "Are you Hispanic or Latino?", "answer": [], "linkId": "irondemog_v3.27"}'

$  flask update-qnr --qnr_id 16960 --link_id irondemog_v3.27 --actor pbugni@gmail.com --replacement '{"text": "Are you Hispanic or Latino?", "answer": [{"valueString": "No"}, {"valueCoding": {"code": "irondemog_v3.27.2", "system": "https://eproms.truenth.org/api/codings/assessment"}}], "linkId": "irondemog_v3.27"}'
Updated QNR 16960 irondemog_v3.27 answer from [] to [{'valueString': 'No'}, {'valueCoding': {'code': 'irondemog_v3.27.2', 'system': 'https://eproms.truenth.org/api/codings/assessment'}}]
```