### PR TITLE
TN-3226 new celery job to intentionally raise exceptions

### DIFF
--- a/portal/config/eproms/ScheduledJob.json
+++ b/portal/config/eproms/ScheduledJob.json
@@ -264,6 +264,17 @@
       "resourceType": "ScheduledJob",
       "schedule": "1 4,10,16,22 * * *",
       "task": "process_triggers_task"
+    },
+    {
+      "active": false,
+      "args": null,
+      "kwargs": {
+        "exception_type": "ValueError"
+      },
+      "name": "Raise Background Exception",
+      "resourceType": "ScheduledJob",
+      "schedule": "0 0 0 0 0",
+      "task": "raise_background_exception_task"
     }
   ],
   "id": "SitePersistence v0.2",

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -413,3 +413,14 @@ def process_triggers_task(**kwargs):
     # Include within function as not all applications include the blueprint
     from portal.trigger_states.empro_states import fire_trigger_events
     fire_trigger_events()
+
+
+@celery.task()
+@scheduled_task
+def raise_background_exception_task(**kwargs):
+    """Manually trigger to verify job raised exceptions are caught"""
+    if kwargs.get("exception_type") == "RuntimeError":
+        raise RuntimeError("intentional RuntimeError raised from task")
+    if kwargs.get("exception_type") == "ValueError":
+        raise ValueError("intentional ValueError raised from task")
+    raise Exception("intentional Exception raised from task")


### PR DESCRIPTION
NB, this job is not scheduled, but can be manually triggered anytime we need to verify handling and routing of errors.