### PR TITLE
bug found in qb_timeline overlap check

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -812,7 +812,11 @@ def check_for_overlaps(qbt_rows, cli_presentation=False):
     for row in qbt_rows:
         # Confirm expected order
         if last_at:
-            assert row.at >= last_at
+            if last_at > row.at:
+                raise ValueError(
+                    f"patient {row.user_id} has overlapping qb_timeline rows"
+                    f" {last_at} and {row.at}"
+                )
 
         key = f"{row.qb_id}:{row.qb_iteration}"
         if previous_key and previous_key != key:
@@ -975,11 +979,9 @@ def update_users_QBT(user_id, research_study_id, invalidate_existing=False):
                                 if (
                                         pending_qbts[j].qb_id != remove_qb_id or
                                         pending_qbts[j].qb_iteration != remove_iteration):
-                                    # To qualify for this special case,
-                                    # having worked back to previous QB, if
-                                    # at > start, take action
-                                    if pending_qbts[j].at > start:
-                                        unwanted_count = len(pending_qbts)-j-1
+                                    # unwanted_count represents all rows from
+                                    # overlapped, unwanted visit
+                                    unwanted_count = len(pending_qbts)-j-1
                                     break
 
                                 # keep a lookout for work done in old RP


### PR DESCRIPTION
between protocol v3 and v5, additional months were added, i.e. month 33.

if v3 month 36 didn't have any committed work and it's time to change protocols for the user, v5 month 33 should follow v3 month 30.

the code looking for this case had an extra check which prevented the above from functioning, in the rare case where v3 month 30 ended before v5 month 33 starts.

this was discovered with the new withdrawal handling in adherence data, as the insertion of the withdrawal row could not predictably insert before the time point just after withdrawal, when the timeline was found to have such an overlap.