### PR TITLE
Edge found on last month of EMPRO study, requires initialization.

### DIFF
--- a/portal/trigger_states/models.py
+++ b/portal/trigger_states/models.py
@@ -195,6 +195,7 @@ class TriggerStatesReporting:
         # user didn't necessarily fill out next.  continue till another
         # submission of EMPRO is found, or default to now()
         visit = visit_month + 1
+        end_date = None
         while visit < self.MAX_VISIT:
             end_date = self.authored_from_visit(visit)
             visit += 1


### PR DESCRIPTION
Hit an edge when a user is near the end of their study, thus the call to initialize a variable was never being hit and causing a stack in `celery_worker_slow`