### PR TITLE
Fixup Testrunner Config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands =
         --ignore tests/test_user_document.py \
         --ignore tests/test_user.py \
     []
-allowlist_externals = /bin/sh
+allowlist_externals = sh
 
 [testenv:celery_background]
 description = Environment for tests that require celery running in background


### PR DESCRIPTION
Fixup `sh` consistency in `command`s and `allowlist_externals`