### PR TITLE
wrap error message generation with checks, avoid stack observed in log

### DIFF
--- a/portal/timeout_lock.py
+++ b/portal/timeout_lock.py
@@ -62,7 +62,12 @@ class TimeoutLock(object):
         # To avoid interrupting iterative lock use, return truthy
         # value to stop exception propagation - see PEP
         if exc_type is not None:
-            current_app.logger.error(f"{exc_type}: {exc_value}; {traceback}")
+            error_message = f"{exc_type}"
+            if exc_value:
+                error_message += f": {exc_value}"
+            if traceback:
+                error_message += f"; {traceback}"
+            current_app.logger.error(error_message)
         return True
 
     def is_locked(self):


### PR DESCRIPTION
intended to prevent the following, and thereby generate a useful error to help track down the real issue:

```
celeryworkerslow_1  | {"written_at": "2023-06-08T04:01:00.370Z", "written_ts": 1686196860370567000, "msg": "<class 'TypeError'>: argument of type 'NoneType' is not iterable; <traceback object at 0x7f960c4d5488>", "type": "log", "logger": "flask.app", "thread": "MainThread", "level": "ERROR", "module": "timeout_lock", "line_no": 65, "correlation_id": "145320d6-05b1-11ee-9893-0242ac130006"}
```