### PR TITLE
generate `site.cfg` for celery workers

### DIFF
--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -17,3 +17,17 @@ services:
         target: /mnt/code
         type: bind
         read_only: true
+
+  celeryworker:
+    volumes:
+      - source: ../
+        target: /mnt/code
+        type: bind
+        read_only: true
+
+  celeryworkerslow:
+    volumes:
+      - source: ../
+        target: /mnt/code
+        type: bind
+        read_only: true

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -16,18 +16,21 @@ services:
       - source: ../
         target: /mnt/code
         type: bind
-        read_only: true
 
   celeryworker:
+    environment:
+      FLASK_DEBUG: 1
+      FLASK_APP: /mnt/code/manage.py
     volumes:
       - source: ../
         target: /mnt/code
         type: bind
-        read_only: true
 
   celeryworkerslow:
+    environment:
+      FLASK_DEBUG: 1
+      FLASK_APP: /mnt/code/manage.py
     volumes:
       - source: ../
         target: /mnt/code
         type: bind
-        read_only: true

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -29,11 +29,13 @@ services:
     # Set lower CPU priority to prevent blocking web service
     cap_add:
       - SYS_NICE
-    command:
+    command: sh -c '
+      flask generate-site-cfg &&
       nice
         celery worker
           --app portal.celery_worker.celery
           --loglevel debug
+      '
 
   celeryworkerslow:
     restart: unless-stopped
@@ -44,12 +46,14 @@ services:
     # Set lower CPU priority to prevent blocking web service
     cap_add:
       - SYS_NICE
-    command:
+    command: sh -c '
+      flask generate-site-cfg &&
       nice -n 15
         celery worker
           --app portal.celery_worker.celery
           --queue low_priority
           --loglevel debug
+      '
 
   celerybeat:
     restart: unless-stopped

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -42,22 +42,24 @@ services:
 
   celeryworker:
     <<: *service_base
-    command:
+    command: sh -c '
       flask generate-site-cfg &&
       celery worker
         --app portal.celery_worker.celery
         --loglevel debug
+      '
     depends_on:
       - redis
 
   celeryworkerslow:
     <<: *service_base
-    command:
+    command: sh -c '
       flask generate-site-cfg &&
       celery worker
         --app portal.celery_worker.celery
         --queue low_priority
         --loglevel debug
+      '
     depends_on:
       - redis
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -43,6 +43,7 @@ services:
   celeryworker:
     <<: *service_base
     command:
+      flask generate-site-cfg &&
       celery worker
         --app portal.celery_worker.celery
         --loglevel debug
@@ -52,6 +53,7 @@ services:
   celeryworkerslow:
     <<: *service_base
     command:
+      flask generate-site-cfg &&
       celery worker
         --app portal.celery_worker.celery
         --queue low_priority

--- a/manage.py
+++ b/manage.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from portal.audit import auditable_event
 from portal.date_tools import FHIR_datetime
+from portal.config.config_persistence import import_config
 from portal.config.site_persistence import SitePersistence
 from portal.extensions import db, user_manager
 from portal.factories.app import create_app
@@ -176,6 +177,18 @@ def seed(keep_unmentioned=False):
     # import site export file if found
     SitePersistence(target_dir=None).import_(
         keep_unmentioned=keep_unmentioned)
+
+
+@app.cli.command()
+def generate_site_cfg():
+    """Generate only the site.cfg file via site_persistence
+
+    Typically done via `sync` or `seed`, this option exists for the
+    backend job queues to generate the `site.cfg` file to maintain
+    consistent configuration with the front end, withou the overhead
+    of the rest of `sync`
+    """
+    import_config(target_dir=None)
 
 
 @click.option('--directory', '-d', default=None, help="Export directory")

--- a/manage.py
+++ b/manage.py
@@ -188,7 +188,9 @@ def generate_site_cfg():
     consistent configuration with the front end, withou the overhead
     of the rest of `sync`
     """
+    app.logger.info("generate-site-cfg begin")
     import_config(target_dir=None)
+    app.logger.info("generate-site-cfg complete")
 
 
 @click.option('--directory', '-d', default=None, help="Export directory")

--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -137,6 +137,8 @@ def configure_app(app, config):
     """Load successive configs - overriding defaults"""
     app.config.from_object(DefaultConfig)
     app.config.from_pyfile('base.cfg', silent=True)
+    if not os.path.isfile(os.path.join(app.config.root_path, SITE_CFG)):
+        app.logger.warn(f"{SITE_CFG} not found")
     app.config.from_pyfile(SITE_CFG, silent=True)
     app.config.from_pyfile('application.cfg', silent=True)
 

--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -138,7 +138,9 @@ def configure_app(app, config):
     app.config.from_object(DefaultConfig)
     app.config.from_pyfile('base.cfg', silent=True)
     if not os.path.isfile(os.path.join(app.config.root_path, SITE_CFG)):
-        app.logger.warn(f"{SITE_CFG} not found")
+        app.logger.warn(f"{SITE_CFG} not found!!!!!!!!!!!!!")
+    else:
+        app.logger.warn(f"{SITE_CFG} FOUND!!!!!!!!!!!!!!")
     app.config.from_pyfile(SITE_CFG, silent=True)
     app.config.from_pyfile('application.cfg', silent=True)
 

--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -137,10 +137,11 @@ def configure_app(app, config):
     """Load successive configs - overriding defaults"""
     app.config.from_object(DefaultConfig)
     app.config.from_pyfile('base.cfg', silent=True)
-    if not os.path.isfile(os.path.join(app.config.root_path, SITE_CFG)):
-        app.logger.warn(f"{SITE_CFG} not found!!!!!!!!!!!!!")
+    site_cfg_fullpath = os.path.join(app.config.root_path, SITE_CFG)
+    if not os.path.isfile(site_cfg_fullpath):
+        app.logger.warn(f"{site_cfg_fullpath} not found!!!!!!!!!!!!!")
     else:
-        app.logger.warn(f"{SITE_CFG} FOUND!!!!!!!!!!!!!!")
+        app.logger.warn(f"{site_cfg_fullpath} FOUND!!!!!!!!!!!!!!")
     app.config.from_pyfile(SITE_CFG, silent=True)
     app.config.from_pyfile('application.cfg', silent=True)
 


### PR DESCRIPTION
The site_persistence machinery generates a site specific (eproms vs USA) config file for consumption on start-up.

Previously, only the `web` service was executing `flask sync` which generates this file for consumption.

New `generate-site-cfg` CLI included in the respective `celery` launch commands does exactly that, so the jobs have the same configuration as the web service.