### PR TITLE
Feature/prevent dup post tx questionnaire submission

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1758,8 +1758,9 @@ export default (function() {
                         return;
                     }
                     // disabled questions section to prevent user from submitting it again
+                    // the disabled class with zIndex = -1 will prevent user from clicking on the submit button
                     $(`${containerElementIdentifier} #questionsSection`).addClass("disabled");
-                    
+
                     setTimeout(function() {
                         location.reload();
                     }.bind(this), 2000);

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1757,6 +1757,9 @@ export default (function() {
                         $(`${containerElementIdentifier} .error-message`).html(i18next.t("Error occurred submitting data, try again"));
                         return;
                     }
+                    // disabled questions section to prevent user from submitting it again
+                    $(`${containerElementIdentifier} #questionsSection`).addClass("disabled");
+                    
                     setTimeout(function() {
                         location.reload();
                     }.bind(this), 2000);


### PR DESCRIPTION
https://jira.movember.com/browse/TN-3245
Debugging result:
I found that during a brief time between a succession submission of post intervention questionnaire responses and [window reloading](https://github.com/uwcirg/truenth-portal/blob/6032da529085f681e48a47237ef5f73fa67ed078/portal/static/js/src/profile.js#L1760), user **could** click on the submit button multiples times that resulted in multiple posts of the same set of responses.
Fix:
Disable the form after a successful submission that will prevent the responses from being submitted again.