### PR TITLE
correct withdrawn patient status in /patients

### DIFF
--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -1348,6 +1348,15 @@ def qb_status_visit_name(user_id, research_study_id, as_of_date):
         QBT.at <= as_of_date).order_by(
         QBT.at.desc(), QBT.id.desc()).first()
     if qbt:
+        # now that timelines are built beyond withdrawal, check for a
+        # withdrawal row before the one found above
+        withdrawn_qbt = (QBT.query.filter(QBT.user_id == user_id).filter(
+            QBT.research_study_id == research_study_id).filter(
+            QBT.at <= qbt.at).filter(
+            QBT.status == OverallStatus.withdrawn)).first()
+        if withdrawn_qbt:
+            qbt = withdrawn_qbt
+
         results['status'] = qbt.status
         results['visit_name'] = visit_name(qbt.qbd())
 


### PR DESCRIPTION
another bug introduced with extending timeline beyond the user's point of withdrawal.

now looking specifically for withdrawn status in /patients list, as it was still assuming the timeline terminated at the point of withdrawal as it used to.
