### PR TITLE
Hotfit/user consent withdrawal date regression

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -928,7 +928,7 @@ def preview_site_update(org_id, retired):
         )
         update_users_QBT(
             patient.id, research_study_id=0, invalidate_existing=True)
-        after_qnrs, after_timeline, qnrs_lost_reference = present_before_after_state(
+        after_qnrs, after_timeline, qnrs_lost_reference, _ = present_before_after_state(
             patient.id, patient.external_study_id, patient_state[patient.id])
         total_qnrs += len(patient_state[patient.id]['qnrs'])
         total_qbs_completed_b4 += len(

--- a/manage.py
+++ b/manage.py
@@ -44,7 +44,11 @@ from portal.models.questionnaire_bank import (
     QuestionnaireBank,
     add_static_questionnaire_bank,
 )
-from portal.models.questionnaire_response import QuestionnaireResponse
+from portal.models.questionnaire_response import (
+    QuestionnaireResponse,
+    capture_patient_state,
+    present_before_after_state,
+)
 from portal.models.relationship import add_static_relationships
 from portal.models.research_study import (
     BASE_RS_ID,
@@ -802,71 +806,6 @@ def merge_users(src_id, tgt_id, actor):
         user_id=acting_user.id,
         subject_id=tgt_id)
     print(message)
-
-
-def capture_patient_state(patient_id):
-    """Call to capture QBT and QNR state for patient, used for before/after"""
-    qnrs = QuestionnaireResponse.qnr_state(patient_id)
-    tl = QBT.timeline_state(patient_id)
-    return {'qnrs': qnrs, 'timeline': tl}
-
-
-def present_before_after_state(user_id, external_study_id, before_state):
-    from portal.dict_tools import dict_compare
-    after_qnrs = QuestionnaireResponse.qnr_state(user_id)
-    after_timeline = QBT.timeline_state(user_id)
-    qnrs_lost_reference = []
-
-    def visit_from_timeline(qb_name, qb_iteration, timeline_results):
-        """timeline results have computed visit name - quick lookup"""
-        for visit, name, iteration in timeline_results.values():
-            if qb_name == name and qb_iteration == iteration:
-                return visit
-        raise ValueError(f"no visit found for {qb_name}, {qb_iteration}")
-
-    # Compare results
-    added_q, removed_q, modified_q, same = dict_compare(
-        after_qnrs, before_state['qnrs'])
-    assert not added_q
-    assert not removed_q
-
-    added_t, removed_t, modified_t, same = dict_compare(
-        after_timeline, before_state['timeline'])
-
-    if any((added_t, removed_t, modified_t, modified_q)):
-        print(f"\nPatient {user_id} ({external_study_id}):")
-    if modified_q:
-        print("\tModified QNRs (old, new)")
-        for mod in sorted(modified_q):
-            print(f"\t\t{mod} {modified_q[mod][1]} ==>"
-                  f" {modified_q[mod][0]}")
-            # If the QNR previously had a reference QB and since
-            # lost it, capture for reporting.
-            if (
-                    modified_q[mod][1][0] != "none of the above" and
-                    modified_q[mod][0][0] == "none of the above"):
-                visit_name = visit_from_timeline(
-                    modified_q[mod][1][0],
-                    modified_q[mod][1][1],
-                    before_state["timeline"])
-                qnrs_lost_reference.append((visit_name, modified_q[mod][1][2]))
-    if added_t:
-        print("\tAdditional timeline rows:")
-        for item in sorted(added_t):
-            print(f"\t\t{item} {after_timeline[item]}")
-    if removed_t:
-        print("\tRemoved timeline rows:")
-        for item in sorted(removed_t):
-            print(
-                f"\t\t{item} "
-                f"{before_state['timeline'][item]}")
-    if modified_t:
-        print(f"\tModified timeline rows: (old, new)")
-        for item in sorted(modified_t):
-            print(f"\t\t{item}")
-            print(f"\t\t\t{modified_t[item][1]} ==> {modified_t[item][0]}")
-
-    return after_qnrs, after_timeline, qnrs_lost_reference
 
 
 @app.cli.command()

--- a/portal/migrations/versions/3c871e710277_.py
+++ b/portal/migrations/versions/3c871e710277_.py
@@ -138,7 +138,15 @@ def upgrade():
                 # special cases best left alone
                 continue
             user = User.query.get(patient_id)
-            consent_date, withdrawal_date = consent_withdrawal_dates(user, study_id)
+            if user.deleted:
+                continue
+            consent_date, withdrawal_date = consent_withdrawal_dates(
+                user, study_id)
+            if withdrawal_date is None:
+                # scenario happens with a withdrawn patient re-start
+                # i.e. as withdrawal was entered in error.
+                # no change needed in this situation
+                continue
 
             # report if dates don't match spreadsheet in IRONN-210
             cd_str = '{dt.day}-{dt:%b}-{dt:%y}'.format(dt=consent_date)

--- a/portal/migrations/versions/3c871e710277_.py
+++ b/portal/migrations/versions/3c871e710277_.py
@@ -1,0 +1,172 @@
+"""Correct user_consent regression issues raised by PR #4343
+
+Revision ID: 3c871e710277
+Revises: edb52362d013
+Create Date: 2024-01-25 20:04:48.109980
+
+"""
+from alembic import op
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.sql.functions import count
+
+from portal.models.research_study import BASE_RS_ID, EMPRO_RS_ID
+from portal.models.qb_timeline import update_users_QBT
+from portal.models.questionnaire_response import (
+    capture_patient_state,
+    present_before_after_state,
+)
+from portal.models.user import User
+from portal.models.user_consent import UserConsent, consent_withdrawal_dates
+
+Session = sessionmaker()
+
+
+# revision identifiers, used by Alembic.
+revision = '3c871e710277'
+down_revision = 'edb52362d013'
+
+
+# csv values direct from attachment in #IRONN-210, used to verify
+verified_user_consent_dates = (
+    {
+        101: ("13-Dec-17", "13-Dec-17"),
+        1073: ("16-Nov-18", "19-Sep-23"),
+        1113: ("24-Oct-18", "27-Oct-21"),
+        1186: ("19-Dec-18", "19-Dec-18"),
+        1229: ("14-Jan-19", "10-Jan-24"),
+        145: ("11-Jan-18", "17-Oct-18"),
+        1524: ("12-Mar-19", "28-Oct-21"),
+        1608: ("2-Apr-19", "7-Jun-21"),
+        164: ("8-Jan-18", "7-Mar-18"),
+        184: ("2-Feb-18", "2-May-19"),
+        2049: ("4-Jul-19", "1-Jun-22"),
+        209: ("22-Feb-18", "14-Dec-20"),
+        224: ("28-Feb-18", "9-Mar-18"),
+        2425: ("18-Sep-19", "26-May-21"),
+        2547: ("25-Sep-19", "4-Aug-21"),
+        2748: ("19-Nov-19", "22-Oct-22"),
+        2845: ("23-Aug-19", "23-Sep-21"),
+        2911: ("27-Nov-19", "9-Sep-23"),
+        310: ("12-Apr-18", "16-Aug-18"),
+        3251: ("16-Mar-20", "19-Jan-22"),
+        3256: ("19-Mar-20", "5-May-22"),
+        3427: ("26-May-20", "2-Sep-22"),
+        3430: ("16-Jun-20", "15-May-21"),
+        3455: ("4-Jun-20", "7-May-21"),
+        3826: ("11-Nov-20", "30-Nov-20"),
+        4316: ("19-Apr-21", "27-Apr-22"),
+        4806: ("17-Feb-22", "13-Oct-22"),
+        482: ("8-Aug-17", "28-Jul-20"),
+        4861: ("28-Sep-21", "27-Feb-22"),
+        4868: ("3-Mar-22", "18-Aug-22"),
+        5004: ("5-Oct-21", "24-Sep-23"),
+        5336: ("31-Jan-22", "7-Nov-23"),
+        5852: ("5-Jul-22", "15-Apr-23"),
+        5853: ("5-Jul-22", "20-Apr-23"),
+        5959: ("26-Jul-22", "17-Aug-22"),
+        6204: ("17-Sep-22", "25-Oct-23"),
+        6218: ("27-Sep-22", "29-Oct-23"),
+        641: ("7-Aug-18", "29-Dec-20"),
+        653: ("9-Jul-18", "10-Sep-18"),
+        6686: ("29-Jan-23", "12-Jun-23"),
+        719: ("29-May-18", "27-Aug-18"),
+        723: ("16-May-18", "25-Aug-23"),
+        774: ("24-Oct-17", "9-Nov-17"),
+        833: ("12-Sep-18", "11-Sep-23"),
+        892: ("18-Sep-18", "5-Jan-20"),
+        98: ("13-Dec-17", "22-Mar-18"),
+        986: ("6-Sep-18", "22-Jun-23"),
+        987: ("26-Jul-18", "14-Oct-19"),
+    },
+    {
+        563: ("10-Nov-22", "16-Dec-22"),
+        3591: ("1-Oct-22", "1-Oct-23"),
+        5596: ("12-Jul-22", "12-Oct-22"),
+        5747: ("6-Jun-22", "10-Jun-23"),
+        5849: ("5-Jul-22", "12-Oct-22"),
+        6026: ("4-Nov-22", "4-Nov-23"),
+    }
+)
+
+
+def upgrade():
+    """Correct UserConsents for any negatively affected patients
+
+    Prior to the release of 23.10.12.1, moving withdrawal dates wasn't
+    allowed. This made lookups for the last valid user_consent *prior*
+    to the withdrawal date, reliable, as user_consents land in the table
+    in an ordered fashion, and the most recently deleted prior to
+    withdrawal would have been in use.
+
+    The implementation of IRONN-210 enabled moving of withdrawal dates,
+    and incorrectly assumed it would be necessary to allow lookups of
+    the previous valid consent, to just work further back in the stack
+    of user_consents.  That would only be correct on the few tested,
+    where the user didn't have multiple user_consents on file prior to
+    withdrawal.
+
+    To enable moving withdrawal dates, user_consents now allow multiple
+    of status "suspended", with the most recent by id taking precedence.
+    To determine the valid consent in use prior to withdrawal, look back
+    by insertion order (id) for the first deleted user consent prior to
+    status "suspended".
+
+    With code changes in place, migration must simply locate any potential
+    consent changes since the error was introduced and recalculate timeline
+    """
+    # turns out, we have no reliable mechanism to determine which patients
+    # may have been affected, as the acceptance date on withdrawn was simply
+    # changed on the already withdrawn user_consent, and no audit of the
+    # modification was recorded.  need to try a recalc and find persist
+    # any changes for any users with a suspended user_consent and more
+    # than two (the original valid consent plus the suspended one) on
+    # any given research study.
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    for study_id in (BASE_RS_ID, EMPRO_RS_ID):
+        subquery = session.query(UserConsent.user_id).distinct().filter(
+            UserConsent.research_study_id == study_id).filter(
+            UserConsent.status == 'suspended').subquery()
+        query = session.query(
+            count(UserConsent.user_id), UserConsent.user_id).filter(
+            UserConsent.research_study_id == study_id).filter(
+            UserConsent.user_id.in_(subquery)).group_by(
+            UserConsent.user_id).having(count(UserConsent.user_id) > 2)
+        for num, patient_id in query:
+            if patient_id in (1305,):
+                # special cases best left alone
+                continue
+            user = User.query.get(patient_id)
+            consent_date, withdrawal_date = consent_withdrawal_dates(user, study_id)
+
+            # report if dates don't match spreadsheet in IRONN-210
+            cd_str = '{dt.day}-{dt:%b}-{dt:%y}'.format(dt=consent_date)
+            wd_str = '{dt.day}-{dt:%b}-{dt:%y}'.format(dt=withdrawal_date)
+            #wd_str = withdrawal_date.strftime('%d-%b-%y')
+            try:
+                match = verified_user_consent_dates[study_id][patient_id]
+                if (cd_str, wd_str) != match:
+                    print(f"user_id {patient_id} \t {cd_str} \t {wd_str}")
+                    print(" vs expected:")
+                    print(f"\t\t {match[0]} \t {match[1]}")
+            except KeyError:
+                # user found to not see timeline change
+                #print(f"user_id {patient_id} NOT FOUND in verified list")
+                #print(f"\t {cd_str} \t {wd_str}")
+                pass
+
+            b4_state = capture_patient_state(patient_id)
+            update_users_QBT(
+                patient_id,
+                research_study_id=study_id,
+                invalidate_existing=True)
+            present_before_after_state(
+                patient_id, study_id, b4_state)
+
+    #raise NotImplemented('finish me')
+
+
+def downgrade():
+    """no downgrade available"""
+    pass

--- a/portal/migrations/versions/edb52362d013_.py
+++ b/portal/migrations/versions/edb52362d013_.py
@@ -53,14 +53,18 @@ def user_consent_manual_cleanup(session):
     def update_user_consent(user_id, user_consent_id, acceptance_date):
         uc = UserConsent.query.filter(
             UserConsent.id == user_consent_id).filter(
-            UserConsent.user_id == user_id).one()
-        uc.acceptance_date = acceptance_date
+            UserConsent.user_id == user_id).first()
+        if uc:
+            uc.acceptance_date = acceptance_date
+            return True
 
-    bogus_values = [
+    bogus_values = (
         {'user_id': 101, 'user_consent_id': 219},
         {'user_id': 145, 'user_consent_id': 1238},
         {'user_id': 164, 'user_consent_id': 218},
         {'user_id': 224, 'user_consent_id': 211},
+        {'user_id': 310, 'user_consent_id': 1198},
+        {'user_id': 310, 'user_consent_id': 1199},
         {'user_id': 310, 'user_consent_id': 1200},
         {'user_id': 4316, 'user_consent_id': 5033},
         {'user_id': 4316, 'user_consent_id': 5032},
@@ -68,27 +72,28 @@ def user_consent_manual_cleanup(session):
         {'user_id': 774, 'user_consent_id': 897},
         {'user_id': 723, 'user_consent_id': 551},
         {'user_id': 653, 'user_consent_id': 820},
-    ]
+        {'user_id': 563, 'user_consent_id': 5896},
+        {'user_id': 6686, 'user_consent_id': 6117},
+    )
 
-    correct_values = []
-    #    {'user_id': 719, 'user_consent_id': 544, 'acceptance_date': '2018/05/29 00:00:00'},
-    #    {'user_id': 723, 'user_consent_id': 551, 'acceptance_date': '2018/05/16 00:00:00'},
-    #]
+    correct_values = (
+        {'user_id': 986, 'user_consent_id': 7434, 'acceptance_date': '2023/06/22 18:00:00'},
+    )
     for row in correct_values:
-        update_user_consent(
-            user_id=row['user_id'],
-            user_consent_id=row['user_consent_id'],
-            acceptance_date=row['acceptance_date'])
-        audit_insert(
-            subject_id=row['user_id'],
-            user_consent_id=row['user_consent_id'],
-            acceptance_date=row['acceptance_date'])
-        session.commit()
+        if update_user_consent(
+                user_id=row['user_id'],
+                user_consent_id=row['user_consent_id'],
+                acceptance_date=row['acceptance_date']):
+            audit_insert(
+                subject_id=row['user_id'],
+                user_consent_id=row['user_consent_id'],
+                acceptance_date=row['acceptance_date'])
+            session.commit()
 
     for row in bogus_values:
-        if  delete_user_consent(
-            user_id=row['user_id'],
-            user_consent_id=row['user_consent_id']):
+        if delete_user_consent(
+                user_id=row['user_id'],
+                user_consent_id=row['user_consent_id']):
             audit_insert(
                 subject_id=row['user_id'],
                 user_consent_id=row['user_consent_id'])

--- a/portal/migrations/versions/edb52362d013_.py
+++ b/portal/migrations/versions/edb52362d013_.py
@@ -1,7 +1,7 @@
 """Remove/correct bogus user_consents as per IRONN-210
 
 Revision ID: edb52362d013
-Revises: d1f3ed8d16ef
+Revises: 66368e673005
 Create Date: 2024-01-11 16:23:34.961937
 
 """
@@ -14,7 +14,7 @@ from portal.models.user_consent import UserConsent
 
 # revision identifiers, used by Alembic.
 revision = 'edb52362d013'
-down_revision = 'd1f3ed8d16ef'
+down_revision = '66368e673005'
 
 Session = sessionmaker()
 
@@ -46,7 +46,7 @@ def user_consent_manual_cleanup(session):
         session.execute(insert)
 
     def delete_user_consent(user_id, user_consent_id):
-        UserConsent.query.filter(
+        return UserConsent.query.filter(
             UserConsent.id == user_consent_id).filter(
             UserConsent.user_id == user_id).delete()
 
@@ -84,13 +84,13 @@ def user_consent_manual_cleanup(session):
         session.commit()
 
     for row in bogus_values:
-        delete_user_consent(
+        if  delete_user_consent(
             user_id=row['user_id'],
-            user_consent_id=row['user_consent_id'])
-        audit_insert(
-            subject_id=row['user_id'],
-            user_consent_id=row['user_consent_id'])
-        session.commit()
+            user_consent_id=row['user_consent_id']):
+            audit_insert(
+                subject_id=row['user_id'],
+                user_consent_id=row['user_consent_id'])
+            session.commit()
 
 
 def upgrade():

--- a/portal/migrations/versions/edb52362d013_.py
+++ b/portal/migrations/versions/edb52362d013_.py
@@ -1,0 +1,86 @@
+"""Correct user_consent regression issues raised by PR #4343
+
+Revision ID: edb52362d013
+Revises: d1f3ed8d16ef
+Create Date: 2024-01-11 16:23:34.961937
+
+"""
+from alembic import op
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.sql.functions import count
+
+from portal.models.research_study import BASE_RS_ID, EMPRO_RS_ID
+from portal.models.qb_timeline import update_users_QBT
+from portal.models.questionnaire_response import (
+    capture_patient_state,
+    present_before_after_state,
+)
+from portal.models.user_consent import UserConsent
+
+# revision identifiers, used by Alembic.
+revision = 'edb52362d013'
+down_revision = 'd1f3ed8d16ef'
+
+Session = sessionmaker()
+
+
+def upgrade():
+    """Correct UserConsents for any negatively affected patients
+
+    Prior to the release of 23.10.12.1, moving withdrawal dates wasn't
+    allowed. This made lookups for the last valid user_consent *prior*
+    to the withdrawal date, reliable, as user_consents land in the table
+    in an ordered fashion, and the most recently deleted prior to
+    withdrawal would have been in use.
+
+    The implementation of IRONN-210 enabled moving of withdrawal dates,
+    and incorrectly assumed it would be necessary to allow lookups of
+    the previous valid consent, to just work further back in the stack
+    of user_consents.  That would only be correct on the few tested,
+    where the user didn't have multiple user_consents on file prior to
+    withdrawal.
+
+    To enable moving withdrawal dates, user_consents now allow multiple
+    of status "suspended", with the most recent by id taking precedence.
+    To determine the valid consent in use prior to withdrawal, look back
+    by insertion order (id) for the first deleted user consent prior to
+    status "suspended".
+
+    With code changes in place, migration must simply locate any potential
+    consent changes since the error was introduced and recalculate timeline
+    """
+    # turns out, we have no reliable mechanism to determine which patients
+    # may have been affected, as the acceptance date on withdrawn was simply
+    # changed on the already withdrawn user_consent, and no audit of the
+    # modification was recorded.  need to try a recalc and find persist
+    # any changes for any users with a suspended user_consent and more
+    # than two (the original valid consent plus the suspended one) on
+    # any given research study.
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    for study_id in (BASE_RS_ID, EMPRO_RS_ID):
+
+        subquery = session.query(UserConsent.user_id).distinct().filter(
+            UserConsent.research_study_id == study_id).filter(
+            UserConsent.status == 'suspended').subquery()
+        query = session.query(
+            count(UserConsent.user_id), UserConsent.user_id).filter(
+            UserConsent.research_study_id == study_id).filter(
+            UserConsent.user_id.in_(subquery)).group_by(
+            UserConsent.user_id).having(count(UserConsent.user_id) > 2)
+        for num, patient_id in query:
+            b4_state = capture_patient_state(patient_id)
+            update_users_QBT(
+                patient_id,
+                research_study_id=study_id,
+                invalidate_existing=True)
+            present_before_after_state(
+                patient_id, study_id, b4_state)
+
+    raise NotImplemented('finish me')
+
+
+def downgrade():
+    """no downgrade available"""
+    pass

--- a/portal/migrations/versions/edb52362d013_.py
+++ b/portal/migrations/versions/edb52362d013_.py
@@ -66,6 +66,8 @@ def user_consent_manual_cleanup(session):
         {'user_id': 4316, 'user_consent_id': 5032},
         {'user_id': 98, 'user_consent_id': 339},
         {'user_id': 774, 'user_consent_id': 897},
+        {'user_id': 723, 'user_consent_id': 551},
+        {'user_id': 653, 'user_consent_id': 820},
     ]
 
     correct_values = []

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -95,6 +95,8 @@ class QBT(db.Model):
         results = dict()
         for i in tl:
             qb = QuestionnaireBank.query.get(i.qb_id)
+            if qb is None:
+                continue
             recur_id = qb.recurs[0].id if qb.recurs else None
             vn = visit_name(QBD(
                 relative_start=None,

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -1217,3 +1217,70 @@ def first_last_like_qnr(qnr):
             continue
         last = q
     return initial, last
+
+
+def capture_patient_state(patient_id):
+    """Call to capture QBT and QNR state for patient, used for before/after"""
+    from .qb_timeline import QBT
+    qnrs = QuestionnaireResponse.qnr_state(patient_id)
+    tl = QBT.timeline_state(patient_id)
+    return {'qnrs': qnrs, 'timeline': tl}
+
+
+def present_before_after_state(user_id, external_study_id, before_state):
+    from .qb_timeline import QBT
+    from ..dict_tools import dict_compare
+    after_qnrs = QuestionnaireResponse.qnr_state(user_id)
+    after_timeline = QBT.timeline_state(user_id)
+    qnrs_lost_reference = []
+
+    def visit_from_timeline(qb_name, qb_iteration, timeline_results):
+        """timeline results have computed visit name - quick lookup"""
+        for visit, name, iteration in timeline_results.values():
+            if qb_name == name and qb_iteration == iteration:
+                return visit
+        raise ValueError(f"no visit found for {qb_name}, {qb_iteration}")
+
+    # Compare results
+    added_q, removed_q, modified_q, same = dict_compare(
+        after_qnrs, before_state['qnrs'])
+    assert not added_q
+    assert not removed_q
+
+    added_t, removed_t, modified_t, same = dict_compare(
+        after_timeline, before_state['timeline'])
+
+    if any((added_t, removed_t, modified_t, modified_q)):
+        print(f"\nPatient {user_id} ({external_study_id}):")
+    if modified_q:
+        print("\tModified QNRs (old, new)")
+        for mod in sorted(modified_q):
+            print(f"\t\t{mod} {modified_q[mod][1]} ==>"
+                  f" {modified_q[mod][0]}")
+            # If the QNR previously had a reference QB and since
+            # lost it, capture for reporting.
+            if (
+                    modified_q[mod][1][0] != "none of the above" and
+                    modified_q[mod][0][0] == "none of the above"):
+                visit_name = visit_from_timeline(
+                    modified_q[mod][1][0],
+                    modified_q[mod][1][1],
+                    before_state["timeline"])
+                qnrs_lost_reference.append((visit_name, modified_q[mod][1][2]))
+    if added_t:
+        print("\tAdditional timeline rows:")
+        for item in sorted(added_t):
+            print(f"\t\t{item} {after_timeline[item]}")
+    if removed_t:
+        print("\tRemoved timeline rows:")
+        for item in sorted(removed_t):
+            print(
+                f"\t\t{item} "
+                f"{before_state['timeline'][item]}")
+    if modified_t:
+        print(f"\tModified timeline rows: (old, new)")
+        for item in sorted(modified_t):
+            print(f"\t\t{item}")
+            print(f"\t\t\t{modified_t[item][1]} ==> {modified_t[item][0]}")
+
+    return after_qnrs, after_timeline, qnrs_lost_reference

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -1233,6 +1233,7 @@ def present_before_after_state(user_id, external_study_id, before_state):
     after_qnrs = QuestionnaireResponse.qnr_state(user_id)
     after_timeline = QBT.timeline_state(user_id)
     qnrs_lost_reference = []
+    any_change_noted = False
 
     def visit_from_timeline(qb_name, qb_iteration, timeline_results):
         """timeline results have computed visit name - quick lookup"""
@@ -1251,8 +1252,10 @@ def present_before_after_state(user_id, external_study_id, before_state):
         after_timeline, before_state['timeline'])
 
     if any((added_t, removed_t, modified_t, modified_q)):
+        any_change_noted = True
         print(f"\nPatient {user_id} ({external_study_id}):")
     if modified_q:
+        any_change_noted = True
         print("\tModified QNRs (old, new)")
         for mod in sorted(modified_q):
             print(f"\t\t{mod} {modified_q[mod][1]} ==>"
@@ -1268,19 +1271,22 @@ def present_before_after_state(user_id, external_study_id, before_state):
                     before_state["timeline"])
                 qnrs_lost_reference.append((visit_name, modified_q[mod][1][2]))
     if added_t:
+        any_change_noted = True
         print("\tAdditional timeline rows:")
         for item in sorted(added_t):
             print(f"\t\t{item} {after_timeline[item]}")
     if removed_t:
+        any_change_noted = True
         print("\tRemoved timeline rows:")
         for item in sorted(removed_t):
             print(
                 f"\t\t{item} "
                 f"{before_state['timeline'][item]}")
     if modified_t:
+        any_change_noted = True
         print(f"\tModified timeline rows: (old, new)")
         for item in sorted(modified_t):
             print(f"\t\t{item}")
             print(f"\t\t\t{modified_t[item][1]} ==> {modified_t[item][0]}")
 
-    return after_qnrs, after_timeline, qnrs_lost_reference
+    return after_qnrs, after_timeline, qnrs_lost_reference, any_change_noted

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -91,11 +91,16 @@ def single_patient_adherence_data(patient, as_of_date, research_study_id):
 
         row['qb'] = qbd.questionnaire_bank.name
         row['visit'] = visit_name(qbd)
-        if row['status'] == 'Completed':
+        # Withdrawn users that happened to have completed their last QB
+        # are treated as "Completed"
+        withdrawn_and_completed = (
+            row['status'] == 'Withdrawn' and qbd.completed_date(patient.id))
+        if row['status'] == 'Completed' or withdrawn_and_completed:
             row['completion_date'] = report_format(
                 qbd.completed_date(patient.id)) or ""
             row['oow_completion_date'] = report_format(
                 qbd.oow_completed_date(patient.id)) or ""
+            row['status'] = 'Completed'
         if row['status'] == 'Withdrawn':
             # visit unreliable when withdrawn - clear
             row['visit'] = ''

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -104,6 +104,10 @@ def single_patient_adherence_data(patient, as_of_date, research_study_id):
         if row['status'] == 'Withdrawn':
             # visit unreliable when withdrawn - clear
             row['visit'] = ''
+            # use date of withdrawal for "completion date"
+            _, withdrawal_date = consent_withdrawal_dates(
+                user=patient, research_study_id=research_study_id)
+            row['completion_date'] = report_format(withdrawal_date)
         entry_method = QNR_results(
             patient,
             research_study_id=research_study_id,

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -323,7 +323,7 @@ class User(db.Model, UserMixin):
                                      cascade='delete')
     _consents = db.relationship(
         'UserConsent', lazy='joined', cascade='delete',
-        order_by="desc(UserConsent.acceptance_date)")
+        order_by="desc(UserConsent.id)")
     indigenous = db.relationship(Coding, lazy='dynamic',
                                  secondary="user_indigenous")
     encounters = db.relationship('Encounter', cascade='delete')

--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -190,8 +190,6 @@ def consent_withdrawal_dates(user, research_study_id):
         may be None if not found.
 
     """
-    if user.id == 1:
-        import pdb; pdb.set_trace()
     withdrawal_date = None
     consent = latest_consent(user, research_study_id=research_study_id)
     if consent:

--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -165,7 +165,7 @@ def latest_consent(user, research_study_id):
         if no match is located
 
     """
-    # consents are ordered desc(acceptance_date)
+    # consents are ordered desc(id), i.e. most recent action first
     for consent in user.valid_consents:
         if consent.research_study_id != research_study_id:
             continue
@@ -190,6 +190,8 @@ def consent_withdrawal_dates(user, research_study_id):
         may be None if not found.
 
     """
+    if user.id == 1:
+        import pdb; pdb.set_trace()
     withdrawal_date = None
     consent = latest_consent(user, research_study_id=research_study_id)
     if consent:
@@ -197,7 +199,10 @@ def consent_withdrawal_dates(user, research_study_id):
         return consent.acceptance_date, withdrawal_date
 
     # Look for withdrawn case.  If found, also look up the previous
-    # consent date (prior to withdrawal)
+    # consent date (prior to withdrawal).  As withdrawal dates can
+    # be moved, continue to look back beyond all `suspended` until
+    # one of status deleted is found, as that would be the last one
+    # valid prior to withdrawal.
 
     prior_acceptance = None
     for consent in user.all_consents:
@@ -205,13 +210,15 @@ def consent_withdrawal_dates(user, research_study_id):
             continue
         if not withdrawal_date and (
                 consent.status == 'suspended' and not consent.deleted_id):
+            # the first or most recent withdrawal takes precedence.
             withdrawal_date = consent.acceptance_date
             if prior_acceptance:
                 raise ValueError(
                     "don't expect prior acceptance before withdrawal date")
         if consent.status == 'deleted' and withdrawal_date:
+            # the first deleted prior to any number of `suspended` is
+            # taken to be the most recent legit consent prior to withdrawal
             prior_acceptance = consent.acceptance_date
-            # situation where consent date was changed before withdrawal
-            # requires we continue to look and use last found (don't break!)
+            break
 
     return prior_acceptance, withdrawal_date

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -494,7 +494,11 @@ def patient_timeline(patient_id):
         i['auth_method'] = d['encounter']['auth_method']
         i['encounter_period'] = d['encounter']['period']
         i['document_authored'] = d['authored']
-        i['ae_session'] = d['identifier']['value']
+        try:
+            i['ae_session'] = d['identifier']['value']
+        except KeyError:
+            # happens with sub-study follow up, skip ae_session
+            pass
         i['status'] = d['status']
         i['org'] = d['subject']['careProvider'][0]['display']
         i['visit'] = d['timepoint']

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -38,6 +38,7 @@ from ..models.research_study import (
 )
 from ..models.role import ROLE
 from ..models.user import User, current_user, get_user
+from ..models.user_consent import consent_withdrawal_dates
 from ..timeout_lock import ADHERENCE_DATA_KEY, CacheModeration
 from .crossdomain import crossdomain
 from .demographics import demographics
@@ -504,7 +505,10 @@ def patient_timeline(patient_id):
         i['visit'] = d['timepoint']
         qnr_data.append(i)
 
+    consent_date, withdrawal_date = consent_withdrawal_dates(user, research_study_id)
+    consents = {"consent_date": consent_date, "withdrawal_date": withdrawal_date}
     kwargs = {
+        "consents": consents,
         "rps": rps,
         "status": status,
         "posted": posted,

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -109,11 +109,11 @@ class TestUserConsent(TestCase):
             '/api/user/{}/consent'.format(TEST_USER_ID))
         assert response.status_code == 200
         assert len(response.json['consent_agreements']) == 3
-        # should be ordered by acceptance date, descending: (uc3, uc1, uc2)
+        # regardless of age, most recent action takes precedence
         uc1, uc2, uc3 = map(db.session.merge, (uc1, uc2, uc3))
         assert response.json['consent_agreements'][0] == uc3.as_json()
-        assert response.json['consent_agreements'][1] == uc1.as_json()
-        assert response.json['consent_agreements'][2] == uc2.as_json()
+        assert response.json['consent_agreements'][1] == uc2.as_json()
+        assert response.json['consent_agreements'][2] == uc1.as_json()
 
     def test_post_user_consent(self):
         self.shallow_org_tree()


### PR DESCRIPTION
not ready!!!

reverts bug introduced by #4343 , which incorrectly started using the oldest (not most recent) user_consent as last valid consent prior to withdrawal.

includes migration to clean up problem cases.  required careful re-assessment of consent/withdrawal dates for a number of patients found to have qb_timeline revisions after applying patch above.  see https://movember.atlassian.net/browse/IRONN-210 for more detail.