### PR TITLE
remove logger.error noise

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -96,7 +96,7 @@ class QB_Status(object):
                     " {} vs as_of {}".format(
                         self.__ordered_qbs[0].relative_start, self.as_of_date))
             else:
-                current_app.logger.error(f"patient {self.user.id} w/o cur_qbd??")
+                current_app.logger.warning(f"patient {self.user.id} w/o cur_qbd??")
             self._overall_status = OverallStatus.expired
             self.next_qbd = self.__ordered_qbs[0]
             return


### PR DESCRIPTION
observed a few errors in the log since latest hotfix rollout.  the situation no longer deserves error alert status, as the withdrawn users will legitimately raise this error.  dialed back to a `logger.warning` just in case it helps with future debugging.

not critical to push live, unless the alerts are overwhelming.

example of error it was generating:
```
celeryworkerslow_1  | {"written_at": "2024-03-27T14:30:02.073Z", "written_ts": 1711549802073935000, "msg": "patient 5357 w/o cur_qbd??", "type": "log", "logger": "flask.app", "thread": "MainThread", "level": "ERROR", "module": "qb_status", "line_no": 99, "correlation_id": "7f2f63ac-ec46-11ee-b0e1-0242ac190006"}
celeryworkerslow_1  | 2024-03-27 14:30:02,073: patient 5357 w/o cur_qbd??
```