### PR TITLE
TN-3267 Remove Zulu

### DIFF
--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -3613,11 +3613,6 @@
                 "code": "xh_ZA",
                 "display": "Xhosa",
                 "system": "urn:ietf:bcp:47"
-              },
-              {
-                "code": "zu_ZA",
-                "display": "Zulu",
-                "system": "urn:ietf:bcp:47"
               }
             ]
           }
@@ -4796,11 +4791,6 @@
                 "system": "urn:ietf:bcp:47"
               },
               {
-                "code": "zu_ZA",
-                "display": "Zulu",
-                "system": "urn:ietf:bcp:47"
-              },
-              {
                 "code": "xh_ZA",
                 "display": "Xhosa",
                 "system": "urn:ietf:bcp:47"
@@ -4900,11 +4890,6 @@
               {
                 "code": "fr_CA",
                 "display": "Canadian French",
-                "system": "urn:ietf:bcp:47"
-              },
-              {
-                "code": "zu_ZA",
-                "display": "Zulu",
                 "system": "urn:ietf:bcp:47"
               },
               {


### PR DESCRIPTION
Only Groote Schuur Hospital has been using it to date.  https://movember.atlassian.net/browse/TN-3267 .

See the description at that story, we actually removed Zulu in 2021 but earlier this year were asked to use it for Groote Schuur. 

I think we'll need a migration to switch any user from Zulu to English, like we did for orgs in 2021 https://github.com/uwcirg/truenth-portal/pull/4086 (and we'll need to run that existing migration again)