### PR TITLE
adding an admin accessible only /celery-settings view

### DIFF
--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -94,6 +94,13 @@ def add(x, y):
     return x + y
 
 
+@celery.task(name="tasks.settings")
+def settings():
+    """similar to /settings view, but from job queue"""
+    config = current_app.config
+    return [f"{k}: {v}" for k, v in config.items()]
+
+
 @celery.task(name="tasks.info", queue=LOW_PRIORITY)
 def info():
     return "BROKER_URL: {} <br/> SERVER_NAME: {}".format(

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -1064,6 +1064,15 @@ def celery_info():
     return jsonify(result=res.get(), task_id=res.task_id)
 
 
+@portal.route("/celery-settings")
+@roles_required([ROLE.ADMIN.value])
+@oauth.require_oauth()
+def celery_settings():
+    from ..tasks import settings
+    res = settings.apply_async()
+    return jsonify(result=res.get(), task_id=res.task_id)
+
+
 @portal.route("/task/<task_id>")
 @oauth.require_oauth()
 def task_result(task_id):


### PR DESCRIPTION
needing to see differences between background and portal's config settings, added a task and view to see what celery has for `current_app.config` values