### PR TITLE
logger.error on empro message sans email

### DIFF
--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -116,6 +116,11 @@ class EmailMessage(db.Model):
     def recipients(self, value):
         """Set recipients_id if a user is found w/ matching email"""
 
+        if value is None:
+            self._recipients = None
+            self.recipient_id = None
+            return
+
         # As the schema only tracks a single recipient_id, capture abuse;
         # don't allow comma in recipients till schema can capture
         if ',' in value:

--- a/portal/trigger_states/empro_states.py
+++ b/portal/trigger_states/empro_states.py
@@ -292,9 +292,13 @@ def fire_trigger_events():
         patient = User.query.get(ts.user_id)
 
         # Patient always gets mail
-        pending_emails.append((
-            patient_email(patient, soft_triggers, hard_triggers),
-            "patient thank you"))
+        if patient.email_ready():
+            pending_emails.append((
+                patient_email(patient, soft_triggers, hard_triggers),
+                "patient thank you"))
+        else:
+            current_app.logger.error(
+                f"EMPRO Patient({patient.id}) w/o email!  Can't send message")
 
         if hard_triggers:
             triggers['action_state'] = 'required'


### PR DESCRIPTION
Generate a reasonable error if EMPRO patient can't receive email at time of generation.

(shouldn't ever happen in production, but makes a mess of the logs in dev/testing)