### PR TITLE
TN-3231 look further ahead with protocol changes

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -742,6 +742,11 @@ class QNR_indef_results(QNR_results):
     """
 
     def __init__(self, user, research_study_id, qb_id):
+        # define unused attributes from base class:
+        self.qb_ids = None
+        self.qb_iteration = None
+        self.ignore_iteration = None
+
         self.user = user
         self.research_study_id = research_study_id
         # qb_id is the current indef qb - irrelevant if done in previous

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -553,10 +553,14 @@ class QNR_results(object):
             match, laps = None, 0
             for qbd in container:
                 if match:
-                    # once a match is found, only look ahead a
-                    # single QB for a second, overlapping match
+                    # due to the introduction of additional visits
+                    # from protocol changes, i.e. month 33 and 39 in v5
+                    # once a match is found allow look ahead for 3 QBs,
+                    # looking for a subsequent overlapping match.
+                    # such a protocol change generates the ordered array
+                    # [..., month36-v3, month33-v5, month36-v5, ...]
                     laps += 1
-                    if laps > 1:
+                    if laps > 3:
                         return match
                 qb_start = calc_and_adjust_start(
                     user=self.user,


### PR DESCRIPTION
Assigning questionnaire responses to the correct visit (questionnaire_bank and iteration) includes considering research protocol change by the patient's organization.

This PR corrects a situation where the overlapping and additional visits added by v5 coincide with the organizations transition date and a patient's questionnaire response authored date.  For protocol v3, month 30 precedes month 36.  In v5 additional visits month 33 and month 39 were added.

When a questionnaire response authored date lands near the protocol change, it must be determined which protocol was being fulfilled when assigning the visit to the questionnaire response.  The code was looking ahead but not far enough, due to the additional visits in the new protocol.  The case in question had an authored date that fit within valid dates for both month 36 v3 and month 39 v5.