### PR TITLE
TN-3205 Fix for `update_qnr` 

### DIFF
--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -439,7 +439,7 @@ class QuestionnaireResponse(db.Model):
             if question["linkId"] == link_id:
                 questions.append(replacement)
                 continue
-            questions.append(replacement)
+            questions.append(question)
         assert len(questions) == len(self.document["group"]["question"])
         return questions
 


### PR DESCRIPTION
Correct typo/bug: include all questions as they were, replacing only the matching link_id.
As it was, replaced every question with the target answer intended for just a single link_id.