### PR TITLE
safeguard withdrawn patients from notification emails

### DIFF
--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -249,6 +249,9 @@ def update_patients(patient_list, update_cache, queue_messages):
                 update_users_QBT(user_id, research_study_id)
             if queue_messages:
                 qbstatus = QB_Status(user, research_study_id, now)
+                if qbstatus.withdrawn_by(now):
+                    # NEVER notify withdrawn patients
+                    continue
                 qbd = qbstatus.current_qbd()
                 if qbd:
                     queue_outstanding_messages(


### PR DESCRIPTION
Due to change in keeping timeline info beyond withdrawal dates, must now check withdrawn status before sending notifications