### PR TITLE
TN-3259 research data export - UI not showing the most current download link

### DIFF
--- a/portal/static/js/src/components/ExportInstruments.vue
+++ b/portal/static/js/src/components/ExportInstruments.vue
@@ -247,7 +247,6 @@
                     self.setInProgress(false);
                 });
                 $(window).on("focus", function() {
-                    console.log("onfocus fired")
                     self.handleSetExportHistory();
                 });
             },

--- a/portal/static/js/src/components/asyncExportDataLoader.vue
+++ b/portal/static/js/src/components/asyncExportDataLoader.vue
@@ -87,11 +87,15 @@
             clearTimeElapsed: function() {
                 this.exportTimeElapsed = 0;
             },
-            onBeforeExportData: function() {
+            clearInProgress: function() {
                 this.updateExportProgress("", "");
                 this.clearExportDataTimeoutID();
                 this.clearTimeElapsed();
                 this.clearExportDataUI();
+                this.setInProgress(false);
+            },
+            onBeforeExportData: function() {
+                this.clearInProgress();
                 this.setInProgress(true);
                 $("#" + this.initElementId).attr("disabled", true);
                 $(".export__display-container").addClass("active");
@@ -128,6 +132,7 @@
                         url: exportDataUrl,
                         success: function(data, status, request) {
                             let statusUrl= request.getResponseHeader("Location");
+                          //  console.log("status URL ", statusUrl)
                             self.$emit("initExport", statusUrl);
                             self.updateExportProgress(statusUrl, function(data) {
                                 self.onAfterExportData(data);

--- a/portal/static/js/src/components/asyncExportDataLoader.vue
+++ b/portal/static/js/src/components/asyncExportDataLoader.vue
@@ -103,7 +103,6 @@
             },
             onAfterExportData: function(options) {
                 options = options || {};
-                let delay = options.delay||5000;
                 $("#" + this.initElementId).attr("disabled", false);
                 $(".export__status").removeClass("active");
                 this.setInProgress();
@@ -129,6 +128,7 @@
                         url: exportDataUrl,
                         success: function(data, status, request) {
                             let statusUrl= request.getResponseHeader("Location");
+                            self.$emit("initExport", statusUrl);
                             self.updateExportProgress(statusUrl, function(data) {
                                 self.onAfterExportData(data);
                             });
@@ -165,7 +165,7 @@
                 let self = this;
                 let waitTime = 3000;
                 // send GET request to status URL
-                let rqId = $.getJSON(statusUrl, function(data) {
+                $.getJSON(statusUrl, function(data) {
                     if (!data) {
                         callback({error: true});
                         return;
@@ -183,12 +183,12 @@
                         percent = parseInt(data['current'] * 100 / data['total']) + "%";
                     } else {
                         percent = " -- %";
-                        //allow maximum allowed elapsed time of pending status and no progress percentage returned, 
-                        //if still no progress returned, then return error and display message
-                        if (exportStatus === "PENDING" && self.exportTimeElapsed > self.maximumPendingTime) {
-                            callback({error: true, message: "Processing job not responding. Please try again.", delay: 10000});
-                            return;
-                        }
+                    }
+                    //allow maximum allowed elapsed time of pending status and no progress percentage returned, 
+                    //if still no progress returned, then return error and display message
+                    if (exportStatus === "PENDING" && self.exportTimeElapsed > self.maximumPendingTime) {
+                        callback({error: true, message: "Processing job not responding. Please try again.", delay: 30000});
+                        return;
                     }
                     //update status and percentage displays
                     self.updateProgressDisplay(exportStatus, percent, true);
@@ -199,6 +199,9 @@
                             setTimeout(function() {
                                 window.location.assign(resultUrl);
                             }, 50); //wait a bit before retrieving results
+                        } else {
+                            callback({error: true, message: "Unknown status return from the processing job. Status: ", exportStatus});
+                            return;
                         }
                         self.updateProgressDisplay(data["state"], "");
                         setTimeout(function() {
@@ -214,7 +217,7 @@
                         (self.arrExportDataTimeoutID).push(self.exportDataTimeoutID);
                     }
                 }).fail(function() {
-                    callback({error: true});
+                    callback({error: true, message: "The processing job has failed."});
                 });
             }
         }


### PR DESCRIPTION
Address story: [TN-3259](https://movember.atlassian.net/browse/TN-3259?atlOrigin=eyJpIjoiM2Q1MzQ2ZjE0YzY1NDBjMDk0OTM2OWMxMWMzMTc3ODAiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)
See also Slack convo [here](https://cirg.slack.com/archives/C5EU4L7PF/p1694733386101599)
Changes include:
- Whenever an data export is initiated on the UI, the frontend will cache the celery task URL associated with the export
- Address the scenario where the export is left running in the background, e.g. as when user switches to a different browser tab - when data export window receives focus again, e.g. as when the user comes back from a different browser tab, the frontend will now check if the download has finished by calling the celery task URL cached from the previous step and update the download link on UI if it has finished successfully.
- other change - enhance error checking