### PR TITLE
confirm staff have valid email before attempt to send

### DIFF
--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -157,6 +157,10 @@ class EmailMessage(db.Model):
         NB the cc isn't persisted with the rest of the record.
 
         """
+        if not self.recipients:
+            current_app.logger.error(
+                "can't email w/o recipients.  failed to send "
+                f"'{self.subject}' to user {self.recipient_id}")
         message = Message(
             subject=self.subject,
             extra_headers=extra_headers(),

--- a/portal/trigger_states/empro_messages.py
+++ b/portal/trigger_states/empro_messages.py
@@ -112,6 +112,9 @@ def staff_emails(patient, hard_triggers, initial_notification):
     }
     emails = []
     for staff in staff_list:
+        if not staff.email_ready():
+            current_app.logger.error(f"can't email staff {staff} without email")
+            continue
         mr = MailResource(
             app_text(app_text_name),
             locale_code=staff.locale_code,

--- a/portal/trigger_states/empro_messages.py
+++ b/portal/trigger_states/empro_messages.py
@@ -37,6 +37,7 @@ def patient_email(patient, soft_triggers, hard_triggers):
     mr = MailResource(
         app_text(name), locale_code=patient.locale_code, variables=args)
     em = EmailMessage(
+        recipient_id=patient.id,
         recipients=patient.email,
         sender=current_app.config['MAIL_DEFAULT_SENDER'],
         subject=mr.subject,
@@ -120,6 +121,7 @@ def staff_emails(patient, hard_triggers, initial_notification):
             locale_code=staff.locale_code,
             variables=args)
         emails.append(EmailMessage(
+            recipient_id=staff.id,
             recipients=staff.email,
             sender=current_app.config['MAIL_DEFAULT_SENDER'],
             subject=mr.subject,


### PR DESCRIPTION
found additional cases where test system may be attempting to send EMPRO alert emails to user's w/o a valid email address (staff).

added detailed logging where failure is occurring, as well.