### PR TITLE
TN-3140 Catch second submission of a known QNR dyad in the act

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -180,6 +180,22 @@ class QuestionnaireResponse(db.Model):
                 subject_id=self.subject_id, user_id=acting_user_id,
                 context='assessment', comment=msg)
             db.session.add(audit)
+            # TN-3140 multiple QNRs found for visit/questionnaire dyad
+            # Generate an error for alerts, should this look to be a fresh
+            # duplicate.  Ignore if we don't have a valid questionnaire bank
+            if self.questionnaire_bank_id > 0:
+                count = db.session.query(QuestionnaireResponse).filter(
+                    QuestionnaireResponse.questionnaire_bank_id ==
+                    self.questionnaire_bank_id).filter(
+                    QuestionnaireResponse.qb_iteration ==
+                    self.qb_iteration).filter(
+                    QuestionnaireResponse.document['questionnaire']['reference'] ==
+                    self.document['questionnaire']['reference']).count()
+                if count != 1:
+                    current_app.logger.error(
+                        "Second submission for an existing QNR dyad received."
+                        f" Patient: {self.subject_id}, QNR {self.id}"
+                    )
 
     @staticmethod
     def purge_qb_relationship(


### PR DESCRIPTION
as per TN-3140, need to prevent duplicate QNRs, that is, ones that match on visit, a function of (questionnaire_bank_id, qb_iteration), and instrument for a given patient.

given the complexity of source data - interventions including AE submitting such QNRs, don't raise but rather log the error to trigger a notification.