### PR TITLE
Fixup delete query, for single entry

### DIFF
--- a/portal/migrations/versions/2f125954b69a_.py
+++ b/portal/migrations/versions/2f125954b69a_.py
@@ -150,7 +150,7 @@ def upgrade():
     if purge_ids:
         print(f"purging duplicates: {purge_ids}")
         if len(purge_ids) > 1:
-            conn.execute(f"delete from questionnaire_responses where id in {tuple(purge_ids)})")
+            conn.execute(f"delete from questionnaire_responses where id in {tuple(purge_ids)}")
         else:
             conn.execute(f"delete from questionnaire_responses where id = {purge_ids[0]}")
     Session = sessionmaker()

--- a/portal/migrations/versions/2f125954b69a_.py
+++ b/portal/migrations/versions/2f125954b69a_.py
@@ -149,7 +149,7 @@ def upgrade():
     print(differences.getvalue())
     if purge_ids:
         print(f"purging duplicates: {purge_ids}")
-        conn.execute(f"delete from questionnaire_responses where id in ({''.join(str(i) for i in tuple(purge_ids))})")
+        conn.execute(f"delete from questionnaire_responses where id in ({','.join(str(i) for i in tuple(purge_ids))})")
     Session = sessionmaker()
     session = Session(bind=op.get_bind())
     for audit in audits:

--- a/portal/migrations/versions/2f125954b69a_.py
+++ b/portal/migrations/versions/2f125954b69a_.py
@@ -149,7 +149,10 @@ def upgrade():
     print(differences.getvalue())
     if purge_ids:
         print(f"purging duplicates: {purge_ids}")
-        conn.execute(f"delete from questionnaire_responses where id in ({','.join(str(i) for i in tuple(purge_ids))})")
+        if len(purge_ids) > 1:
+            conn.execute(f"delete from questionnaire_responses where id in {tuple(purge_ids)})")
+        else:
+            conn.execute(f"delete from questionnaire_responses where id = {purge_ids[0]}")
     Session = sessionmaker()
     session = Session(bind=op.get_bind())
     for audit in audits:

--- a/portal/migrations/versions/2f125954b69a_.py
+++ b/portal/migrations/versions/2f125954b69a_.py
@@ -149,7 +149,7 @@ def upgrade():
     print(differences.getvalue())
     if purge_ids:
         print(f"purging duplicates: {purge_ids}")
-        conn.execute(f"delete from questionnaire_responses where id in {tuple(purge_ids)}")
+        conn.execute(f"delete from questionnaire_responses where id in ({''.join(str(i) for i in tuple(purge_ids))})")
     Session = sessionmaker()
     session = Session(bind=op.get_bind())
     for audit in audits:


### PR DESCRIPTION
Followup to #4297

Fixup string formatting when there is only a single problematic result

See eproms-test `web` output:
```
  File "/opt/venvs/portal/lib/python3.7/site-packages/portal/migrations/versions/2f125954b69a_.py", line 152, in upgrade
    conn.execute(f"delete from questionnaire_responses where id in {tuple(purge_ids)}")
  File "/opt/venvs/portal/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 976, in execute
    return self._execute_text(object_, multiparams, params)
  File "/opt/venvs/portal/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1149, in _execute_text
    parameters,
  File "/opt/venvs/portal/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1250, in _execute_context
    e, statement, parameters, cursor, context
  File "/opt/venvs/portal/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1476, in _handle_dbapi_exception
    util.raise_from_cause(sqlalchemy_exception, exc_info)
  File "/opt/venvs/portal/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 398, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/opt/venvs/portal/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 152, in reraise
    raise value.with_traceback(tb)
  File "/opt/venvs/portal/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1246, in _execute_context
    cursor, statement, parameters, context
  File "/opt/venvs/portal/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 581, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.SyntaxError) syntax error at or near ")"
LINE 1: delete from questionnaire_responses where id in (62,)
```