### PR TITLE
Test Deadlock Workaround

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,11 @@ unit_tests_deadlocks:
     TOXENV: deadlocks
   <<: *unit_test_definition
 
+unit_tests_deadlocks:
+  variables:
+    TOXENV: deadlocks1
+  <<: *unit_test_definition
+
 docgen_test:
   variables:
     TOXENV: docs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,11 @@ unit_tests_celery_background:
     TOXENV: celery_background
   <<: *unit_test_definition
 
+unit_tests_deadlocks:
+  variables:
+    TOXENV: deadlocks
+  <<: *unit_test_definition
+
 docgen_test:
   variables:
     TOXENV: docs

--- a/tox.ini
+++ b/tox.ini
@@ -113,7 +113,6 @@ commands =
         tests/test_portal.py \
         tests/test_practitioner.py \
         tests/test_procedure.py \
-        tests/test_qb_timeline.py \
         tests/test_questionnaire_bank.py \
         tests/test_recur.py \
         tests/test_reference.py \
@@ -128,6 +127,29 @@ commands =
         tests/test_truenth.py \
         tests/test_user_document.py \
         tests/test_user.py \
+    []
+
+[testenv:deadlocks]
+description = Tests that cause deadlocks when run alongside other tests
+commands =
+    # start celery in background, only on continuous integration
+    # Todo: migrate tests to fixtures
+    sh -c ' \
+        if [ "$CI" = true ]; then \
+            celery worker \
+                --detach \
+                --app portal.celery_worker.celery \
+                --queues celery,low_priority \
+                --loglevel info ; \
+        fi \
+    '
+    py.test \
+        --cov portal \
+        --cov-report xml:"{toxinidir}/coverage.xml" \
+        --timeout=3600 \
+        --timeout_method=thread \
+
+        tests/test_qb_timeline.py \
     []
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -116,7 +116,6 @@ commands =
         tests/test_questionnaire_bank.py \
         tests/test_recur.py \
         tests/test_reference.py \
-        tests/test_reporting.py \
         tests/test_research_protocol.py \
         tests/test_scheduled_job.py \
         tests/test_site_persistence.py \
@@ -149,6 +148,7 @@ commands =
         --timeout=3600 \
         --timeout_method=thread \
 
+        tests/test_reporting.py \
         tests/test_qb_timeline.py \
     []
 

--- a/tox.ini
+++ b/tox.ini
@@ -149,6 +149,28 @@ commands =
         --timeout_method=thread \
 
         tests/test_reporting.py \
+    []
+
+[testenv:deadlocks1]
+description = Tests that cause deadlocks when run alongside other tests
+commands =
+    # start celery in background, only on continuous integration
+    # Todo: migrate tests to fixtures
+    sh -c ' \
+        if [ "$CI" = true ]; then \
+            celery worker \
+                --detach \
+                --app portal.celery_worker.celery \
+                --queues celery,low_priority \
+                --loglevel info ; \
+        fi \
+    '
+    py.test \
+        --cov portal \
+        --cov-report xml:"{toxinidir}/coverage.xml" \
+        --timeout=3600 \
+        --timeout_method=thread \
+
         tests/test_qb_timeline.py \
     []
 


### PR DESCRIPTION
Split tests causing deadlocks to separate test suite (tox "env") invocation