### PR TITLE
Fixup Docker Image Building

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 
 
-FROM debian:bookworm as builder
+FROM debian:bullseye as builder
 
 ENV \
     ARTIFACT_DIR=/tmp/artifacts \
@@ -51,7 +51,7 @@ RUN \
 
 # -----------------------------------------------------------------------------
 
-FROM debian:bookworm as production
+FROM debian:bullseye as production
 
 LABEL org.opencontainers.image.source https://github.com/uwcirg/truenth-portal
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 
 
-FROM debian:bullseye as builder
+FROM debian:bookworm as builder
 
 ENV \
     ARTIFACT_DIR=/tmp/artifacts \
@@ -51,7 +51,7 @@ RUN \
 
 # -----------------------------------------------------------------------------
 
-FROM debian:bullseye as production
+FROM debian:bookworm as production
 
 LABEL org.opencontainers.image.source https://github.com/uwcirg/truenth-portal
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 
 
-FROM debian:buster as builder
+FROM debian:bullseye as builder
 
 ENV \
     ARTIFACT_DIR=/tmp/artifacts \
@@ -51,7 +51,7 @@ RUN \
 
 # -----------------------------------------------------------------------------
 
-FROM debian:buster as production
+FROM debian:bullseye as production
 
 LABEL org.opencontainers.image.source https://github.com/uwcirg/truenth-portal
 


### PR DESCRIPTION
- Update debian base image from oldoldstable (buster) to oldstable (bullseye)
  - current stable (bookworm) fails to build

We'll probably want to switch to our general (simpler) approach for building python images and remove [`dh-virtualenv`](https://github.com/spotify/dh-virtualenv), instead of upgrading to bookworm