### PR TITLE
TN-3229 Add sdc restart policy

### DIFF
--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -54,6 +54,9 @@ services:
   celerybeat:
     restart: unless-stopped
 
+  sdc:
+    restart: unless-stopped
+
   redis:
     restart: unless-stopped
 


### PR DESCRIPTION
- Auto-restart `sdc` container, if not explicitly stopped (eg on reboot)