### PR TITLE
TN-3223; IRONN-196; patch sitecode errors and lookup.

### DIFF
--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -213,6 +213,10 @@ class Organization(db.Model):
     def sitecode(self):
         """Return site code identifier if found, else empty string"""
         system = current_app.config.get('REPORTING_IDENTIFIER_SYSTEMS')
+        if isinstance(system, (list, tuple)):
+            # catch need to support more than one
+            assert len(system) == 1
+            system = system[0]
         sitecodes = [
             id for id in self.identifiers if id.system == system]
         if len(sitecodes) > 1:

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -213,6 +213,8 @@ class Organization(db.Model):
     def sitecode(self):
         """Return site code identifier if found, else empty string"""
         system = current_app.config.get('REPORTING_IDENTIFIER_SYSTEMS')
+        if not system:
+            return ""
         if isinstance(system, (list, tuple)):
             # catch need to support more than one
             assert len(system) == 1

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -101,7 +101,7 @@ def generate_overdue_table_html(overdue_stats, user, top_org):
             continue
 
         # For each org, generate a row with org name in position 0
-        sitecode = ot.find(org_id).sitecode
+        sitecode = Organization.query.get(org_id).sitecode
         rows.append((org_name, org_id, sitecode, '', '', '', ''))
 
         # Prepend each patient row to line up with header

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -585,7 +585,9 @@ class TestCase(Base):
                 break
             sleep(1)
 
-        assert response.json['state'] == 'SUCCESS'
+        if response.json['state'] != 'SUCCESS':
+            print(response.json)
+            raise RuntimeError(response.json)
 
         # done, now pull result (chop /status from status url for task result)
         task_path = status_url[:-len('/status')]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -181,10 +181,10 @@ class TestQBStats(TestQuestionnaireBankFixture):
         # with zero orgs in common, should see empty result set
         assert response.json['total'] == 0
 
-        # Add org to staff to see results from matching patients (2&3)
+        # Add org to staff to see results from matching patiens (2&3)
         self.consent_with_org(org_id=org1_id)
         response = self.results_from_async_call(
-            "/api/report/questionnaire_status", timeout=20)
+            "/api/report/questionnaire_status", timeout=10)
         assert response.json['total'] == 2
 
     def test_results(self):
@@ -239,7 +239,7 @@ class TestQBStats(TestQuestionnaireBankFixture):
         self.consent_with_org(org_id=org_id)
         self.login()
         response = self.results_from_async_call(
-            "/api/report/questionnaire_status", timeout=20)
+            "/api/report/questionnaire_status", timeout=10)
 
         # expect baseline for each plus 3 mo for user4
         assert response.json['total'] == 4

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -181,10 +181,10 @@ class TestQBStats(TestQuestionnaireBankFixture):
         # with zero orgs in common, should see empty result set
         assert response.json['total'] == 0
 
-        # Add org to staff to see results from matching patiens (2&3)
+        # Add org to staff to see results from matching patients (2&3)
         self.consent_with_org(org_id=org1_id)
         response = self.results_from_async_call(
-            "/api/report/questionnaire_status", timeout=10)
+            "/api/report/questionnaire_status", timeout=20)
         assert response.json['total'] == 2
 
     def test_results(self):
@@ -239,7 +239,7 @@ class TestQBStats(TestQuestionnaireBankFixture):
         self.consent_with_org(org_id=org_id)
         self.login()
         response = self.results_from_async_call(
-            "/api/report/questionnaire_status", timeout=10)
+            "/api/report/questionnaire_status", timeout=20)
 
         # expect baseline for each plus 3 mo for user4
         assert response.json['total'] == 4


### PR DESCRIPTION
Site codes were not working in most places, as we were looking for an identifier that matched:
```
current_app.config.get('REPORTING_IDENTIFIER_SYSTEMS')
```
that happens to be a list, not a string on most systems.  now handling either input type.

The error preventing weekly reports from going out stems from an orgtree node being treated like an Organization instance.  