### PR TITLE
TimeoutLock.__exit__() fixed to correctly generate a stack in the log

### DIFF
--- a/portal/timeout_lock.py
+++ b/portal/timeout_lock.py
@@ -62,12 +62,8 @@ class TimeoutLock(object):
         # To avoid interrupting iterative lock use, return truthy
         # value to stop exception propagation - see PEP
         if exc_type is not None:
-            error_message = f"{exc_type}"
-            if exc_value:
-                error_message += f": {exc_value}"
-            if traceback:
-                error_message += f"; {traceback}"
-            current_app.logger.error(error_message)
+            current_app.logger.exception(
+                "TimeoutLock trapped exception:", exc_info=True)
         return True
 
     def is_locked(self):


### PR DESCRIPTION
When an exception is raised from any code during the use of a TimeoutLock, it propagates to the `TimeoutLock.__exit__()` method, which must catch and disband the exception, less it'll remain in a potential deadlock state.

But, the code attempting to log the exception text was incorrectly accessing the attributes from the stack.  This PR corrects to generate a stack in the log file, and move on.

This is an old issue, and has been hiding errors raised behind TimeoutLocks from the log files for some time.  Is also probably the reason celery will occasionally behave as if it's in a locked state.

Finally found a reproduction (while working on #4343 regression issues), and found a solution!

I should add, the code in our system protected by TimeoutLocks is SIGNIFICANT - most all questionnaire bank work, building OrganizationTree in memory, EMPRO state manipulation, Adherence Reports, etc.