### PR TITLE
TN-3255 status check from front-end to /me raising unexpected errors

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -99,8 +99,12 @@ def me():
 
     """
     user = current_user()
-    if user.current_encounter().auth_method == 'url_authenticated':
+
+    # only return user id, if auth came from a URL such as embedded within an email
+    encounter = user.current_encounter(generate_failsafe_if_missing=False)
+    if encounter and encounter.auth_method == 'url_authenticated':
         return jsonify(id=user.id)
+
     return jsonify(
         id=user.id, username=user.username, email=user.email)
 


### PR DESCRIPTION
Strange behavior observed multiple times on prod.  A relatively new check for a valid token, from the front-end to the `/api/me` view hits:

```if user.current_encounter().auth_method == 'url_authenticated':```

the error stack from the alerts indicate `current_encounter()` is returning `None`.  given the default behavior within `current_encounter` of generating a fallback encounter if none is found, this would be seemingly impossible!!

as this check is only being used to lookup the `auth_method` for the current user, and the fallback encounter will always have a different level auth, the code has been made more "robust" by not attempting to generate this fallback encounter and handle the lack of a  `current_encounter` in `/api/me`
