### PR TITLE
TN-3250, incorrect type in check for withdrawn from study

### DIFF
--- a/portal/eproms/templates/eproms/assessment_engine/ae_complete.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_complete.html
@@ -38,17 +38,24 @@
                 <div class="text-content">{{_("No questionnaire is due.")}}</div>
             {%- endcall -%}
         {%- else -%}
-            <!-- substudy due card -->
-            {{empro_due(
-                substudy_assessment_is_due=substudy_assessment_is_due,
-                assessment_status=assessment_status,
-                OverallStatus=OverallStatus,
-                substudy_assessment_status=substudy_assessment_status,
-                substudy_due_date=substudy_due_date,
-                enrolled_in_substudy=enrolled_in_substudy,
-                substudy_assessment_is_ready=substudy_assessment_is_ready,
-                substudy_assessment_errors=substudy_assessment_errors
-            )}}
+            {%- if substudy_assessment_status.overall_status == OverallStatus.expired -%}
+                {{empro_expired(
+                    user=user,
+                    substudy_assessment_status=substudy_assessment_status
+                )}}
+            {%- else -%}
+                <!-- substudy due card -->
+                {{empro_due(
+                    substudy_assessment_is_due=substudy_assessment_is_due,
+                    assessment_status=assessment_status,
+                    OverallStatus=OverallStatus,
+                    substudy_assessment_status=substudy_assessment_status,
+                    substudy_due_date=substudy_due_date,
+                    enrolled_in_substudy=enrolled_in_substudy,
+                    substudy_assessment_is_ready=substudy_assessment_is_ready,
+                    substudy_assessment_errors=substudy_assessment_errors
+                )}}
+            {%- endif -%}
         {%- endif -%}
         <!-- both main and sub-study completed -->
         {{completed_cards(

--- a/portal/eproms/templates/eproms/assessment_engine/ae_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_due.html
@@ -1,4 +1,4 @@
-{%- from "eproms/assessment_engine/ae_macros.html" import render_header, render_greeting, render_card_content, render_call_to_button, due_card, completed_card, empro_due, empro_completed, completed_cards -%}
+{%- from "eproms/assessment_engine/ae_macros.html" import render_header, render_greeting, render_card_content, render_call_to_button, due_card, completed_card, empro_due, empro_completed,  empro_expired, completed_cards -%}
 {% extends "eproms/assessment_engine/ae_base.html" %}
 <!-- baseline due -->
 {% block head %}
@@ -32,16 +32,23 @@
     <!-- main study due card -->
     {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=due_title_text)}}
     {%- if enrolled_in_substudy -%}
-        <!-- substudy due card, NOTE if global study work is still due, this tile will be disabled -->
-        {{empro_due(
-            substudy_assessment_is_due=substudy_assessment_is_due,
-            assessment_status=assessment_status,
-            OverallStatus=OverallStatus,
-            substudy_assessment_status=substudy_assessment_status,
-            substudy_due_date=substudy_due_date,
-            enrolled_in_substudy=enrolled_in_substudy,
-            substudy_assessment_is_ready=substudy_assessment_is_ready
-        )}}
+        {%- if substudy_assessment_status.overall_status == OverallStatus.expired -%}
+            {{empro_expired(
+                user=user,
+                substudy_assessment_status=substudy_assessment_status
+            )}}
+        {%- else -%}
+            <!-- substudy due card, NOTE if global study work is still due, this tile will be disabled -->
+            {{empro_due(
+                substudy_assessment_is_due=substudy_assessment_is_due,
+                assessment_status=assessment_status,
+                OverallStatus=OverallStatus,
+                substudy_assessment_status=substudy_assessment_status,
+                substudy_due_date=substudy_due_date,
+                enrolled_in_substudy=enrolled_in_substudy,
+                substudy_assessment_is_ready=substudy_assessment_is_ready
+            )}}
+        {%- endif -%}
         <!-- main study and/or substudy completed cards if either main study is completed or sub-study is completed -->
         {{completed_cards(
             user=user,

--- a/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_indefinite_due.html
@@ -18,16 +18,23 @@
     <!-- main study due card -->
     {{due_card(assessment_status=assessment_status, button_label=button_label, title_text=due_title_text)}}
     {%- if enrolled_in_substudy -%}
-        <!-- substudy due card, NOTE if global study work is still due, this tile will be disabled -->
-        {{empro_due(
-            substudy_assessment_is_due=substudy_assessment_is_due,
-            assessment_status=assessment_status,
-            OverallStatus=OverallStatus,
-            substudy_assessment_status=substudy_assessment_status,
-            substudy_due_date=substudy_due_date,
-            enrolled_in_substudy=enrolled_in_substudy,
-            substudy_assessment_is_ready=substudy_assessment_is_ready
-        )}}
+        {%- if substudy_assessment_status.overall_status == OverallStatus.expired -%}
+            {{empro_expired(
+                user=user,
+                substudy_assessment_status=substudy_assessment_status
+            )}}
+        {%- else -%}
+            <!-- substudy due card, NOTE if global study work is still due, this tile will be disabled -->
+            {{empro_due(
+                substudy_assessment_is_due=substudy_assessment_is_due,
+                assessment_status=assessment_status,
+                OverallStatus=OverallStatus,
+                substudy_assessment_status=substudy_assessment_status,
+                substudy_due_date=substudy_due_date,
+                enrolled_in_substudy=enrolled_in_substudy,
+                substudy_assessment_is_ready=substudy_assessment_is_ready
+            )}}
+        {%- endif %}
          <!-- main study and/or substudy completed cards if either main study is completed or sub-study is completed -->
         {{completed_cards(
             user=user,

--- a/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
+++ b/portal/eproms/templates/eproms/assessment_engine/ae_macros.html
@@ -62,6 +62,20 @@
     {{render_logout()}}
 {%- endmacro -%}
 
+{%- macro empro_expired(user=user, substudy_assessment_status={}) -%}
+    {% set substudy_title = "EMPRO" %}
+    {% call render_card_content(title_text=_("%(substudy_title)s Study", substudy_title=substudy_title), card_class="") %}
+        <div class="text-content">
+             <!-- verbiage used also for expired main study questionnaire -->
+             <p>{{_("The assessment is no longer available. A research staff member will contact you for assistance.")}}</p>
+             {% if substudy_assessment_status.at_least_one_completed %}
+                <div class="button-container">
+                    {{empro_report_link(user)}}
+                </div>
+             {% endif %}
+        </div>
+    {% endcall %}
+{%- endmacro -%}
 <!-- sub-study macro -->
 {%- macro empro_due(
                     substudy_assessment_is_due=false,
@@ -139,10 +153,23 @@
                 substudy_assessment_status=substudy_assessment_status,
                 substudy_comp_date=substudy_comp_date,
                 enrolled_in_substudy=enrolled_in_substudy,
-                card_class="" if substudy_overall_completed_status else "disabled"
+                card_class="" if substudy_overall_completed_status or substudy_assessment_status.at_least_one_completed else "disabled"
             )}}
         </div>
     </div>
+{%- endmacro -%}
+{%- macro empro_report_link(user=user, inModal=false) -%}
+    {%- if inModal -%}
+        {%- if user and user.current_encounter().auth_method == 'url_authenticated' -%}
+            <!-- for an url authenticated user, trying to access the report will be prompted to login in -->
+            <a class="btn btn-empro-primary btn-report portal-weak-auth-disabled" href="{{url_for('patients.longitudinal_report', subject_id=user.id, instrument_id='ironman_ss')}}">{{_("View My Report")}}</a>
+        {%- else -%}
+            <a class="btn btn-empro-primary btn-report longitudinal-report-link">{{_("View My Report")}}</a>
+        {%- endif -%}
+    {%- else -%}
+        <a class="btn-lg btn-tnth-primary portal-weak-auth-disabled" href="{{url_for('patients.longitudinal_report', subject_id=user.id, instrument_id='ironman_ss')}}">{{_("View My Report")}}</a>
+    {%- endif -%}
+    <!--btn-lg btn-tnth-primary -->
 {%- endmacro -%}
 <!-- sub-study macro -->
 {%- macro empro_completed(
@@ -160,15 +187,21 @@
             title_text = _("%(substudy_title)s Study", substudy_title=substudy_title),
             card_class = card_class if card_class else "portal-description-complete") -%}
             <div class="text-content">
-                <p>{{_("View a summary of your questionnaire responses, as well as key health tips and resources.")}}</p>
                 {% if substudy_assessment_status.overall_status == OverallStatus.completed %}
+                    <p>{{_("View a summary of your questionnaire responses, as well as key health tips and resources.")}}</p>
                     <div class="buttons-container">
                         <br/>
                         <!-- this is an anchor link to open thank you modal -->
                         <a class="btn-lg btn-tnth-primary" data-toggle="modal" data-target="#emproModal">{{_("View report and resources", substudy_comp_date=substudy_comp_date)}}</a>
                     </div>
                 {% else %}
-                    <p>{{_("No %(substudy_title)s questionnaire has been completed yet.", substudy_title=substudy_title)}}</p>
+                    {% if substudy_assessment_status.at_least_one_completed %}
+                        <div class="button-container">
+                            {{empro_report_link(user)}}
+                        </div>
+                    {% else %}
+                        <p>{{_("No %(substudy_title)s questionnaire has been completed yet.", substudy_title=substudy_title)}}</p>
+                    {% endif %}
                 {% endif %}
             </div>
         {%- endcall -%}
@@ -207,12 +240,7 @@
         <h4>{{_("Your Report")}}</h4>
         <p>{{_("Here's where you'll find an ongoing summary of your responses, each time you complete a questionnaire.")}}</p>
         <div class="buttons-container">
-            {%- if user and user.current_encounter().auth_method == 'url_authenticated' -%}
-                <!-- for an url authenticated user, trying to access the report will be prompted to login in -->
-                <a class="btn btn-empro-primary btn-report portal-weak-auth-disabled" href="{{url_for('patients.longitudinal_report', subject_id=user.id, instrument_id='ironman_ss')}}">{{_("View My Report")}}</a>
-            {%- else -%}
-                <a class="btn btn-empro-primary btn-report longitudinal-report-link">{{_("View My Report")}}</a>
-            {%- endif -%}
+            {{empro_report_link(user, true)}}
         </div>
     </div>
 {%- endmacro -%}

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -562,6 +562,9 @@ def patient_research_study_status(patient, ignore_QB_status=False):
         if assessment_status.overall_status == OverallStatus.withdrawn:
             rs_status['errors'].append('Withdrawn')
             continue
+        if assessment_status.overall_status == OverallStatus.expired:
+            rs_status['errors'].append('Expired')
+            continue
 
         needing_full = assessment_status.instruments_needing_full_assessment(
             classification='all')

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -24,6 +24,7 @@ class QB_Status(object):
     def __init__(self, user, research_study_id, as_of_date):
         self.user = user
         self.as_of_date = as_of_date
+        self.at_least_one_completed = False
         self.research_study_id = research_study_id
         for state in OverallStatus:
             setattr(self, "_{}_date".format(state.name), None)
@@ -45,6 +46,11 @@ class QB_Status(object):
         users_qbs = QBT.query.filter(QBT.user_id == self.user.id).filter(
             QBT.research_study_id == self.research_study_id).filter(
             QBT.status == OverallStatus.due).order_by(QBT.at.asc())
+
+        completed = QBT.query.filter(QBT.user_id == self.user.id).filter(
+            QBT.research_study_id == self.research_study_id).filter(
+            QBT.status == OverallStatus.completed).count()
+        self.at_least_one_completed = completed > 0
 
         # Obtain withdrawal date if applicable
         withdrawn = QBT.query.filter(QBT.user_id == self.user.id).filter(

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -860,8 +860,10 @@ def aggregate_responses(
         current_user, include_test_role=False).with_entities(User.id)
 
     annotated_questionnaire_responses = []
+    # TN-3250, don't include QNRs without assigned visits, i.e. qb_id > 0
     questionnaire_responses = QuestionnaireResponse.query.filter(
-        QuestionnaireResponse.subject_id.in_(user_ids)).order_by(
+        QuestionnaireResponse.subject_id.in_(user_ids)).filter(
+        QuestionnaireResponse.questionnaire_bank_id > 0).order_by(
         QuestionnaireResponse.document['authored'].desc())
 
     if instrument_ids:

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -394,7 +394,8 @@ def adherence_report(
 
 def research_report(
         instrument_ids, research_study_id, acting_user_id, patch_dstu2,
-        request_url, response_format, lock_key, celery_task):
+        request_url, response_format, lock_key, ignore_qb_requirement,
+        celery_task):
     """Generates the research report
 
     Designed to be executed in a background task - all inputs and outputs are
@@ -407,6 +408,7 @@ def research_report(
     :param request_url: original request url, for inclusion in FHIR bundle
     :param response_format: 'json' or 'csv'
     :param lock_key: name of TimeoutLock key used to throttle requests
+    :param ignore_qb_requirement: Set to include all questionnaire responses
     :param celery_task: used to update status when run as a celery task
     :return: dictionary of results, easily stored as a task output, including
        any details needed to assist the view method
@@ -421,6 +423,7 @@ def research_report(
         research_study_id=research_study_id,
         current_user=acting_user,
         patch_dstu2=patch_dstu2,
+        ignore_qb_requirement=ignore_qb_requirement,
         celery_task=celery_task
     )
     bundle.update({

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -96,6 +96,9 @@ def single_patient_adherence_data(patient, as_of_date, research_study_id):
                 qbd.completed_date(patient.id)) or ""
             row['oow_completion_date'] = report_format(
                 qbd.oow_completed_date(patient.id)) or ""
+        if row['status'] == 'Withdrawn':
+            # visit unreliable when withdrawn - clear
+            row['visit'] = ''
         entry_method = QNR_results(
             patient,
             research_study_id=research_study_id,
@@ -110,6 +113,10 @@ def single_patient_adherence_data(patient, as_of_date, research_study_id):
         if 'completion_date' in row:
             row['EMPRO_questionnaire_completion_date'] = (
                 row.pop('completion_date'))
+
+        # If withdrawn, the rest is unreliable
+        if row['status'] == 'Withdrawn':
+            return
 
         # Correct for zero index visit month in db
         visit_month = int(row['visit'].split()[-1]) - 1

--- a/portal/static/js/src/components/ExportInstruments.vue
+++ b/portal/static/js/src/components/ExportInstruments.vue
@@ -57,6 +57,7 @@
                             :initElementId="getInitElementId()"
                             :exportUrl="getExportUrl()"
                             :exportIdentifier="currentStudy"
+                            v-on:initExport="handleInitExport"
                             v-on:doneExport="handleAfterExport"
                             v-on:initExportCustomEvent="initExportEvent"></ExportDataLoader>
                         <!-- display link to the last export -->
@@ -64,7 +65,7 @@
                             <div class="text-muted prompt" v-text="exportHistoryTitle"></div>
                             <div v-if="exportHistory">
                                 <a :href="exportHistory.url" target="_blank">
-                                    <span v-text="exportHistory.instruments.join(', ')"></span>
+                                    <span v-text="(exportHistory.instruments || []).join(', ')"></span>
                                     <span v-text="exportHistory.date"></span>
                                 </a>
                             </div>
@@ -98,7 +99,8 @@
                 subStudyIdentifier: "substudy",
                 mainStudyInstrumentsList:[],
                 subStudyInstrumentsList:[],
-                exportHistory: null
+                exportHistory: null,
+                currentTaskUrl: null
             }};
         },
         mixins: [CurrentUser],
@@ -106,16 +108,16 @@
             this.setCurrentMainStudy();
             this.initCurrentUser(function() {
                 this.getInstrumentList();
-                this.setExportHistory(this.getCacheExportedDataInfo());
+                this.handleSetExportHistory();
             }.bind(this));
         },
         watch: {
             currentStudy: function(newVal, oldVal) {
                 //watch for when study changes
                 //reset last exported item link as it is specific to each study
-                this.setExportHistory(this.getCacheExportedDataInfo());
-                //reset export error
-                this.resetExportError();
+                this.handleSetExportHistory();
+                //reset export display info
+                this.resetExportInfoUI();
                 //reset instrument(s) selected
                 this.resetInstrumentSelections();
             },
@@ -206,8 +208,11 @@
                     self.instruments.selected = arrSelected;
                 });
                 $("#patientsInstrumentList [name='instrument'], #patientsDownloadTypeList [name='downloadType']").on("click", function() {
-                    //clear pre-existing error
-                    self.resetExportError();
+                    //clear pre-existing export info display
+                    self.resetExportInfoUI();
+                    if (self.hasInstrumentsSelection()) {
+                        $("#patientsDownloadButton").removeAttr("disabled");
+                    }
                 });
                 //patientsDownloadTypeList downloadType
                 $("#patientsDownloadTypeList [name='downloadType']").on("click", function() {
@@ -218,15 +223,23 @@
                     }
                 });
                 $("#dataDownloadModal").on("show.bs.modal", function () {
+                    self.resetExportInfoUI();
+                    self.setInstrumentsListReady();
                     self.instruments.selected = [];
                     self.instruments.dataType = "csv";
-                    self.resetExportError();
-                    self.setInstrumentsListReady();
+                    $(this).find("#patientsInstrumentList label").removeClass("active");
                     $(this).find("[name='instrument']").prop("checked", false);
                 });
             },
-            resetExportError: function() {
-                this.$refs.exportDataLoader.clearExportDataUI();
+            resetExportInfoUI: function() {
+                this.$refs.exportDataLoader.clearInProgress();
+            },
+            setInProgress: function(inProgress) {
+                if (!inProgress) {
+                    this.resetExportInfoUI();
+                    return;
+                }
+                this.$refs.exportDataLoader.setInProgress(true);
             },
             initExportEvent: function() {
                 /*
@@ -234,7 +247,10 @@
                  */
                 let self = this;
                  $("#dataDownloadModal").on("hide.bs.modal", function () {
-                    $("#"+self.getInitElementId()).removeAttr("data-export-in-progress");
+                    self.setInProgress(false);
+                });
+                $(window).on("focus", function() {
+                    self.handleSetExportHistory();
                 });
             },
             setDataType: function (event) {
@@ -259,21 +275,100 @@
                 var queryStringInstruments = (this.instruments.selected).map(item => `instrument_id=${item}`).join("&");
                 return `/api/patient/assessment?${queryStringInstruments}&format=${this.instruments.dataType}`;
             },
+            getDefaultExportObj: function() {
+                return {
+                    study: this.currentStudy,
+                    date: new Date().toLocaleString(),
+                    instruments: this.instruments.selected || []
+                }
+            },
+            handleInitExport: function(statusUrl) {
+                if (!statusUrl) return;
+                // whenever the user initiates an export, we cache the associated celery task URL
+                this.setCacheTask({
+                    ...this.getDefaultExportObj(),
+                    url: statusUrl
+                });
+                this.currentTaskUrl = statusUrl;
+            },
             handleAfterExport: function(resultUrl) {
                 //export is done, save the last export to local storage
                 this.setCacheExportedDataInfo(resultUrl);
             },
+            getCacheExportTaskKey: function() {
+                return `export_data_task_${this.getUserId()}_${this.currentStudy}`;
+            },
+            removeCacheTaskURL: function() {
+                localStorage.removeItem(this.getCacheExportTaskKey());
+            },
+            setCacheTask: function(taskObj) {
+                if (!taskObj) return;
+                localStorage.setItem(this.getCacheExportTaskKey(), JSON.stringify(taskObj));
+            },
+            getCacheTask: function() {
+                const task = localStorage.getItem(this.getCacheExportTaskKey());
+                if (!task) return null;
+                let resultJSON = null;
+                try {
+                    resultJSON = JSON.parse(task);
+                } catch(e) {
+                    console.log("Unable to parse task JSON ", e);
+                    resultJSON = null;
+                }
+                return resultJSON;
+            },
+            getFinishedStatusURL: function(url) {
+                if (!url) return "";
+                return url.replace("/status", "");
+            },
+            getExportDataInfoFromTask: function(callback) {
+                callback = callback || function() {};
+                const task = this.getCacheTask();
+                const self = this;
+                if (!task) {
+                    callback({data: null});
+                    return;
+                }
+                const taskURL = task.url;
+                if (!taskURL) {
+                    callback({data: null});
+                    return;
+                }
+                $.getJSON(taskURL, function(data) {
+                    if (!data) {
+                        callback({data: null});
+                        return;
+                    }
+                    // check the status of the celery task and returns the data if it had been successful
+                    const exportStatus = String(data["state"]).toUpperCase();
+                    callback({
+                                data : 
+                                    exportStatus === "SUCCESS"? 
+                                    {
+                                        ...task,
+                                        url: self.getFinishedStatusURL(taskURL)
+                                    }:
+                                    null
+                            });
+                    // callback({
+                    //     data: {
+                    //         ...task,
+                    //         url: self.getFinishedStatusURL(taskURL)
+                    //     }
+                    // })
+                }).fail(function() {
+                    callback({data: null});
+                });
+            },
             getCacheExportedDataInfoKey: function() {
                 //uniquely identified by each user and the study
-                return `exporDataInfo_${this.getUserId()}_${this.currentStudy}}`;
+                return `exporDataInfo_${this.getUserId()}_${this.currentStudy}`;
             },
             setCacheExportedDataInfo: function(resultUrl) {
                 if (!resultUrl) return false;
                 if (!this.hasInstrumentsSelection()) return;
                 var o = {
-                    study: this.currentStudy,
-                    date: new Date().toLocaleString(),
-                    instruments: this.instruments.selected,
+                    ...this.getDefaultExportObj(),
                     url: resultUrl
                 };
                 localStorage.setItem(this.getCacheExportedDataInfoKey(), JSON.stringify(o));
@@ -284,7 +379,14 @@
                 if (!cachedItem) {
                     return null;
                 }
-                return JSON.parse(cachedItem);
+                let resultJSON = null;
+                try {
+                    resultJSON = JSON.parse(cachedItem);
+                } catch(e) {
+                    console.log("Unable to parse cached data export info ", e);
+                    resultJSON = null;
+                }
+                return resultJSON;
             },
             hasExportHistory: function() {
                 return this.exportHistory || this.getCacheExportedDataInfo();
@@ -292,6 +394,27 @@
             setExportHistory: function(o) {
                 this.exportHistory = o;
             },
+            handleSetExportHistory: function() {
+                const self = this;
+                this.getExportDataInfoFromTask(function(data) {
+                    if (data && data.data) {
+                        this.setExportHistory(data.data);
+                        const task = this.getCacheTask();
+                      //  console.log("current task URL ", self.getFinishedStatusURL(self.currentTaskUrl));
+                      //  console.log("cached task URL ", self.getFinishedStatusURL(task.url));
+                        if (task &&
+                            task.url &&
+                            self.getFinishedStatusURL(task.url) === self.getFinishedStatusURL(self.currentTaskUrl)) {
+                            this.setInProgress(false);
+                        }
+                        return;
+                    }
+                    const cachedDataInfo = this.getCacheExportedDataInfo();
+                    if (cachedDataInfo) {
+                        this.setExportHistory(cachedDataInfo);
+                    }
+                }.bind(this));
+            }
         }
     };
 </script>

--- a/portal/static/js/src/components/asyncExportDataLoader.vue
+++ b/portal/static/js/src/components/asyncExportDataLoader.vue
@@ -87,11 +87,15 @@
             clearTimeElapsed: function() {
                 this.exportTimeElapsed = 0;
             },
-            onBeforeExportData: function() {
+            clearInProgress: function() {
                 this.updateExportProgress("", "");
                 this.clearExportDataTimeoutID();
                 this.clearTimeElapsed();
                 this.clearExportDataUI();
+                this.setInProgress(false);
+            },
+            onBeforeExportData: function() {
+                this.clearInProgress();
                 this.setInProgress(true);
                 $("#" + this.initElementId).attr("disabled", true);
                 $(".export__display-container").addClass("active");
@@ -103,7 +107,6 @@
             },
             onAfterExportData: function(options) {
                 options = options || {};
-                let delay = options.delay||5000;
                 $("#" + this.initElementId).attr("disabled", false);
                 $(".export__status").removeClass("active");
                 this.setInProgress();
@@ -129,6 +132,8 @@
                         url: exportDataUrl,
                         success: function(data, status, request) {
                             let statusUrl= request.getResponseHeader("Location");
+                          //  console.log("status URL ", statusUrl)
+                            self.$emit("initExport", statusUrl);
                             self.updateExportProgress(statusUrl, function(data) {
                                 self.onAfterExportData(data);
                             });
@@ -165,7 +170,7 @@
                 let self = this;
                 let waitTime = 3000;
                 // send GET request to status URL
-                let rqId = $.getJSON(statusUrl, function(data) {
+                $.getJSON(statusUrl, function(data) {
                     if (!data) {
                         callback({error: true});
                         return;
@@ -183,12 +188,12 @@
                         percent = parseInt(data['current'] * 100 / data['total']) + "%";
                     } else {
                         percent = " -- %";
-                        //allow maximum allowed elapsed time of pending status and no progress percentage returned, 
-                        //if still no progress returned, then return error and display message
-                        if (exportStatus === "PENDING" && self.exportTimeElapsed > self.maximumPendingTime) {
-                            callback({error: true, message: "Processing job not responding. Please try again.", delay: 10000});
-                            return;
-                        }
+                    }
+                    //allow maximum allowed elapsed time of pending status and no progress percentage returned, 
+                    //if still no progress returned, then return error and display message
+                    if (exportStatus === "PENDING" && self.exportTimeElapsed > self.maximumPendingTime) {
+                        callback({error: true, message: "Processing job not responding. Please try again.", delay: 30000});
+                        return;
                     }
                     //update status and percentage displays
                     self.updateProgressDisplay(exportStatus, percent, true);
@@ -199,6 +204,9 @@
                             setTimeout(function() {
                                 window.location.assign(resultUrl);
                             }, 50); //wait a bit before retrieving results
+                        } else {
+                            callback({error: true, message: "Unknown status return from the processing job. Status: ", exportStatus});
+                            return;
                         }
                         self.updateProgressDisplay(data["state"], "");
                         setTimeout(function() {
@@ -214,7 +222,7 @@
                         (self.arrExportDataTimeoutID).push(self.exportDataTimeoutID);
                     }
                 }).fail(function() {
-                    callback({error: true});
+                    callback({error: true, message: "The processing job has failed."});
                 });
             }
         }

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -28,6 +28,7 @@ from ..models.encounter import EC
 from ..models.fhir import bundle_results
 from ..models.identifier import Identifier
 from ..models.intervention import INTERVENTION
+from ..models.overall_status import OverallStatus
 from ..models.qb_timeline import invalidate_users_QBT
 from ..models.questionnaire import Questionnaire
 from ..models.questionnaire_response import (
@@ -1772,7 +1773,7 @@ def present_needed():
     for rs in ResearchStudy.assigned_to(subject):
         assessment_status = QB_Status(
             subject, research_study_id=rs, as_of_date=as_of_date)
-        if assessment_status.overall_status == 'Withdrawn':
+        if assessment_status.overall_status == OverallStatus.withdrawn:
             abort(400, 'Withdrawn; no pending work found')
 
         args = dict(request.args.items())

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -851,6 +851,7 @@ def get_assessments():
 
     research_studies = set()
     questionnaire_list = request.args.getlist('instrument_id')
+    ignore_qb_requirement = request.args.get("ignore_qb_requirement", False)
     for q in questionnaire_list:
         research_studies.add(research_study_id_from_questionnaire(q))
     if len(research_studies) != 1:
@@ -871,6 +872,7 @@ def get_assessments():
         'patch_dstu2': request.args.get('patch_dstu2'),
         'request_url': request.url,
         'lock_key': "research_report_task_lock",
+        'ignore_qb_requirement': request.args.get("ignore_qb_requirement"),
         'response_format': request.args.get('format', 'json').lower()
     }
 

--- a/tests/test_assessment_engine.py
+++ b/tests/test_assessment_engine.py
@@ -412,7 +412,9 @@ class TestAssessmentEngine(TestCase):
 
         updated_qnr_response = self.results_from_async_call(
             '/api/patient/assessment',
-            query_string={'instrument_id': instrument_id})
+            query_string={
+                'instrument_id': instrument_id,
+                'ignore_qb_requirement': True})
         assert updated_qnr_response.status_code == 200
         assert (
             updated_qnr_response.json['entry'][0]['group']
@@ -457,7 +459,9 @@ class TestAssessmentEngine(TestCase):
 
         response = self.results_from_async_call(
             '/api/patient/assessment',
-            query_string={'instrument_id': instrument_id})
+            query_string={
+                'instrument_id': instrument_id,
+                'ignore_qb_requirement': True})
         assert response.status_code == 200
         response = response.json
 


### PR DESCRIPTION
The view used to determine which questionnaires (assessments) a given patient needs to submit, was incorrectly comparing an `OverallStatus` instance with the string `Withdrawn`.  Thus, patients withdrawn from a given study would incorrectly be administered assessments.

Extending this hotfix to include exclusion of questionnaire responses after withdrawn visits - actually now excluding ALL questionnaire responses that aren't associated with a valid questionnaire bank (i.e. a visit).