### PR TITLE
time warp UI fix - should be present regardless of QR completion

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2352,6 +2352,9 @@ export default (function() {
             initAssessmentListSection: function() {
                 var self = this;
                 $("#assessmentListMessage").text(i18next.t("No questionnaire data found."));
+                //test/debug feature to allow time warping patient data
+                //non-production environment ONLY
+                self.initTimeWarpUI();
                 self.modules.tnthAjax.assessmentList(self.subjectId, {useWorker: true}, function(data) {
                     if (data.error) {
                         self.assessment.assessmentListError = i18next.t("Problem retrieving session data from server.");
@@ -2363,9 +2366,6 @@ export default (function() {
                     if (!entries || entries.length === 0) {
                         return false;
                     }
-                    //test/debug feature to allow time warping patient data
-                    //non-production environment ONLY
-                    self.initTimeWarpUI();
                     entries.forEach(function(entry, index) {
                         var reference = entry.questionnaire.reference;
                         if ((new RegExp(EMPRO_POST_TX_QUESTIONNAIRE_IDENTIFIER)).test(reference)) {

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -1064,7 +1064,7 @@
                         <div class="modal-body">
                             <div class="body-content">
                                 <div class="form-group">
-                                    By <input type="text" id="timeWarpDays" class="form-control" disabled="false" pattern="(\d)?\d" maxlength="2" width="50"> Days
+                                    By <input type="number" id="timeWarpDays" class="form-control" disabled="false" width="80"> Days
                                     <div class="help-block"></div>
                                 </div>
                                 <div class="button-container">


### PR DESCRIPTION
Per convo with Sie-ce: see [here](https://cirg.slack.com/archives/C5TVC8KQE/p1678483156811069)

Changes include:
- Made fix so that the appearance the time warp UI is not dependent on the completion of a questionnaire response
- Make the time warp input field to be a number field and without limiting the number of digits one can enter (currently one can only enter 2 digits).