### PR TITLE
TN-3250 Possible a withdrawn user returns via access email

### DIFF
--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1776,7 +1776,11 @@ def present_needed():
         assessment_status = QB_Status(
             subject, research_study_id=rs, as_of_date=as_of_date)
         if assessment_status.overall_status == OverallStatus.withdrawn:
-            abort(400, 'Withdrawn; no pending work found')
+            # As it's possible a user withdrew, then followed an old email
+            # link back in to take the assessment, log this fact and redirect
+            current_app.logger.warning(
+                f'{subject_id} is Withdrawn, no pending work found; redirect home')
+            return redirect('/')
 
         args = dict(request.args.items())
         args['instrument_id'] = (


### PR DESCRIPTION
 If a withdrawn user returns via access mail with next_step to present_needed, the user would see a 400:
 
![image](https://github.com/uwcirg/truenth-portal/assets/755392/60a6bb6d-c7e6-4bd1-8f5f-f1cdce61d275)

Adjusted to log event and redirect home.