### PR TITLE
add check to ensure user is still authorized to prevent stale session

### DIFF
--- a/portal/static/js/portal_wrapper/SessionMonitor.js
+++ b/portal/static/js/portal_wrapper/SessionMonitor.js
@@ -44,6 +44,17 @@ var SessionMonitorObj = function() { /* global $ */
                                 "X-CSRFToken": o
                             };
                         }
+                        // extra check to ensure that the user's session hasn't gone staled
+                        $.ajax("/api/me")
+                        .done(function() {
+                            console.log("user authorized");
+                        })
+                        .fail(function(xhr) {
+                            // user not authorized
+                            if (parseInt(xhr.status) === 401) {
+                                window.location = l.logoutUrl;
+                            }
+                        });
                         $.ajax(options);
                     },
                     setLogoutStorage: function() {


### PR DESCRIPTION
address https://jira.movember.com/browse/IRONN-176
and follow up to meeting, see [slack convo](https://cirg.slack.com/archives/C5EU4L7PF/p1682532067179999)
I believe the current behavior is:

- Frontend receives when session will`expires_in` information from the backend.
- Frontend calculates the session lifetime.
- Frontend pops up a warning a minute before the session expires.
- Frontend logs out the user when the session expires.

This change to add extra check, in case for some reason, the previous steps fail to ensure session freshness, via call to `/api/me`.  If the API call returns `401` unauthorized status code - the user will be logged out
