### PR TITLE
Hotfix/add window to 2FA check

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -485,7 +485,7 @@ class User(db.Model, UserMixin):
     TOTP_TOKEN_LEN = 6
     TOTP_TOKEN_LIFE = 30*60
 
-    def generate_otp(self):
+    def generate_otp(self, clock=None):
         """Generate One Time Password for 2FA from user's otp_secret"""
 
         # having experienced random problems, regenerate if the token doesn't
@@ -495,12 +495,14 @@ class User(db.Model, UserMixin):
             token = otp.get_totp(
                 secret=secret,
                 token_length=self.TOTP_TOKEN_LEN,
-                interval_length=self.TOTP_TOKEN_LIFE)
+                interval_length=self.TOTP_TOKEN_LIFE,
+                clock=clock)
             if otp.valid_totp(
                     token=token,
                     secret=secret,
                     token_length=self.TOTP_TOKEN_LEN,
-                    interval_length=self.TOTP_TOKEN_LIFE):
+                    interval_length=self.TOTP_TOKEN_LIFE,
+                    clock=clock):
                 break
             secret = generate_random_secret()
 
@@ -513,13 +515,21 @@ class User(db.Model, UserMixin):
             f"generated 2FA {secret}:{token} for user {self.id}")
         return token
 
-    def validate_otp(self, token):
+    def validate_otp(self, token, window=0):
+        """validate One Time Password token
+
+        :param token: the 6 digit token sent to the user
+        :param window: optional parameter, to check the previous and next
+          number of "windows" of valid time.  Works around clock skew issues
+        :return: True if valid; False otherwise
+        """
         assert(self.otp_secret)
         valid = otp.valid_totp(
             token,
             self.otp_secret,
             token_length=self.TOTP_TOKEN_LEN,
-            interval_length=self.TOTP_TOKEN_LIFE)
+            interval_length=self.TOTP_TOKEN_LIFE,
+            window=window)
         if valid:
             # due to the long timeout window, a second request
             # for a code within the first few minutes will generate

--- a/tests/test_2fa.py
+++ b/tests/test_2fa.py
@@ -1,0 +1,36 @@
+import time
+from portal.models.user import User, generate_random_secret
+
+
+def test_2fa_tokens():
+    """random failure, verify a large number all work
+
+    Random failures seen in production, see TN-3097.
+    Potential fix in place.  NB this would NEVER fail
+    reliably despite large loop values.  Give the sleep
+    a value greater than 1 sec and bump range to increase chances,
+    but still unpredictable.
+    """
+    user = User()
+    msg = "PASSED"
+    for i in range(10):
+        user.otp_secret = generate_random_secret()  # force new
+        code = user.generate_otp()
+        time.sleep(0.01)
+        if not user.validate_otp(code):
+            msg = f"FAILED {user.otp_secret}:{code}"
+            break
+    assert msg == "PASSED"
+
+
+def test_expired_2FA():
+    user = User()
+    user.otp_secret = generate_random_secret()
+    clock = int(time.time()) - user.TOTP_TOKEN_LIFE
+    code = user.generate_otp(clock=clock)
+
+    # since token life has passed, should fail
+    assert not user.validate_otp(code)
+
+    # give window to expand time
+    assert user.validate_otp(code, window=1)


### PR DESCRIPTION
Extending the 2FA token check to try the window of time before and after the current, to compensate for clock skew.
No, this shouldn't be necessary, but as one user continues to see problems, and testing the logged values shows this would have prevented that, it is worth a shot!

The system will record in the audit record, if extending the valid window was necessary.