### PR TITLE
Pull ethnicity and race coding from filesystem

### DIFF
--- a/portal/config/eproms/Coding.json
+++ b/portal/config/eproms/Coding.json
@@ -5863,12 +5863,6 @@
       "system": "http://snomed.info/sct"
     },
     {
-      "code": "",
-      "display": "",
-      "resourceType": "Coding",
-      "system": "http://us.truenth.org/clinical-codes"
-    },
-    {
       "code": "111",
       "display": "biopsy",
       "resourceType": "Coding",

--- a/portal/models/code_systems/v3-Ethnicity.cs.json
+++ b/portal/models/code_systems/v3-Ethnicity.cs.json
@@ -1,0 +1,274 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "v3-Ethnicity",
+  "meta": {
+    "lastUpdated": "2016-11-11T00:00:00.000+11:00"
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>Release Date: 2016-11-11</p>\r\n<table class=\"grid\">\r\n <tr><td><b>Level</b></td><td><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr>\r\n <tr><td>1</td><td>2135-2<a name=\"2135-2\"> </a></td><td>Hispanic or Latino</td><td/></tr>\r\n <tr><td>2</td><td>  2137-8<a name=\"2137-8\"> </a></td><td>Spaniard</td><td/></tr>\r\n <tr><td>3</td><td>    2138-6<a name=\"2138-6\"> </a></td><td>Andalusian</td><td/></tr>\r\n <tr><td>3</td><td>    2139-4<a name=\"2139-4\"> </a></td><td>Asturian</td><td/></tr>\r\n <tr><td>3</td><td>    2140-2<a name=\"2140-2\"> </a></td><td>Castillian</td><td/></tr>\r\n <tr><td>3</td><td>    2141-0<a name=\"2141-0\"> </a></td><td>Catalonian</td><td/></tr>\r\n <tr><td>3</td><td>    2142-8<a name=\"2142-8\"> </a></td><td>Belearic Islander</td><td/></tr>\r\n <tr><td>3</td><td>    2143-6<a name=\"2143-6\"> </a></td><td>Gallego</td><td/></tr>\r\n <tr><td>3</td><td>    2144-4<a name=\"2144-4\"> </a></td><td>Valencian</td><td/></tr>\r\n <tr><td>3</td><td>    2145-1<a name=\"2145-1\"> </a></td><td>Canarian</td><td/></tr>\r\n <tr><td>3</td><td>    2146-9<a name=\"2146-9\"> </a></td><td>Spanish Basque</td><td/></tr>\r\n <tr><td>2</td><td>  2148-5<a name=\"2148-5\"> </a></td><td>Mexican</td><td/></tr>\r\n <tr><td>3</td><td>    2149-3<a name=\"2149-3\"> </a></td><td>Mexican American</td><td/></tr>\r\n <tr><td>3</td><td>    2150-1<a name=\"2150-1\"> </a></td><td>Mexicano</td><td/></tr>\r\n <tr><td>3</td><td>    2151-9<a name=\"2151-9\"> </a></td><td>Chicano</td><td/></tr>\r\n <tr><td>3</td><td>    2152-7<a name=\"2152-7\"> </a></td><td>La Raza</td><td/></tr>\r\n <tr><td>3</td><td>    2153-5<a name=\"2153-5\"> </a></td><td>Mexican American Indian</td><td/></tr>\r\n <tr><td>2</td><td>  2155-0<a name=\"2155-0\"> </a></td><td>Central American</td><td/></tr>\r\n <tr><td>3</td><td>    2156-8<a name=\"2156-8\"> </a></td><td>Costa Rican</td><td/></tr>\r\n <tr><td>3</td><td>    2157-6<a name=\"2157-6\"> </a></td><td>Guatemalan</td><td/></tr>\r\n <tr><td>3</td><td>    2158-4<a name=\"2158-4\"> </a></td><td>Honduran</td><td/></tr>\r\n <tr><td>3</td><td>    2159-2<a name=\"2159-2\"> </a></td><td>Nicaraguan</td><td/></tr>\r\n <tr><td>3</td><td>    2160-0<a name=\"2160-0\"> </a></td><td>Panamanian</td><td/></tr>\r\n <tr><td>3</td><td>    2161-8<a name=\"2161-8\"> </a></td><td>Salvadoran</td><td/></tr>\r\n <tr><td>3</td><td>    2162-6<a name=\"2162-6\"> </a></td><td>Central American Indian</td><td/></tr>\r\n <tr><td>3</td><td>    2163-4<a name=\"2163-4\"> </a></td><td>Canal Zone</td><td/></tr>\r\n <tr><td>2</td><td>  2165-9<a name=\"2165-9\"> </a></td><td>South American</td><td/></tr>\r\n <tr><td>3</td><td>    2166-7<a name=\"2166-7\"> </a></td><td>Argentinean</td><td/></tr>\r\n <tr><td>3</td><td>    2167-5<a name=\"2167-5\"> </a></td><td>Bolivian</td><td/></tr>\r\n <tr><td>3</td><td>    2168-3<a name=\"2168-3\"> </a></td><td>Chilean</td><td/></tr>\r\n <tr><td>3</td><td>    2169-1<a name=\"2169-1\"> </a></td><td>Colombian</td><td/></tr>\r\n <tr><td>3</td><td>    2170-9<a name=\"2170-9\"> </a></td><td>Ecuadorian</td><td/></tr>\r\n <tr><td>3</td><td>    2171-7<a name=\"2171-7\"> </a></td><td>Paraguayan</td><td/></tr>\r\n <tr><td>3</td><td>    2172-5<a name=\"2172-5\"> </a></td><td>Peruvian</td><td/></tr>\r\n <tr><td>3</td><td>    2173-3<a name=\"2173-3\"> </a></td><td>Uruguayan</td><td/></tr>\r\n <tr><td>3</td><td>    2174-1<a name=\"2174-1\"> </a></td><td>Venezuelan</td><td/></tr>\r\n <tr><td>3</td><td>    2175-8<a name=\"2175-8\"> </a></td><td>South American Indian</td><td/></tr>\r\n <tr><td>3</td><td>    2176-6<a name=\"2176-6\"> </a></td><td>Criollo</td><td/></tr>\r\n <tr><td>2</td><td>  2178-2<a name=\"2178-2\"> </a></td><td>Latin American</td><td/></tr>\r\n <tr><td>2</td><td>  2180-8<a name=\"2180-8\"> </a></td><td>Puerto Rican</td><td/></tr>\r\n <tr><td>2</td><td>  2182-4<a name=\"2182-4\"> </a></td><td>Cuban</td><td/></tr>\r\n <tr><td>2</td><td>  2184-0<a name=\"2184-0\"> </a></td><td>Dominican</td><td/></tr>\r\n <tr><td>1</td><td>2186-5<a name=\"2186-5\"> </a></td><td>Not Hispanic or Latino</td><td>\n                        Note that this term remains in the table for completeness, even though within HL7, the notion of &quot;not otherwise coded&quot; term is deprecated.<br/>\r\n\n                     </td></tr>\r\n</table>\r\n</div>"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-ballot-status",
+      "valueString": "External"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+      "valueInteger": 0
+    }
+  ],
+  "url": "http://hl7.org/fhir/v3/Ethnicity",
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:2.16.840.1.113883.5.50"
+  },
+  "version": "2016-11-11",
+  "name": "v3 Code System Ethnicity",
+  "status": "active",
+  "experimental": false,
+  "date": "2016-11-11T00:00:00+11:00",
+  "publisher": "HL7, Inc",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.org"
+        }
+      ]
+    }
+  ],
+  "description": " In the United States, federal standards for classifying data on ethnicity determine the categories used by federal agencies and exert a strong influence on categorization by state and local agencies and private sector organizations. The federal standards do not conceptually define ethnicity, and they recognize the absence of an anthropological or scientific basis for ethnicity classification.  Instead, the federal standards acknowledge that ethnicity is a social-political construct in which an individual's own identification with a particular ethnicity is preferred to observer identification.  The standards specify two minimum ethnicity categories: Hispanic or Latino, and Not Hispanic or Latino.  The standards define a Hispanic or Latino as a person of \"Mexican, Puerto Rican, Cuban, South or Central America, or other Spanish culture or origin, regardless of race.\" The standards stipulate that ethnicity data need not be limited to the two minimum categories, but any expansion must be collapsible to those categories.  In addition, the standards stipulate that an individual can be Hispanic or Latino or can be Not Hispanic or Latino, but cannot be both.",
+  "caseSensitive": true,
+  "valueSet": "http://hl7.org/fhir/ValueSet/v3-Ethnicity",
+  "hierarchyMeaning": "is-a",
+  "content": "complete",
+  "concept": [
+    {
+      "code": "2135-2",
+      "display": "Hispanic or Latino",
+      "definition": "Hispanic or Latino",
+      "concept": [
+        {
+          "code": "2137-8",
+          "display": "Spaniard",
+          "definition": "Spaniard",
+          "concept": [
+            {
+              "code": "2138-6",
+              "display": "Andalusian",
+              "definition": "Andalusian"
+            },
+            {
+              "code": "2139-4",
+              "display": "Asturian",
+              "definition": "Asturian"
+            },
+            {
+              "code": "2140-2",
+              "display": "Castillian",
+              "definition": "Castillian"
+            },
+            {
+              "code": "2141-0",
+              "display": "Catalonian",
+              "definition": "Catalonian"
+            },
+            {
+              "code": "2142-8",
+              "display": "Belearic Islander",
+              "definition": "Belearic Islander"
+            },
+            {
+              "code": "2143-6",
+              "display": "Gallego",
+              "definition": "Gallego"
+            },
+            {
+              "code": "2144-4",
+              "display": "Valencian",
+              "definition": "Valencian"
+            },
+            {
+              "code": "2145-1",
+              "display": "Canarian",
+              "definition": "Canarian"
+            },
+            {
+              "code": "2146-9",
+              "display": "Spanish Basque",
+              "definition": "Spanish Basque"
+            }
+          ]
+        },
+        {
+          "code": "2148-5",
+          "display": "Mexican",
+          "definition": "Mexican",
+          "concept": [
+            {
+              "code": "2149-3",
+              "display": "Mexican American",
+              "definition": "Mexican American"
+            },
+            {
+              "code": "2150-1",
+              "display": "Mexicano",
+              "definition": "Mexicano"
+            },
+            {
+              "code": "2151-9",
+              "display": "Chicano",
+              "definition": "Chicano"
+            },
+            {
+              "code": "2152-7",
+              "display": "La Raza",
+              "definition": "La Raza"
+            },
+            {
+              "code": "2153-5",
+              "display": "Mexican American Indian",
+              "definition": "Mexican American Indian"
+            }
+          ]
+        },
+        {
+          "code": "2155-0",
+          "display": "Central American",
+          "definition": "Central American",
+          "concept": [
+            {
+              "code": "2156-8",
+              "display": "Costa Rican",
+              "definition": "Costa Rican"
+            },
+            {
+              "code": "2157-6",
+              "display": "Guatemalan",
+              "definition": "Guatemalan"
+            },
+            {
+              "code": "2158-4",
+              "display": "Honduran",
+              "definition": "Honduran"
+            },
+            {
+              "code": "2159-2",
+              "display": "Nicaraguan",
+              "definition": "Nicaraguan"
+            },
+            {
+              "code": "2160-0",
+              "display": "Panamanian",
+              "definition": "Panamanian"
+            },
+            {
+              "code": "2161-8",
+              "display": "Salvadoran",
+              "definition": "Salvadoran"
+            },
+            {
+              "code": "2162-6",
+              "display": "Central American Indian",
+              "definition": "Central American Indian"
+            },
+            {
+              "code": "2163-4",
+              "display": "Canal Zone",
+              "definition": "Canal Zone"
+            }
+          ]
+        },
+        {
+          "code": "2165-9",
+          "display": "South American",
+          "definition": "South American",
+          "concept": [
+            {
+              "code": "2166-7",
+              "display": "Argentinean",
+              "definition": "Argentinean"
+            },
+            {
+              "code": "2167-5",
+              "display": "Bolivian",
+              "definition": "Bolivian"
+            },
+            {
+              "code": "2168-3",
+              "display": "Chilean",
+              "definition": "Chilean"
+            },
+            {
+              "code": "2169-1",
+              "display": "Colombian",
+              "definition": "Colombian"
+            },
+            {
+              "code": "2170-9",
+              "display": "Ecuadorian",
+              "definition": "Ecuadorian"
+            },
+            {
+              "code": "2171-7",
+              "display": "Paraguayan",
+              "definition": "Paraguayan"
+            },
+            {
+              "code": "2172-5",
+              "display": "Peruvian",
+              "definition": "Peruvian"
+            },
+            {
+              "code": "2173-3",
+              "display": "Uruguayan",
+              "definition": "Uruguayan"
+            },
+            {
+              "code": "2174-1",
+              "display": "Venezuelan",
+              "definition": "Venezuelan"
+            },
+            {
+              "code": "2175-8",
+              "display": "South American Indian",
+              "definition": "South American Indian"
+            },
+            {
+              "code": "2176-6",
+              "display": "Criollo",
+              "definition": "Criollo"
+            }
+          ]
+        },
+        {
+          "code": "2178-2",
+          "display": "Latin American",
+          "definition": "Latin American"
+        },
+        {
+          "code": "2180-8",
+          "display": "Puerto Rican",
+          "definition": "Puerto Rican"
+        },
+        {
+          "code": "2182-4",
+          "display": "Cuban",
+          "definition": "Cuban"
+        },
+        {
+          "code": "2184-0",
+          "display": "Dominican",
+          "definition": "Dominican"
+        }
+      ]
+    },
+    {
+      "code": "2186-5",
+      "display": "Not Hispanic or Latino",
+      "definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of \"not otherwise coded\" term is deprecated."
+    }
+  ]
+}

--- a/portal/models/code_systems/v3-Race.cs.json
+++ b/portal/models/code_systems/v3-Race.cs.json
@@ -1,0 +1,4846 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "v3-Race",
+  "meta": {
+    "lastUpdated": "2016-11-11T00:00:00.000+11:00"
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>Release Date: 2016-11-11</p>\r\n<table class=\"grid\">\r\n <tr><td><b>Level</b></td><td><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr>\r\n <tr><td>1</td><td>1002-5<a name=\"1002-5\"> </a></td><td>American Indian or Alaska Native</td><td/></tr>\r\n <tr><td>2</td><td>  1004-1<a name=\"1004-1\"> </a></td><td>American Indian</td><td/></tr>\r\n <tr><td>3</td><td>    1006-6<a name=\"1006-6\"> </a></td><td>Abenaki</td><td/></tr>\r\n <tr><td>3</td><td>    1008-2<a name=\"1008-2\"> </a></td><td>Algonquian</td><td/></tr>\r\n <tr><td>3</td><td>    1010-8<a name=\"1010-8\"> </a></td><td>Apache</td><td/></tr>\r\n <tr><td>4</td><td>      1011-6<a name=\"1011-6\"> </a></td><td>Chiricahua</td><td/></tr>\r\n <tr><td>4</td><td>      1012-4<a name=\"1012-4\"> </a></td><td>Fort Sill Apache</td><td/></tr>\r\n <tr><td>4</td><td>      1013-2<a name=\"1013-2\"> </a></td><td>Jicarilla Apache</td><td/></tr>\r\n <tr><td>4</td><td>      1014-0<a name=\"1014-0\"> </a></td><td>Lipan Apache</td><td/></tr>\r\n <tr><td>4</td><td>      1015-7<a name=\"1015-7\"> </a></td><td>Mescalero Apache</td><td/></tr>\r\n <tr><td>4</td><td>      1016-5<a name=\"1016-5\"> </a></td><td>Oklahoma Apache</td><td/></tr>\r\n <tr><td>4</td><td>      1017-3<a name=\"1017-3\"> </a></td><td>Payson Apache</td><td/></tr>\r\n <tr><td>4</td><td>      1018-1<a name=\"1018-1\"> </a></td><td>San Carlos Apache</td><td/></tr>\r\n <tr><td>4</td><td>      1019-9<a name=\"1019-9\"> </a></td><td>White Mountain Apache</td><td/></tr>\r\n <tr><td>3</td><td>    1021-5<a name=\"1021-5\"> </a></td><td>Arapaho</td><td/></tr>\r\n <tr><td>4</td><td>      1022-3<a name=\"1022-3\"> </a></td><td>Northern Arapaho</td><td/></tr>\r\n <tr><td>4</td><td>      1023-1<a name=\"1023-1\"> </a></td><td>Southern Arapaho</td><td/></tr>\r\n <tr><td>4</td><td>      1024-9<a name=\"1024-9\"> </a></td><td>Wind River Arapaho</td><td/></tr>\r\n <tr><td>3</td><td>    1026-4<a name=\"1026-4\"> </a></td><td>Arikara</td><td/></tr>\r\n <tr><td>3</td><td>    1028-0<a name=\"1028-0\"> </a></td><td>Assiniboine</td><td/></tr>\r\n <tr><td>3</td><td>    1030-6<a name=\"1030-6\"> </a></td><td>Assiniboine Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1031-4<a name=\"1031-4\"> </a></td><td>Fort Peck Assiniboine Sioux</td><td/></tr>\r\n <tr><td>3</td><td>    1033-0<a name=\"1033-0\"> </a></td><td>Bannock</td><td/></tr>\r\n <tr><td>3</td><td>    1035-5<a name=\"1035-5\"> </a></td><td>Blackfeet</td><td/></tr>\r\n <tr><td>3</td><td>    1037-1<a name=\"1037-1\"> </a></td><td>Brotherton</td><td/></tr>\r\n <tr><td>3</td><td>    1039-7<a name=\"1039-7\"> </a></td><td>Burt Lake Band</td><td/></tr>\r\n <tr><td>3</td><td>    1041-3<a name=\"1041-3\"> </a></td><td>Caddo</td><td/></tr>\r\n <tr><td>4</td><td>      1042-1<a name=\"1042-1\"> </a></td><td>Oklahoma Cado</td><td/></tr>\r\n <tr><td>3</td><td>    1044-7<a name=\"1044-7\"> </a></td><td>Cahuilla</td><td/></tr>\r\n <tr><td>4</td><td>      1045-4<a name=\"1045-4\"> </a></td><td>Agua Caliente Cahuilla</td><td/></tr>\r\n <tr><td>4</td><td>      1046-2<a name=\"1046-2\"> </a></td><td>Augustine</td><td/></tr>\r\n <tr><td>4</td><td>      1047-0<a name=\"1047-0\"> </a></td><td>Cabazon</td><td/></tr>\r\n <tr><td>4</td><td>      1048-8<a name=\"1048-8\"> </a></td><td>Los Coyotes</td><td/></tr>\r\n <tr><td>4</td><td>      1049-6<a name=\"1049-6\"> </a></td><td>Morongo</td><td/></tr>\r\n <tr><td>4</td><td>      1050-4<a name=\"1050-4\"> </a></td><td>Santa Rosa Cahuilla</td><td/></tr>\r\n <tr><td>4</td><td>      1051-2<a name=\"1051-2\"> </a></td><td>Torres-Martinez</td><td/></tr>\r\n <tr><td>3</td><td>    1053-8<a name=\"1053-8\"> </a></td><td>California Tribes</td><td/></tr>\r\n <tr><td>4</td><td>      1054-6<a name=\"1054-6\"> </a></td><td>Cahto</td><td/></tr>\r\n <tr><td>4</td><td>      1055-3<a name=\"1055-3\"> </a></td><td>Chimariko</td><td/></tr>\r\n <tr><td>4</td><td>      1056-1<a name=\"1056-1\"> </a></td><td>Coast Miwok</td><td/></tr>\r\n <tr><td>4</td><td>      1057-9<a name=\"1057-9\"> </a></td><td>Digger</td><td/></tr>\r\n <tr><td>4</td><td>      1058-7<a name=\"1058-7\"> </a></td><td>Kawaiisu</td><td/></tr>\r\n <tr><td>4</td><td>      1059-5<a name=\"1059-5\"> </a></td><td>Kern River</td><td/></tr>\r\n <tr><td>4</td><td>      1060-3<a name=\"1060-3\"> </a></td><td>Mattole</td><td/></tr>\r\n <tr><td>4</td><td>      1061-1<a name=\"1061-1\"> </a></td><td>Red Wood</td><td/></tr>\r\n <tr><td>4</td><td>      1062-9<a name=\"1062-9\"> </a></td><td>Santa Rosa</td><td/></tr>\r\n <tr><td>4</td><td>      1063-7<a name=\"1063-7\"> </a></td><td>Takelma</td><td/></tr>\r\n <tr><td>4</td><td>      1064-5<a name=\"1064-5\"> </a></td><td>Wappo</td><td/></tr>\r\n <tr><td>4</td><td>      1065-2<a name=\"1065-2\"> </a></td><td>Yana</td><td/></tr>\r\n <tr><td>4</td><td>      1066-0<a name=\"1066-0\"> </a></td><td>Yuki</td><td/></tr>\r\n <tr><td>3</td><td>    1068-6<a name=\"1068-6\"> </a></td><td>Canadian and Latin American Indian</td><td/></tr>\r\n <tr><td>4</td><td>      1069-4<a name=\"1069-4\"> </a></td><td>Canadian Indian</td><td/></tr>\r\n <tr><td>4</td><td>      1070-2<a name=\"1070-2\"> </a></td><td>Central American Indian</td><td/></tr>\r\n <tr><td>4</td><td>      1071-0<a name=\"1071-0\"> </a></td><td>French American Indian</td><td/></tr>\r\n <tr><td>4</td><td>      1072-8<a name=\"1072-8\"> </a></td><td>Mexican American Indian</td><td/></tr>\r\n <tr><td>4</td><td>      1073-6<a name=\"1073-6\"> </a></td><td>South American Indian</td><td/></tr>\r\n <tr><td>3</td><td>    1074-4<a name=\"1074-4\"> </a></td><td>Spanish American Indian</td><td/></tr>\r\n <tr><td>3</td><td>    1076-9<a name=\"1076-9\"> </a></td><td>Catawba</td><td/></tr>\r\n <tr><td>4</td><td>      1741-8<a name=\"1741-8\"> </a></td><td>Alatna</td><td/></tr>\r\n <tr><td>4</td><td>      1742-6<a name=\"1742-6\"> </a></td><td>Alexander</td><td/></tr>\r\n <tr><td>4</td><td>      1743-4<a name=\"1743-4\"> </a></td><td>Allakaket</td><td/></tr>\r\n <tr><td>4</td><td>      1744-2<a name=\"1744-2\"> </a></td><td>Alanvik</td><td/></tr>\r\n <tr><td>4</td><td>      1745-9<a name=\"1745-9\"> </a></td><td>Anvik</td><td/></tr>\r\n <tr><td>4</td><td>      1746-7<a name=\"1746-7\"> </a></td><td>Arctic</td><td/></tr>\r\n <tr><td>4</td><td>      1747-5<a name=\"1747-5\"> </a></td><td>Beaver</td><td/></tr>\r\n <tr><td>4</td><td>      1748-3<a name=\"1748-3\"> </a></td><td>Birch Creek</td><td/></tr>\r\n <tr><td>4</td><td>      1749-1<a name=\"1749-1\"> </a></td><td>Cantwell</td><td/></tr>\r\n <tr><td>4</td><td>      1750-9<a name=\"1750-9\"> </a></td><td>Chalkyitsik</td><td/></tr>\r\n <tr><td>4</td><td>      1751-7<a name=\"1751-7\"> </a></td><td>Chickaloon</td><td/></tr>\r\n <tr><td>4</td><td>      1752-5<a name=\"1752-5\"> </a></td><td>Chistochina</td><td/></tr>\r\n <tr><td>4</td><td>      1753-3<a name=\"1753-3\"> </a></td><td>Chitina</td><td/></tr>\r\n <tr><td>4</td><td>      1754-1<a name=\"1754-1\"> </a></td><td>Circle</td><td/></tr>\r\n <tr><td>4</td><td>      1755-8<a name=\"1755-8\"> </a></td><td>Cook Inlet</td><td/></tr>\r\n <tr><td>4</td><td>      1756-6<a name=\"1756-6\"> </a></td><td>Copper Center</td><td/></tr>\r\n <tr><td>4</td><td>      1757-4<a name=\"1757-4\"> </a></td><td>Copper River</td><td/></tr>\r\n <tr><td>4</td><td>      1758-2<a name=\"1758-2\"> </a></td><td>Dot Lake</td><td/></tr>\r\n <tr><td>4</td><td>      1759-0<a name=\"1759-0\"> </a></td><td>Doyon</td><td/></tr>\r\n <tr><td>4</td><td>      1760-8<a name=\"1760-8\"> </a></td><td>Eagle</td><td/></tr>\r\n <tr><td>4</td><td>      1761-6<a name=\"1761-6\"> </a></td><td>Eklutna</td><td/></tr>\r\n <tr><td>4</td><td>      1762-4<a name=\"1762-4\"> </a></td><td>Evansville</td><td/></tr>\r\n <tr><td>4</td><td>      1763-2<a name=\"1763-2\"> </a></td><td>Fort Yukon</td><td/></tr>\r\n <tr><td>4</td><td>      1764-0<a name=\"1764-0\"> </a></td><td>Gakona</td><td/></tr>\r\n <tr><td>4</td><td>      1765-7<a name=\"1765-7\"> </a></td><td>Galena</td><td/></tr>\r\n <tr><td>4</td><td>      1766-5<a name=\"1766-5\"> </a></td><td>Grayling</td><td/></tr>\r\n <tr><td>4</td><td>      1767-3<a name=\"1767-3\"> </a></td><td>Gulkana</td><td/></tr>\r\n <tr><td>4</td><td>      1768-1<a name=\"1768-1\"> </a></td><td>Healy Lake</td><td/></tr>\r\n <tr><td>4</td><td>      1769-9<a name=\"1769-9\"> </a></td><td>Holy Cross</td><td/></tr>\r\n <tr><td>4</td><td>      1770-7<a name=\"1770-7\"> </a></td><td>Hughes</td><td/></tr>\r\n <tr><td>4</td><td>      1771-5<a name=\"1771-5\"> </a></td><td>Huslia</td><td/></tr>\r\n <tr><td>4</td><td>      1772-3<a name=\"1772-3\"> </a></td><td>Iliamna</td><td/></tr>\r\n <tr><td>4</td><td>      1773-1<a name=\"1773-1\"> </a></td><td>Kaltag</td><td/></tr>\r\n <tr><td>4</td><td>      1774-9<a name=\"1774-9\"> </a></td><td>Kluti Kaah</td><td/></tr>\r\n <tr><td>4</td><td>      1775-6<a name=\"1775-6\"> </a></td><td>Knik</td><td/></tr>\r\n <tr><td>4</td><td>      1776-4<a name=\"1776-4\"> </a></td><td>Koyukuk</td><td/></tr>\r\n <tr><td>4</td><td>      1777-2<a name=\"1777-2\"> </a></td><td>Lake Minchumina</td><td/></tr>\r\n <tr><td>4</td><td>      1778-0<a name=\"1778-0\"> </a></td><td>Lime</td><td/></tr>\r\n <tr><td>4</td><td>      1779-8<a name=\"1779-8\"> </a></td><td>Mcgrath</td><td/></tr>\r\n <tr><td>4</td><td>      1780-6<a name=\"1780-6\"> </a></td><td>Manley Hot Springs</td><td/></tr>\r\n <tr><td>4</td><td>      1781-4<a name=\"1781-4\"> </a></td><td>Mentasta Lake</td><td/></tr>\r\n <tr><td>4</td><td>      1782-2<a name=\"1782-2\"> </a></td><td>Minto</td><td/></tr>\r\n <tr><td>4</td><td>      1783-0<a name=\"1783-0\"> </a></td><td>Nenana</td><td/></tr>\r\n <tr><td>4</td><td>      1784-8<a name=\"1784-8\"> </a></td><td>Nikolai</td><td/></tr>\r\n <tr><td>4</td><td>      1785-5<a name=\"1785-5\"> </a></td><td>Ninilchik</td><td/></tr>\r\n <tr><td>4</td><td>      1786-3<a name=\"1786-3\"> </a></td><td>Nondalton</td><td/></tr>\r\n <tr><td>4</td><td>      1787-1<a name=\"1787-1\"> </a></td><td>Northway</td><td/></tr>\r\n <tr><td>4</td><td>      1788-9<a name=\"1788-9\"> </a></td><td>Nulato</td><td/></tr>\r\n <tr><td>4</td><td>      1789-7<a name=\"1789-7\"> </a></td><td>Pedro Bay</td><td/></tr>\r\n <tr><td>4</td><td>      1790-5<a name=\"1790-5\"> </a></td><td>Rampart</td><td/></tr>\r\n <tr><td>4</td><td>      1791-3<a name=\"1791-3\"> </a></td><td>Ruby</td><td/></tr>\r\n <tr><td>4</td><td>      1792-1<a name=\"1792-1\"> </a></td><td>Salamatof</td><td/></tr>\r\n <tr><td>4</td><td>      1793-9<a name=\"1793-9\"> </a></td><td>Seldovia</td><td/></tr>\r\n <tr><td>4</td><td>      1794-7<a name=\"1794-7\"> </a></td><td>Slana</td><td/></tr>\r\n <tr><td>4</td><td>      1795-4<a name=\"1795-4\"> </a></td><td>Shageluk</td><td/></tr>\r\n <tr><td>4</td><td>      1796-2<a name=\"1796-2\"> </a></td><td>Stevens</td><td/></tr>\r\n <tr><td>4</td><td>      1797-0<a name=\"1797-0\"> </a></td><td>Stony River</td><td/></tr>\r\n <tr><td>4</td><td>      1798-8<a name=\"1798-8\"> </a></td><td>Takotna</td><td/></tr>\r\n <tr><td>4</td><td>      1799-6<a name=\"1799-6\"> </a></td><td>Tanacross</td><td/></tr>\r\n <tr><td>4</td><td>      1800-2<a name=\"1800-2\"> </a></td><td>Tanaina</td><td/></tr>\r\n <tr><td>4</td><td>      1801-0<a name=\"1801-0\"> </a></td><td>Tanana</td><td/></tr>\r\n <tr><td>4</td><td>      1802-8<a name=\"1802-8\"> </a></td><td>Tanana Chiefs</td><td/></tr>\r\n <tr><td>4</td><td>      1803-6<a name=\"1803-6\"> </a></td><td>Tazlina</td><td/></tr>\r\n <tr><td>4</td><td>      1804-4<a name=\"1804-4\"> </a></td><td>Telida</td><td/></tr>\r\n <tr><td>4</td><td>      1805-1<a name=\"1805-1\"> </a></td><td>Tetlin</td><td/></tr>\r\n <tr><td>4</td><td>      1806-9<a name=\"1806-9\"> </a></td><td>Tok</td><td/></tr>\r\n <tr><td>4</td><td>      1807-7<a name=\"1807-7\"> </a></td><td>Tyonek</td><td/></tr>\r\n <tr><td>4</td><td>      1808-5<a name=\"1808-5\"> </a></td><td>Venetie</td><td/></tr>\r\n <tr><td>4</td><td>      1809-3<a name=\"1809-3\"> </a></td><td>Wiseman</td><td/></tr>\r\n <tr><td>3</td><td>    1078-5<a name=\"1078-5\"> </a></td><td>Cayuse</td><td/></tr>\r\n <tr><td>3</td><td>    1080-1<a name=\"1080-1\"> </a></td><td>Chehalis</td><td/></tr>\r\n <tr><td>3</td><td>    1082-7<a name=\"1082-7\"> </a></td><td>Chemakuan</td><td/></tr>\r\n <tr><td>4</td><td>      1083-5<a name=\"1083-5\"> </a></td><td>Hoh</td><td/></tr>\r\n <tr><td>4</td><td>      1084-3<a name=\"1084-3\"> </a></td><td>Quileute</td><td/></tr>\r\n <tr><td>3</td><td>    1086-8<a name=\"1086-8\"> </a></td><td>Chemehuevi</td><td/></tr>\r\n <tr><td>3</td><td>    1088-4<a name=\"1088-4\"> </a></td><td>Cherokee</td><td/></tr>\r\n <tr><td>4</td><td>      1089-2<a name=\"1089-2\"> </a></td><td>Cherokee Alabama</td><td/></tr>\r\n <tr><td>4</td><td>      1090-0<a name=\"1090-0\"> </a></td><td>Cherokees of Northeast Alabama</td><td/></tr>\r\n <tr><td>4</td><td>      1091-8<a name=\"1091-8\"> </a></td><td>Cherokees of Southeast Alabama</td><td/></tr>\r\n <tr><td>4</td><td>      1092-6<a name=\"1092-6\"> </a></td><td>Eastern Cherokee</td><td/></tr>\r\n <tr><td>4</td><td>      1093-4<a name=\"1093-4\"> </a></td><td>Echota Cherokee</td><td/></tr>\r\n <tr><td>4</td><td>      1094-2<a name=\"1094-2\"> </a></td><td>Etowah Cherokee</td><td/></tr>\r\n <tr><td>4</td><td>      1095-9<a name=\"1095-9\"> </a></td><td>Northern Cherokee</td><td/></tr>\r\n <tr><td>4</td><td>      1096-7<a name=\"1096-7\"> </a></td><td>Tuscola</td><td/></tr>\r\n <tr><td>4</td><td>      1097-5<a name=\"1097-5\"> </a></td><td>United Keetowah Band of Cherokee</td><td/></tr>\r\n <tr><td>4</td><td>      1098-3<a name=\"1098-3\"> </a></td><td>Western Cherokee</td><td/></tr>\r\n <tr><td>3</td><td>    1100-7<a name=\"1100-7\"> </a></td><td>Cherokee Shawnee</td><td/></tr>\r\n <tr><td>3</td><td>    1102-3<a name=\"1102-3\"> </a></td><td>Cheyenne</td><td/></tr>\r\n <tr><td>4</td><td>      1103-1<a name=\"1103-1\"> </a></td><td>Northern Cheyenne</td><td/></tr>\r\n <tr><td>4</td><td>      1104-9<a name=\"1104-9\"> </a></td><td>Southern Cheyenne</td><td/></tr>\r\n <tr><td>3</td><td>    1106-4<a name=\"1106-4\"> </a></td><td>Cheyenne-Arapaho</td><td/></tr>\r\n <tr><td>3</td><td>    1108-0<a name=\"1108-0\"> </a></td><td>Chickahominy</td><td/></tr>\r\n <tr><td>4</td><td>      1109-8<a name=\"1109-8\"> </a></td><td>Eastern Chickahominy</td><td/></tr>\r\n <tr><td>4</td><td>      1110-6<a name=\"1110-6\"> </a></td><td>Western Chickahominy</td><td/></tr>\r\n <tr><td>3</td><td>    1112-2<a name=\"1112-2\"> </a></td><td>Chickasaw</td><td/></tr>\r\n <tr><td>3</td><td>    1114-8<a name=\"1114-8\"> </a></td><td>Chinook</td><td/></tr>\r\n <tr><td>4</td><td>      1115-5<a name=\"1115-5\"> </a></td><td>Clatsop</td><td/></tr>\r\n <tr><td>4</td><td>      1116-3<a name=\"1116-3\"> </a></td><td>Columbia River Chinook</td><td/></tr>\r\n <tr><td>4</td><td>      1117-1<a name=\"1117-1\"> </a></td><td>Kathlamet</td><td/></tr>\r\n <tr><td>4</td><td>      1118-9<a name=\"1118-9\"> </a></td><td>Upper Chinook</td><td/></tr>\r\n <tr><td>4</td><td>      1119-7<a name=\"1119-7\"> </a></td><td>Wakiakum Chinook</td><td/></tr>\r\n <tr><td>4</td><td>      1120-5<a name=\"1120-5\"> </a></td><td>Willapa Chinook</td><td/></tr>\r\n <tr><td>4</td><td>      1121-3<a name=\"1121-3\"> </a></td><td>Wishram</td><td/></tr>\r\n <tr><td>3</td><td>    1123-9<a name=\"1123-9\"> </a></td><td>Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1124-7<a name=\"1124-7\"> </a></td><td>Bad River</td><td/></tr>\r\n <tr><td>4</td><td>      1125-4<a name=\"1125-4\"> </a></td><td>Bay Mills Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1126-2<a name=\"1126-2\"> </a></td><td>Bois Forte</td><td/></tr>\r\n <tr><td>4</td><td>      1127-0<a name=\"1127-0\"> </a></td><td>Burt Lake Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1128-8<a name=\"1128-8\"> </a></td><td>Fond du Lac</td><td/></tr>\r\n <tr><td>4</td><td>      1129-6<a name=\"1129-6\"> </a></td><td>Grand Portage</td><td/></tr>\r\n <tr><td>4</td><td>      1130-4<a name=\"1130-4\"> </a></td><td>Grand Traverse Band of Ottawa-Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1131-2<a name=\"1131-2\"> </a></td><td>Keweenaw</td><td/></tr>\r\n <tr><td>4</td><td>      1132-0<a name=\"1132-0\"> </a></td><td>Lac Courte Oreilles</td><td/></tr>\r\n <tr><td>4</td><td>      1133-8<a name=\"1133-8\"> </a></td><td>Lac du Flambeau</td><td/></tr>\r\n <tr><td>4</td><td>      1134-6<a name=\"1134-6\"> </a></td><td>Lac Vieux Desert Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1135-3<a name=\"1135-3\"> </a></td><td>Lake Superior</td><td/></tr>\r\n <tr><td>4</td><td>      1136-1<a name=\"1136-1\"> </a></td><td>Leech Lake</td><td/></tr>\r\n <tr><td>4</td><td>      1137-9<a name=\"1137-9\"> </a></td><td>Little Shell Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1138-7<a name=\"1138-7\"> </a></td><td>Mille Lacs</td><td/></tr>\r\n <tr><td>4</td><td>      1139-5<a name=\"1139-5\"> </a></td><td>Minnesota Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1140-3<a name=\"1140-3\"> </a></td><td>Ontonagon</td><td/></tr>\r\n <tr><td>4</td><td>      1141-1<a name=\"1141-1\"> </a></td><td>Red Cliff Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1142-9<a name=\"1142-9\"> </a></td><td>Red Lake Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1143-7<a name=\"1143-7\"> </a></td><td>Saginaw Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1144-5<a name=\"1144-5\"> </a></td><td>St. Croix Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1145-2<a name=\"1145-2\"> </a></td><td>Sault Ste. Marie Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1146-0<a name=\"1146-0\"> </a></td><td>Sokoagon Chippewa</td><td/></tr>\r\n <tr><td>4</td><td>      1147-8<a name=\"1147-8\"> </a></td><td>Turtle Mountain</td><td/></tr>\r\n <tr><td>4</td><td>      1148-6<a name=\"1148-6\"> </a></td><td>White Earth</td><td/></tr>\r\n <tr><td>3</td><td>    1150-2<a name=\"1150-2\"> </a></td><td>Chippewa Cree</td><td/></tr>\r\n <tr><td>4</td><td>      1151-0<a name=\"1151-0\"> </a></td><td>Rocky Boy's Chippewa Cree</td><td/></tr>\r\n <tr><td>3</td><td>    1153-6<a name=\"1153-6\"> </a></td><td>Chitimacha</td><td/></tr>\r\n <tr><td>3</td><td>    1155-1<a name=\"1155-1\"> </a></td><td>Choctaw</td><td/></tr>\r\n <tr><td>4</td><td>      1156-9<a name=\"1156-9\"> </a></td><td>Clifton Choctaw</td><td/></tr>\r\n <tr><td>4</td><td>      1157-7<a name=\"1157-7\"> </a></td><td>Jena Choctaw</td><td/></tr>\r\n <tr><td>4</td><td>      1158-5<a name=\"1158-5\"> </a></td><td>Mississippi Choctaw</td><td/></tr>\r\n <tr><td>4</td><td>      1159-3<a name=\"1159-3\"> </a></td><td>Mowa Band of Choctaw</td><td/></tr>\r\n <tr><td>4</td><td>      1160-1<a name=\"1160-1\"> </a></td><td>Oklahoma Choctaw</td><td/></tr>\r\n <tr><td>3</td><td>    1162-7<a name=\"1162-7\"> </a></td><td>Chumash</td><td/></tr>\r\n <tr><td>4</td><td>      1163-5<a name=\"1163-5\"> </a></td><td>Santa Ynez</td><td/></tr>\r\n <tr><td>3</td><td>    1165-0<a name=\"1165-0\"> </a></td><td>Clear Lake</td><td/></tr>\r\n <tr><td>3</td><td>    1167-6<a name=\"1167-6\"> </a></td><td>Coeur D'Alene</td><td/></tr>\r\n <tr><td>3</td><td>    1169-2<a name=\"1169-2\"> </a></td><td>Coharie</td><td/></tr>\r\n <tr><td>3</td><td>    1171-8<a name=\"1171-8\"> </a></td><td>Colorado River</td><td/></tr>\r\n <tr><td>3</td><td>    1173-4<a name=\"1173-4\"> </a></td><td>Colville</td><td/></tr>\r\n <tr><td>3</td><td>    1175-9<a name=\"1175-9\"> </a></td><td>Comanche</td><td/></tr>\r\n <tr><td>4</td><td>      1176-7<a name=\"1176-7\"> </a></td><td>Oklahoma Comanche</td><td/></tr>\r\n <tr><td>3</td><td>    1178-3<a name=\"1178-3\"> </a></td><td>Coos, Lower Umpqua, Siuslaw</td><td/></tr>\r\n <tr><td>3</td><td>    1180-9<a name=\"1180-9\"> </a></td><td>Coos</td><td/></tr>\r\n <tr><td>3</td><td>    1182-5<a name=\"1182-5\"> </a></td><td>Coquilles</td><td/></tr>\r\n <tr><td>3</td><td>    1184-1<a name=\"1184-1\"> </a></td><td>Costanoan</td><td/></tr>\r\n <tr><td>3</td><td>    1186-6<a name=\"1186-6\"> </a></td><td>Coushatta</td><td/></tr>\r\n <tr><td>4</td><td>      1187-4<a name=\"1187-4\"> </a></td><td>Alabama Coushatta</td><td/></tr>\r\n <tr><td>3</td><td>    1189-0<a name=\"1189-0\"> </a></td><td>Cowlitz</td><td/></tr>\r\n <tr><td>3</td><td>    1191-6<a name=\"1191-6\"> </a></td><td>Cree</td><td/></tr>\r\n <tr><td>3</td><td>    1193-2<a name=\"1193-2\"> </a></td><td>Creek</td><td/></tr>\r\n <tr><td>4</td><td>      1194-0<a name=\"1194-0\"> </a></td><td>Alabama Creek</td><td/></tr>\r\n <tr><td>4</td><td>      1195-7<a name=\"1195-7\"> </a></td><td>Alabama Quassarte</td><td/></tr>\r\n <tr><td>4</td><td>      1196-5<a name=\"1196-5\"> </a></td><td>Eastern Creek</td><td/></tr>\r\n <tr><td>4</td><td>      1197-3<a name=\"1197-3\"> </a></td><td>Eastern Muscogee</td><td/></tr>\r\n <tr><td>4</td><td>      1198-1<a name=\"1198-1\"> </a></td><td>Kialegee</td><td/></tr>\r\n <tr><td>4</td><td>      1199-9<a name=\"1199-9\"> </a></td><td>Lower Muscogee</td><td/></tr>\r\n <tr><td>4</td><td>      1200-5<a name=\"1200-5\"> </a></td><td>Machis Lower Creek Indian</td><td/></tr>\r\n <tr><td>4</td><td>      1201-3<a name=\"1201-3\"> </a></td><td>Poarch Band</td><td/></tr>\r\n <tr><td>4</td><td>      1202-1<a name=\"1202-1\"> </a></td><td>Principal Creek Indian Nation</td><td/></tr>\r\n <tr><td>4</td><td>      1203-9<a name=\"1203-9\"> </a></td><td>Star Clan of Muscogee Creeks</td><td/></tr>\r\n <tr><td>4</td><td>      1204-7<a name=\"1204-7\"> </a></td><td>Thlopthlocco</td><td/></tr>\r\n <tr><td>4</td><td>      1205-4<a name=\"1205-4\"> </a></td><td>Tuckabachee</td><td/></tr>\r\n <tr><td>3</td><td>    1207-0<a name=\"1207-0\"> </a></td><td>Croatan</td><td/></tr>\r\n <tr><td>3</td><td>    1209-6<a name=\"1209-6\"> </a></td><td>Crow</td><td/></tr>\r\n <tr><td>3</td><td>    1211-2<a name=\"1211-2\"> </a></td><td>Cupeno</td><td/></tr>\r\n <tr><td>4</td><td>      1212-0<a name=\"1212-0\"> </a></td><td>Agua Caliente</td><td/></tr>\r\n <tr><td>3</td><td>    1214-6<a name=\"1214-6\"> </a></td><td>Delaware</td><td/></tr>\r\n <tr><td>4</td><td>      1215-3<a name=\"1215-3\"> </a></td><td>Eastern Delaware</td><td/></tr>\r\n <tr><td>4</td><td>      1216-1<a name=\"1216-1\"> </a></td><td>Lenni-Lenape</td><td/></tr>\r\n <tr><td>4</td><td>      1217-9<a name=\"1217-9\"> </a></td><td>Munsee</td><td/></tr>\r\n <tr><td>4</td><td>      1218-7<a name=\"1218-7\"> </a></td><td>Oklahoma Delaware</td><td/></tr>\r\n <tr><td>4</td><td>      1219-5<a name=\"1219-5\"> </a></td><td>Rampough Mountain</td><td/></tr>\r\n <tr><td>4</td><td>      1220-3<a name=\"1220-3\"> </a></td><td>Sand Hill</td><td/></tr>\r\n <tr><td>3</td><td>    1222-9<a name=\"1222-9\"> </a></td><td>Diegueno</td><td/></tr>\r\n <tr><td>4</td><td>      1223-7<a name=\"1223-7\"> </a></td><td>Campo</td><td/></tr>\r\n <tr><td>4</td><td>      1224-5<a name=\"1224-5\"> </a></td><td>Capitan Grande</td><td/></tr>\r\n <tr><td>4</td><td>      1225-2<a name=\"1225-2\"> </a></td><td>Cuyapaipe</td><td/></tr>\r\n <tr><td>4</td><td>      1226-0<a name=\"1226-0\"> </a></td><td>La Posta</td><td/></tr>\r\n <tr><td>4</td><td>      1227-8<a name=\"1227-8\"> </a></td><td>Manzanita</td><td/></tr>\r\n <tr><td>4</td><td>      1228-6<a name=\"1228-6\"> </a></td><td>Mesa Grande</td><td/></tr>\r\n <tr><td>4</td><td>      1229-4<a name=\"1229-4\"> </a></td><td>San Pasqual</td><td/></tr>\r\n <tr><td>4</td><td>      1230-2<a name=\"1230-2\"> </a></td><td>Santa Ysabel</td><td/></tr>\r\n <tr><td>4</td><td>      1231-0<a name=\"1231-0\"> </a></td><td>Sycuan</td><td/></tr>\r\n <tr><td>3</td><td>    1233-6<a name=\"1233-6\"> </a></td><td>Eastern Tribes</td><td/></tr>\r\n <tr><td>4</td><td>      1234-4<a name=\"1234-4\"> </a></td><td>Attacapa</td><td/></tr>\r\n <tr><td>4</td><td>      1235-1<a name=\"1235-1\"> </a></td><td>Biloxi</td><td/></tr>\r\n <tr><td>4</td><td>      1236-9<a name=\"1236-9\"> </a></td><td>Georgetown</td><td/></tr>\r\n <tr><td>4</td><td>      1237-7<a name=\"1237-7\"> </a></td><td>Moor</td><td/></tr>\r\n <tr><td>4</td><td>      1238-5<a name=\"1238-5\"> </a></td><td>Nansemond</td><td/></tr>\r\n <tr><td>4</td><td>      1239-3<a name=\"1239-3\"> </a></td><td>Natchez</td><td/></tr>\r\n <tr><td>4</td><td>      1240-1<a name=\"1240-1\"> </a></td><td>Nausu Waiwash</td><td/></tr>\r\n <tr><td>4</td><td>      1241-9<a name=\"1241-9\"> </a></td><td>Nipmuc</td><td/></tr>\r\n <tr><td>4</td><td>      1242-7<a name=\"1242-7\"> </a></td><td>Paugussett</td><td/></tr>\r\n <tr><td>4</td><td>      1243-5<a name=\"1243-5\"> </a></td><td>Pocomoke Acohonock</td><td/></tr>\r\n <tr><td>4</td><td>      1244-3<a name=\"1244-3\"> </a></td><td>Southeastern Indians</td><td/></tr>\r\n <tr><td>4</td><td>      1245-0<a name=\"1245-0\"> </a></td><td>Susquehanock</td><td/></tr>\r\n <tr><td>4</td><td>      1246-8<a name=\"1246-8\"> </a></td><td>Tunica Biloxi</td><td/></tr>\r\n <tr><td>4</td><td>      1247-6<a name=\"1247-6\"> </a></td><td>Waccamaw-Siousan</td><td/></tr>\r\n <tr><td>4</td><td>      1248-4<a name=\"1248-4\"> </a></td><td>Wicomico</td><td/></tr>\r\n <tr><td>3</td><td>    1250-0<a name=\"1250-0\"> </a></td><td>Esselen</td><td/></tr>\r\n <tr><td>3</td><td>    1252-6<a name=\"1252-6\"> </a></td><td>Fort Belknap</td><td/></tr>\r\n <tr><td>3</td><td>    1254-2<a name=\"1254-2\"> </a></td><td>Fort Berthold</td><td/></tr>\r\n <tr><td>3</td><td>    1256-7<a name=\"1256-7\"> </a></td><td>Fort Mcdowell</td><td/></tr>\r\n <tr><td>3</td><td>    1258-3<a name=\"1258-3\"> </a></td><td>Fort Hall</td><td/></tr>\r\n <tr><td>3</td><td>    1260-9<a name=\"1260-9\"> </a></td><td>Gabrieleno</td><td/></tr>\r\n <tr><td>3</td><td>    1262-5<a name=\"1262-5\"> </a></td><td>Grand Ronde</td><td/></tr>\r\n <tr><td>3</td><td>    1264-1<a name=\"1264-1\"> </a></td><td>Gros Ventres</td><td/></tr>\r\n <tr><td>4</td><td>      1265-8<a name=\"1265-8\"> </a></td><td>Atsina</td><td/></tr>\r\n <tr><td>3</td><td>    1267-4<a name=\"1267-4\"> </a></td><td>Haliwa</td><td/></tr>\r\n <tr><td>3</td><td>    1269-0<a name=\"1269-0\"> </a></td><td>Hidatsa</td><td/></tr>\r\n <tr><td>3</td><td>    1271-6<a name=\"1271-6\"> </a></td><td>Hoopa</td><td/></tr>\r\n <tr><td>4</td><td>      1272-4<a name=\"1272-4\"> </a></td><td>Trinity</td><td/></tr>\r\n <tr><td>4</td><td>      1273-2<a name=\"1273-2\"> </a></td><td>Whilkut</td><td/></tr>\r\n <tr><td>3</td><td>    1275-7<a name=\"1275-7\"> </a></td><td>Hoopa Extension</td><td/></tr>\r\n <tr><td>3</td><td>    1277-3<a name=\"1277-3\"> </a></td><td>Houma</td><td/></tr>\r\n <tr><td>3</td><td>    1279-9<a name=\"1279-9\"> </a></td><td>Inaja-Cosmit</td><td/></tr>\r\n <tr><td>3</td><td>    1281-5<a name=\"1281-5\"> </a></td><td>Iowa</td><td/></tr>\r\n <tr><td>4</td><td>      1282-3<a name=\"1282-3\"> </a></td><td>Iowa of Kansas-Nebraska</td><td/></tr>\r\n <tr><td>4</td><td>      1283-1<a name=\"1283-1\"> </a></td><td>Iowa of Oklahoma</td><td/></tr>\r\n <tr><td>3</td><td>    1285-6<a name=\"1285-6\"> </a></td><td>Iroquois</td><td/></tr>\r\n <tr><td>4</td><td>      1286-4<a name=\"1286-4\"> </a></td><td>Cayuga</td><td/></tr>\r\n <tr><td>4</td><td>      1287-2<a name=\"1287-2\"> </a></td><td>Mohawk</td><td/></tr>\r\n <tr><td>4</td><td>      1288-0<a name=\"1288-0\"> </a></td><td>Oneida</td><td/></tr>\r\n <tr><td>4</td><td>      1289-8<a name=\"1289-8\"> </a></td><td>Onondaga</td><td/></tr>\r\n <tr><td>4</td><td>      1290-6<a name=\"1290-6\"> </a></td><td>Seneca</td><td/></tr>\r\n <tr><td>4</td><td>      1291-4<a name=\"1291-4\"> </a></td><td>Seneca Nation</td><td/></tr>\r\n <tr><td>4</td><td>      1292-2<a name=\"1292-2\"> </a></td><td>Seneca-Cayuga</td><td/></tr>\r\n <tr><td>4</td><td>      1293-0<a name=\"1293-0\"> </a></td><td>Tonawanda Seneca</td><td/></tr>\r\n <tr><td>4</td><td>      1294-8<a name=\"1294-8\"> </a></td><td>Tuscarora</td><td/></tr>\r\n <tr><td>4</td><td>      1295-5<a name=\"1295-5\"> </a></td><td>Wyandotte</td><td/></tr>\r\n <tr><td>3</td><td>    1297-1<a name=\"1297-1\"> </a></td><td>Juaneno</td><td/></tr>\r\n <tr><td>3</td><td>    1299-7<a name=\"1299-7\"> </a></td><td>Kalispel</td><td/></tr>\r\n <tr><td>3</td><td>    1301-1<a name=\"1301-1\"> </a></td><td>Karuk</td><td/></tr>\r\n <tr><td>3</td><td>    1303-7<a name=\"1303-7\"> </a></td><td>Kaw</td><td/></tr>\r\n <tr><td>3</td><td>    1305-2<a name=\"1305-2\"> </a></td><td>Kickapoo</td><td/></tr>\r\n <tr><td>4</td><td>      1306-0<a name=\"1306-0\"> </a></td><td>Oklahoma Kickapoo</td><td/></tr>\r\n <tr><td>4</td><td>      1307-8<a name=\"1307-8\"> </a></td><td>Texas Kickapoo</td><td/></tr>\r\n <tr><td>3</td><td>    1309-4<a name=\"1309-4\"> </a></td><td>Kiowa</td><td/></tr>\r\n <tr><td>4</td><td>      1310-2<a name=\"1310-2\"> </a></td><td>Oklahoma Kiowa</td><td/></tr>\r\n <tr><td>3</td><td>    1312-8<a name=\"1312-8\"> </a></td><td>Klallam</td><td/></tr>\r\n <tr><td>4</td><td>      1313-6<a name=\"1313-6\"> </a></td><td>Jamestown</td><td/></tr>\r\n <tr><td>4</td><td>      1314-4<a name=\"1314-4\"> </a></td><td>Lower Elwha</td><td/></tr>\r\n <tr><td>4</td><td>      1315-1<a name=\"1315-1\"> </a></td><td>Port Gamble Klallam</td><td/></tr>\r\n <tr><td>3</td><td>    1317-7<a name=\"1317-7\"> </a></td><td>Klamath</td><td/></tr>\r\n <tr><td>3</td><td>    1319-3<a name=\"1319-3\"> </a></td><td>Konkow</td><td/></tr>\r\n <tr><td>3</td><td>    1321-9<a name=\"1321-9\"> </a></td><td>Kootenai</td><td/></tr>\r\n <tr><td>3</td><td>    1323-5<a name=\"1323-5\"> </a></td><td>Lassik</td><td/></tr>\r\n <tr><td>3</td><td>    1325-0<a name=\"1325-0\"> </a></td><td>Long Island</td><td/></tr>\r\n <tr><td>4</td><td>      1326-8<a name=\"1326-8\"> </a></td><td>Matinecock</td><td/></tr>\r\n <tr><td>4</td><td>      1327-6<a name=\"1327-6\"> </a></td><td>Montauk</td><td/></tr>\r\n <tr><td>4</td><td>      1328-4<a name=\"1328-4\"> </a></td><td>Poospatuck</td><td/></tr>\r\n <tr><td>4</td><td>      1329-2<a name=\"1329-2\"> </a></td><td>Setauket</td><td/></tr>\r\n <tr><td>3</td><td>    1331-8<a name=\"1331-8\"> </a></td><td>Luiseno</td><td/></tr>\r\n <tr><td>4</td><td>      1332-6<a name=\"1332-6\"> </a></td><td>La Jolla</td><td/></tr>\r\n <tr><td>4</td><td>      1333-4<a name=\"1333-4\"> </a></td><td>Pala</td><td/></tr>\r\n <tr><td>4</td><td>      1334-2<a name=\"1334-2\"> </a></td><td>Pauma</td><td/></tr>\r\n <tr><td>4</td><td>      1335-9<a name=\"1335-9\"> </a></td><td>Pechanga</td><td/></tr>\r\n <tr><td>4</td><td>      1336-7<a name=\"1336-7\"> </a></td><td>Soboba</td><td/></tr>\r\n <tr><td>4</td><td>      1337-5<a name=\"1337-5\"> </a></td><td>Twenty-Nine Palms</td><td/></tr>\r\n <tr><td>4</td><td>      1338-3<a name=\"1338-3\"> </a></td><td>Temecula</td><td/></tr>\r\n <tr><td>3</td><td>    1340-9<a name=\"1340-9\"> </a></td><td>Lumbee</td><td/></tr>\r\n <tr><td>3</td><td>    1342-5<a name=\"1342-5\"> </a></td><td>Lummi</td><td/></tr>\r\n <tr><td>3</td><td>    1344-1<a name=\"1344-1\"> </a></td><td>Maidu</td><td/></tr>\r\n <tr><td>4</td><td>      1345-8<a name=\"1345-8\"> </a></td><td>Mountain Maidu</td><td/></tr>\r\n <tr><td>4</td><td>      1346-6<a name=\"1346-6\"> </a></td><td>Nishinam</td><td/></tr>\r\n <tr><td>3</td><td>    1348-2<a name=\"1348-2\"> </a></td><td>Makah</td><td/></tr>\r\n <tr><td>3</td><td>    1350-8<a name=\"1350-8\"> </a></td><td>Maliseet</td><td/></tr>\r\n <tr><td>3</td><td>    1352-4<a name=\"1352-4\"> </a></td><td>Mandan</td><td/></tr>\r\n <tr><td>3</td><td>    1354-0<a name=\"1354-0\"> </a></td><td>Mattaponi</td><td/></tr>\r\n <tr><td>3</td><td>    1356-5<a name=\"1356-5\"> </a></td><td>Menominee</td><td/></tr>\r\n <tr><td>3</td><td>    1358-1<a name=\"1358-1\"> </a></td><td>Miami</td><td/></tr>\r\n <tr><td>4</td><td>      1359-9<a name=\"1359-9\"> </a></td><td>Illinois Miami</td><td/></tr>\r\n <tr><td>4</td><td>      1360-7<a name=\"1360-7\"> </a></td><td>Indiana Miami</td><td/></tr>\r\n <tr><td>4</td><td>      1361-5<a name=\"1361-5\"> </a></td><td>Oklahoma Miami</td><td/></tr>\r\n <tr><td>3</td><td>    1363-1<a name=\"1363-1\"> </a></td><td>Miccosukee</td><td/></tr>\r\n <tr><td>3</td><td>    1365-6<a name=\"1365-6\"> </a></td><td>Micmac</td><td/></tr>\r\n <tr><td>4</td><td>      1366-4<a name=\"1366-4\"> </a></td><td>Aroostook</td><td/></tr>\r\n <tr><td>3</td><td>    1368-0<a name=\"1368-0\"> </a></td><td>Mission Indians</td><td/></tr>\r\n <tr><td>3</td><td>    1370-6<a name=\"1370-6\"> </a></td><td>Miwok</td><td/></tr>\r\n <tr><td>3</td><td>    1372-2<a name=\"1372-2\"> </a></td><td>Modoc</td><td/></tr>\r\n <tr><td>3</td><td>    1374-8<a name=\"1374-8\"> </a></td><td>Mohegan</td><td/></tr>\r\n <tr><td>3</td><td>    1376-3<a name=\"1376-3\"> </a></td><td>Mono</td><td/></tr>\r\n <tr><td>3</td><td>    1378-9<a name=\"1378-9\"> </a></td><td>Nanticoke</td><td/></tr>\r\n <tr><td>3</td><td>    1380-5<a name=\"1380-5\"> </a></td><td>Narragansett</td><td/></tr>\r\n <tr><td>3</td><td>    1382-1<a name=\"1382-1\"> </a></td><td>Navajo</td><td/></tr>\r\n <tr><td>4</td><td>      1383-9<a name=\"1383-9\"> </a></td><td>Alamo Navajo</td><td/></tr>\r\n <tr><td>4</td><td>      1384-7<a name=\"1384-7\"> </a></td><td>Canoncito Navajo</td><td/></tr>\r\n <tr><td>4</td><td>      1385-4<a name=\"1385-4\"> </a></td><td>Ramah Navajo</td><td/></tr>\r\n <tr><td>3</td><td>    1387-0<a name=\"1387-0\"> </a></td><td>Nez Perce</td><td/></tr>\r\n <tr><td>3</td><td>    1389-6<a name=\"1389-6\"> </a></td><td>Nomalaki</td><td/></tr>\r\n <tr><td>3</td><td>    1391-2<a name=\"1391-2\"> </a></td><td>Northwest Tribes</td><td/></tr>\r\n <tr><td>4</td><td>      1392-0<a name=\"1392-0\"> </a></td><td>Alsea</td><td/></tr>\r\n <tr><td>4</td><td>      1393-8<a name=\"1393-8\"> </a></td><td>Celilo</td><td/></tr>\r\n <tr><td>4</td><td>      1394-6<a name=\"1394-6\"> </a></td><td>Columbia</td><td/></tr>\r\n <tr><td>4</td><td>      1395-3<a name=\"1395-3\"> </a></td><td>Kalapuya</td><td/></tr>\r\n <tr><td>4</td><td>      1396-1<a name=\"1396-1\"> </a></td><td>Molala</td><td/></tr>\r\n <tr><td>4</td><td>      1397-9<a name=\"1397-9\"> </a></td><td>Talakamish</td><td/></tr>\r\n <tr><td>4</td><td>      1398-7<a name=\"1398-7\"> </a></td><td>Tenino</td><td/></tr>\r\n <tr><td>4</td><td>      1399-5<a name=\"1399-5\"> </a></td><td>Tillamook</td><td/></tr>\r\n <tr><td>4</td><td>      1400-1<a name=\"1400-1\"> </a></td><td>Wenatchee</td><td/></tr>\r\n <tr><td>4</td><td>      1401-9<a name=\"1401-9\"> </a></td><td>Yahooskin</td><td/></tr>\r\n <tr><td>3</td><td>    1403-5<a name=\"1403-5\"> </a></td><td>Omaha</td><td/></tr>\r\n <tr><td>3</td><td>    1405-0<a name=\"1405-0\"> </a></td><td>Oregon Athabaskan</td><td/></tr>\r\n <tr><td>3</td><td>    1407-6<a name=\"1407-6\"> </a></td><td>Osage</td><td/></tr>\r\n <tr><td>3</td><td>    1409-2<a name=\"1409-2\"> </a></td><td>Otoe-Missouria</td><td/></tr>\r\n <tr><td>3</td><td>    1411-8<a name=\"1411-8\"> </a></td><td>Ottawa</td><td/></tr>\r\n <tr><td>4</td><td>      1412-6<a name=\"1412-6\"> </a></td><td>Burt Lake Ottawa</td><td/></tr>\r\n <tr><td>4</td><td>      1413-4<a name=\"1413-4\"> </a></td><td>Michigan Ottawa</td><td/></tr>\r\n <tr><td>4</td><td>      1414-2<a name=\"1414-2\"> </a></td><td>Oklahoma Ottawa</td><td/></tr>\r\n <tr><td>3</td><td>    1416-7<a name=\"1416-7\"> </a></td><td>Paiute</td><td/></tr>\r\n <tr><td>4</td><td>      1417-5<a name=\"1417-5\"> </a></td><td>Bishop</td><td/></tr>\r\n <tr><td>4</td><td>      1418-3<a name=\"1418-3\"> </a></td><td>Bridgeport</td><td/></tr>\r\n <tr><td>4</td><td>      1419-1<a name=\"1419-1\"> </a></td><td>Burns Paiute</td><td/></tr>\r\n <tr><td>4</td><td>      1420-9<a name=\"1420-9\"> </a></td><td>Cedarville</td><td/></tr>\r\n <tr><td>4</td><td>      1421-7<a name=\"1421-7\"> </a></td><td>Fort Bidwell</td><td/></tr>\r\n <tr><td>4</td><td>      1422-5<a name=\"1422-5\"> </a></td><td>Fort Independence</td><td/></tr>\r\n <tr><td>4</td><td>      1423-3<a name=\"1423-3\"> </a></td><td>Kaibab</td><td/></tr>\r\n <tr><td>4</td><td>      1424-1<a name=\"1424-1\"> </a></td><td>Las Vegas</td><td/></tr>\r\n <tr><td>4</td><td>      1425-8<a name=\"1425-8\"> </a></td><td>Lone Pine</td><td/></tr>\r\n <tr><td>4</td><td>      1426-6<a name=\"1426-6\"> </a></td><td>Lovelock</td><td/></tr>\r\n <tr><td>4</td><td>      1427-4<a name=\"1427-4\"> </a></td><td>Malheur Paiute</td><td/></tr>\r\n <tr><td>4</td><td>      1428-2<a name=\"1428-2\"> </a></td><td>Moapa</td><td/></tr>\r\n <tr><td>4</td><td>      1429-0<a name=\"1429-0\"> </a></td><td>Northern Paiute</td><td/></tr>\r\n <tr><td>4</td><td>      1430-8<a name=\"1430-8\"> </a></td><td>Owens Valley</td><td/></tr>\r\n <tr><td>4</td><td>      1431-6<a name=\"1431-6\"> </a></td><td>Pyramid Lake</td><td/></tr>\r\n <tr><td>4</td><td>      1432-4<a name=\"1432-4\"> </a></td><td>San Juan Southern Paiute</td><td/></tr>\r\n <tr><td>4</td><td>      1433-2<a name=\"1433-2\"> </a></td><td>Southern Paiute</td><td/></tr>\r\n <tr><td>4</td><td>      1434-0<a name=\"1434-0\"> </a></td><td>Summit Lake</td><td/></tr>\r\n <tr><td>4</td><td>      1435-7<a name=\"1435-7\"> </a></td><td>Utu Utu Gwaitu Paiute</td><td/></tr>\r\n <tr><td>4</td><td>      1436-5<a name=\"1436-5\"> </a></td><td>Walker River</td><td/></tr>\r\n <tr><td>4</td><td>      1437-3<a name=\"1437-3\"> </a></td><td>Yerington Paiute</td><td/></tr>\r\n <tr><td>3</td><td>    1439-9<a name=\"1439-9\"> </a></td><td>Pamunkey</td><td/></tr>\r\n <tr><td>3</td><td>    1441-5<a name=\"1441-5\"> </a></td><td>Passamaquoddy</td><td/></tr>\r\n <tr><td>4</td><td>      1442-3<a name=\"1442-3\"> </a></td><td>Indian Township</td><td/></tr>\r\n <tr><td>4</td><td>      1443-1<a name=\"1443-1\"> </a></td><td>Pleasant Point Passamaquoddy</td><td/></tr>\r\n <tr><td>3</td><td>    1445-6<a name=\"1445-6\"> </a></td><td>Pawnee</td><td/></tr>\r\n <tr><td>4</td><td>      1446-4<a name=\"1446-4\"> </a></td><td>Oklahoma Pawnee</td><td/></tr>\r\n <tr><td>3</td><td>    1448-0<a name=\"1448-0\"> </a></td><td>Penobscot</td><td/></tr>\r\n <tr><td>3</td><td>    1450-6<a name=\"1450-6\"> </a></td><td>Peoria</td><td/></tr>\r\n <tr><td>4</td><td>      1451-4<a name=\"1451-4\"> </a></td><td>Oklahoma Peoria</td><td/></tr>\r\n <tr><td>3</td><td>    1453-0<a name=\"1453-0\"> </a></td><td>Pequot</td><td/></tr>\r\n <tr><td>4</td><td>      1454-8<a name=\"1454-8\"> </a></td><td>Marshantucket Pequot</td><td/></tr>\r\n <tr><td>3</td><td>    1456-3<a name=\"1456-3\"> </a></td><td>Pima</td><td/></tr>\r\n <tr><td>4</td><td>      1457-1<a name=\"1457-1\"> </a></td><td>Gila River Pima-Maricopa</td><td/></tr>\r\n <tr><td>4</td><td>      1458-9<a name=\"1458-9\"> </a></td><td>Salt River Pima-Maricopa</td><td/></tr>\r\n <tr><td>3</td><td>    1460-5<a name=\"1460-5\"> </a></td><td>Piscataway</td><td/></tr>\r\n <tr><td>3</td><td>    1462-1<a name=\"1462-1\"> </a></td><td>Pit River</td><td/></tr>\r\n <tr><td>3</td><td>    1464-7<a name=\"1464-7\"> </a></td><td>Pomo</td><td/></tr>\r\n <tr><td>4</td><td>      1465-4<a name=\"1465-4\"> </a></td><td>Central Pomo</td><td/></tr>\r\n <tr><td>4</td><td>      1466-2<a name=\"1466-2\"> </a></td><td>Dry Creek</td><td/></tr>\r\n <tr><td>4</td><td>      1467-0<a name=\"1467-0\"> </a></td><td>Eastern Pomo</td><td/></tr>\r\n <tr><td>4</td><td>      1468-8<a name=\"1468-8\"> </a></td><td>Kashia</td><td/></tr>\r\n <tr><td>4</td><td>      1469-6<a name=\"1469-6\"> </a></td><td>Northern Pomo</td><td/></tr>\r\n <tr><td>4</td><td>      1470-4<a name=\"1470-4\"> </a></td><td>Scotts Valley</td><td/></tr>\r\n <tr><td>4</td><td>      1471-2<a name=\"1471-2\"> </a></td><td>Stonyford</td><td/></tr>\r\n <tr><td>4</td><td>      1472-0<a name=\"1472-0\"> </a></td><td>Sulphur Bank</td><td/></tr>\r\n <tr><td>3</td><td>    1474-6<a name=\"1474-6\"> </a></td><td>Ponca</td><td/></tr>\r\n <tr><td>4</td><td>      1475-3<a name=\"1475-3\"> </a></td><td>Nebraska Ponca</td><td/></tr>\r\n <tr><td>4</td><td>      1476-1<a name=\"1476-1\"> </a></td><td>Oklahoma Ponca</td><td/></tr>\r\n <tr><td>3</td><td>    1478-7<a name=\"1478-7\"> </a></td><td>Potawatomi</td><td/></tr>\r\n <tr><td>4</td><td>      1479-5<a name=\"1479-5\"> </a></td><td>Citizen Band Potawatomi</td><td/></tr>\r\n <tr><td>4</td><td>      1480-3<a name=\"1480-3\"> </a></td><td>Forest County</td><td/></tr>\r\n <tr><td>4</td><td>      1481-1<a name=\"1481-1\"> </a></td><td>Hannahville</td><td/></tr>\r\n <tr><td>4</td><td>      1482-9<a name=\"1482-9\"> </a></td><td>Huron Potawatomi</td><td/></tr>\r\n <tr><td>4</td><td>      1483-7<a name=\"1483-7\"> </a></td><td>Pokagon Potawatomi</td><td/></tr>\r\n <tr><td>4</td><td>      1484-5<a name=\"1484-5\"> </a></td><td>Prairie Band</td><td/></tr>\r\n <tr><td>4</td><td>      1485-2<a name=\"1485-2\"> </a></td><td>Wisconsin Potawatomi</td><td/></tr>\r\n <tr><td>3</td><td>    1487-8<a name=\"1487-8\"> </a></td><td>Powhatan</td><td/></tr>\r\n <tr><td>3</td><td>    1489-4<a name=\"1489-4\"> </a></td><td>Pueblo</td><td/></tr>\r\n <tr><td>4</td><td>      1490-2<a name=\"1490-2\"> </a></td><td>Acoma</td><td/></tr>\r\n <tr><td>4</td><td>      1491-0<a name=\"1491-0\"> </a></td><td>Arizona Tewa</td><td/></tr>\r\n <tr><td>4</td><td>      1492-8<a name=\"1492-8\"> </a></td><td>Cochiti</td><td/></tr>\r\n <tr><td>4</td><td>      1493-6<a name=\"1493-6\"> </a></td><td>Hopi</td><td/></tr>\r\n <tr><td>4</td><td>      1494-4<a name=\"1494-4\"> </a></td><td>Isleta</td><td/></tr>\r\n <tr><td>4</td><td>      1495-1<a name=\"1495-1\"> </a></td><td>Jemez</td><td/></tr>\r\n <tr><td>4</td><td>      1496-9<a name=\"1496-9\"> </a></td><td>Keres</td><td/></tr>\r\n <tr><td>4</td><td>      1497-7<a name=\"1497-7\"> </a></td><td>Laguna</td><td/></tr>\r\n <tr><td>4</td><td>      1498-5<a name=\"1498-5\"> </a></td><td>Nambe</td><td/></tr>\r\n <tr><td>4</td><td>      1499-3<a name=\"1499-3\"> </a></td><td>Picuris</td><td/></tr>\r\n <tr><td>4</td><td>      1500-8<a name=\"1500-8\"> </a></td><td>Piro</td><td/></tr>\r\n <tr><td>4</td><td>      1501-6<a name=\"1501-6\"> </a></td><td>Pojoaque</td><td/></tr>\r\n <tr><td>4</td><td>      1502-4<a name=\"1502-4\"> </a></td><td>San Felipe</td><td/></tr>\r\n <tr><td>4</td><td>      1503-2<a name=\"1503-2\"> </a></td><td>San Ildefonso</td><td/></tr>\r\n <tr><td>4</td><td>      1504-0<a name=\"1504-0\"> </a></td><td>San Juan Pueblo</td><td/></tr>\r\n <tr><td>4</td><td>      1505-7<a name=\"1505-7\"> </a></td><td>San Juan De</td><td/></tr>\r\n <tr><td>4</td><td>      1506-5<a name=\"1506-5\"> </a></td><td>San Juan</td><td/></tr>\r\n <tr><td>4</td><td>      1507-3<a name=\"1507-3\"> </a></td><td>Sandia</td><td/></tr>\r\n <tr><td>4</td><td>      1508-1<a name=\"1508-1\"> </a></td><td>Santa Ana</td><td/></tr>\r\n <tr><td>4</td><td>      1509-9<a name=\"1509-9\"> </a></td><td>Santa Clara</td><td/></tr>\r\n <tr><td>4</td><td>      1510-7<a name=\"1510-7\"> </a></td><td>Santo Domingo</td><td/></tr>\r\n <tr><td>4</td><td>      1511-5<a name=\"1511-5\"> </a></td><td>Taos</td><td/></tr>\r\n <tr><td>4</td><td>      1512-3<a name=\"1512-3\"> </a></td><td>Tesuque</td><td/></tr>\r\n <tr><td>4</td><td>      1513-1<a name=\"1513-1\"> </a></td><td>Tewa</td><td/></tr>\r\n <tr><td>4</td><td>      1514-9<a name=\"1514-9\"> </a></td><td>Tigua</td><td/></tr>\r\n <tr><td>4</td><td>      1515-6<a name=\"1515-6\"> </a></td><td>Zia</td><td/></tr>\r\n <tr><td>4</td><td>      1516-4<a name=\"1516-4\"> </a></td><td>Zuni</td><td/></tr>\r\n <tr><td>3</td><td>    1518-0<a name=\"1518-0\"> </a></td><td>Puget Sound Salish</td><td/></tr>\r\n <tr><td>4</td><td>      1519-8<a name=\"1519-8\"> </a></td><td>Duwamish</td><td/></tr>\r\n <tr><td>4</td><td>      1520-6<a name=\"1520-6\"> </a></td><td>Kikiallus</td><td/></tr>\r\n <tr><td>4</td><td>      1521-4<a name=\"1521-4\"> </a></td><td>Lower Skagit</td><td/></tr>\r\n <tr><td>4</td><td>      1522-2<a name=\"1522-2\"> </a></td><td>Muckleshoot</td><td/></tr>\r\n <tr><td>4</td><td>      1523-0<a name=\"1523-0\"> </a></td><td>Nisqually</td><td/></tr>\r\n <tr><td>4</td><td>      1524-8<a name=\"1524-8\"> </a></td><td>Nooksack</td><td/></tr>\r\n <tr><td>4</td><td>      1525-5<a name=\"1525-5\"> </a></td><td>Port Madison</td><td/></tr>\r\n <tr><td>4</td><td>      1526-3<a name=\"1526-3\"> </a></td><td>Puyallup</td><td/></tr>\r\n <tr><td>4</td><td>      1527-1<a name=\"1527-1\"> </a></td><td>Samish</td><td/></tr>\r\n <tr><td>4</td><td>      1528-9<a name=\"1528-9\"> </a></td><td>Sauk-Suiattle</td><td/></tr>\r\n <tr><td>4</td><td>      1529-7<a name=\"1529-7\"> </a></td><td>Skokomish</td><td/></tr>\r\n <tr><td>4</td><td>      1530-5<a name=\"1530-5\"> </a></td><td>Skykomish</td><td/></tr>\r\n <tr><td>4</td><td>      1531-3<a name=\"1531-3\"> </a></td><td>Snohomish</td><td/></tr>\r\n <tr><td>4</td><td>      1532-1<a name=\"1532-1\"> </a></td><td>Snoqualmie</td><td/></tr>\r\n <tr><td>4</td><td>      1533-9<a name=\"1533-9\"> </a></td><td>Squaxin Island</td><td/></tr>\r\n <tr><td>4</td><td>      1534-7<a name=\"1534-7\"> </a></td><td>Steilacoom</td><td/></tr>\r\n <tr><td>4</td><td>      1535-4<a name=\"1535-4\"> </a></td><td>Stillaguamish</td><td/></tr>\r\n <tr><td>4</td><td>      1536-2<a name=\"1536-2\"> </a></td><td>Suquamish</td><td/></tr>\r\n <tr><td>4</td><td>      1537-0<a name=\"1537-0\"> </a></td><td>Swinomish</td><td/></tr>\r\n <tr><td>4</td><td>      1538-8<a name=\"1538-8\"> </a></td><td>Tulalip</td><td/></tr>\r\n <tr><td>4</td><td>      1539-6<a name=\"1539-6\"> </a></td><td>Upper Skagit</td><td/></tr>\r\n <tr><td>3</td><td>    1541-2<a name=\"1541-2\"> </a></td><td>Quapaw</td><td/></tr>\r\n <tr><td>3</td><td>    1543-8<a name=\"1543-8\"> </a></td><td>Quinault</td><td/></tr>\r\n <tr><td>3</td><td>    1545-3<a name=\"1545-3\"> </a></td><td>Rappahannock</td><td/></tr>\r\n <tr><td>3</td><td>    1547-9<a name=\"1547-9\"> </a></td><td>Reno-Sparks</td><td/></tr>\r\n <tr><td>3</td><td>    1549-5<a name=\"1549-5\"> </a></td><td>Round Valley</td><td/></tr>\r\n <tr><td>3</td><td>    1551-1<a name=\"1551-1\"> </a></td><td>Sac and Fox</td><td/></tr>\r\n <tr><td>4</td><td>      1552-9<a name=\"1552-9\"> </a></td><td>Iowa Sac and Fox</td><td/></tr>\r\n <tr><td>4</td><td>      1553-7<a name=\"1553-7\"> </a></td><td>Missouri Sac and Fox</td><td/></tr>\r\n <tr><td>4</td><td>      1554-5<a name=\"1554-5\"> </a></td><td>Oklahoma Sac and Fox</td><td/></tr>\r\n <tr><td>3</td><td>    1556-0<a name=\"1556-0\"> </a></td><td>Salinan</td><td/></tr>\r\n <tr><td>3</td><td>    1558-6<a name=\"1558-6\"> </a></td><td>Salish</td><td/></tr>\r\n <tr><td>3</td><td>    1560-2<a name=\"1560-2\"> </a></td><td>Salish and Kootenai</td><td/></tr>\r\n <tr><td>3</td><td>    1562-8<a name=\"1562-8\"> </a></td><td>Schaghticoke</td><td/></tr>\r\n <tr><td>3</td><td>    1564-4<a name=\"1564-4\"> </a></td><td>Scott Valley</td><td/></tr>\r\n <tr><td>3</td><td>    1566-9<a name=\"1566-9\"> </a></td><td>Seminole</td><td/></tr>\r\n <tr><td>4</td><td>      1567-7<a name=\"1567-7\"> </a></td><td>Big Cypress</td><td/></tr>\r\n <tr><td>4</td><td>      1568-5<a name=\"1568-5\"> </a></td><td>Brighton</td><td/></tr>\r\n <tr><td>4</td><td>      1569-3<a name=\"1569-3\"> </a></td><td>Florida Seminole</td><td/></tr>\r\n <tr><td>4</td><td>      1570-1<a name=\"1570-1\"> </a></td><td>Hollywood Seminole</td><td/></tr>\r\n <tr><td>4</td><td>      1571-9<a name=\"1571-9\"> </a></td><td>Oklahoma Seminole</td><td/></tr>\r\n <tr><td>3</td><td>    1573-5<a name=\"1573-5\"> </a></td><td>Serrano</td><td/></tr>\r\n <tr><td>4</td><td>      1574-3<a name=\"1574-3\"> </a></td><td>San Manual</td><td/></tr>\r\n <tr><td>3</td><td>    1576-8<a name=\"1576-8\"> </a></td><td>Shasta</td><td/></tr>\r\n <tr><td>3</td><td>    1578-4<a name=\"1578-4\"> </a></td><td>Shawnee</td><td/></tr>\r\n <tr><td>4</td><td>      1579-2<a name=\"1579-2\"> </a></td><td>Absentee Shawnee</td><td/></tr>\r\n <tr><td>4</td><td>      1580-0<a name=\"1580-0\"> </a></td><td>Eastern Shawnee</td><td/></tr>\r\n <tr><td>3</td><td>    1582-6<a name=\"1582-6\"> </a></td><td>Shinnecock</td><td/></tr>\r\n <tr><td>3</td><td>    1584-2<a name=\"1584-2\"> </a></td><td>Shoalwater Bay</td><td/></tr>\r\n <tr><td>3</td><td>    1586-7<a name=\"1586-7\"> </a></td><td>Shoshone</td><td/></tr>\r\n <tr><td>4</td><td>      1587-5<a name=\"1587-5\"> </a></td><td>Battle Mountain</td><td/></tr>\r\n <tr><td>4</td><td>      1588-3<a name=\"1588-3\"> </a></td><td>Duckwater</td><td/></tr>\r\n <tr><td>4</td><td>      1589-1<a name=\"1589-1\"> </a></td><td>Elko</td><td/></tr>\r\n <tr><td>4</td><td>      1590-9<a name=\"1590-9\"> </a></td><td>Ely</td><td/></tr>\r\n <tr><td>4</td><td>      1591-7<a name=\"1591-7\"> </a></td><td>Goshute</td><td/></tr>\r\n <tr><td>4</td><td>      1592-5<a name=\"1592-5\"> </a></td><td>Panamint</td><td/></tr>\r\n <tr><td>4</td><td>      1593-3<a name=\"1593-3\"> </a></td><td>Ruby Valley</td><td/></tr>\r\n <tr><td>4</td><td>      1594-1<a name=\"1594-1\"> </a></td><td>Skull Valley</td><td/></tr>\r\n <tr><td>4</td><td>      1595-8<a name=\"1595-8\"> </a></td><td>South Fork Shoshone</td><td/></tr>\r\n <tr><td>4</td><td>      1596-6<a name=\"1596-6\"> </a></td><td>Te-Moak Western Shoshone</td><td/></tr>\r\n <tr><td>4</td><td>      1597-4<a name=\"1597-4\"> </a></td><td>Timbi-Sha Shoshone</td><td/></tr>\r\n <tr><td>4</td><td>      1598-2<a name=\"1598-2\"> </a></td><td>Washakie</td><td/></tr>\r\n <tr><td>4</td><td>      1599-0<a name=\"1599-0\"> </a></td><td>Wind River Shoshone</td><td/></tr>\r\n <tr><td>4</td><td>      1600-6<a name=\"1600-6\"> </a></td><td>Yomba</td><td/></tr>\r\n <tr><td>3</td><td>    1602-2<a name=\"1602-2\"> </a></td><td>Shoshone Paiute</td><td/></tr>\r\n <tr><td>4</td><td>      1603-0<a name=\"1603-0\"> </a></td><td>Duck Valley</td><td/></tr>\r\n <tr><td>4</td><td>      1604-8<a name=\"1604-8\"> </a></td><td>Fallon</td><td/></tr>\r\n <tr><td>4</td><td>      1605-5<a name=\"1605-5\"> </a></td><td>Fort McDermitt</td><td/></tr>\r\n <tr><td>3</td><td>    1607-1<a name=\"1607-1\"> </a></td><td>Siletz</td><td/></tr>\r\n <tr><td>3</td><td>    1609-7<a name=\"1609-7\"> </a></td><td>Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1610-5<a name=\"1610-5\"> </a></td><td>Blackfoot Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1611-3<a name=\"1611-3\"> </a></td><td>Brule Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1612-1<a name=\"1612-1\"> </a></td><td>Cheyenne River Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1613-9<a name=\"1613-9\"> </a></td><td>Crow Creek Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1614-7<a name=\"1614-7\"> </a></td><td>Dakota Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1615-4<a name=\"1615-4\"> </a></td><td>Flandreau Santee</td><td/></tr>\r\n <tr><td>4</td><td>      1616-2<a name=\"1616-2\"> </a></td><td>Fort Peck</td><td/></tr>\r\n <tr><td>4</td><td>      1617-0<a name=\"1617-0\"> </a></td><td>Lake Traverse Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1618-8<a name=\"1618-8\"> </a></td><td>Lower Brule Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1619-6<a name=\"1619-6\"> </a></td><td>Lower Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1620-4<a name=\"1620-4\"> </a></td><td>Mdewakanton Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1621-2<a name=\"1621-2\"> </a></td><td>Miniconjou</td><td/></tr>\r\n <tr><td>4</td><td>      1622-0<a name=\"1622-0\"> </a></td><td>Oglala Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1623-8<a name=\"1623-8\"> </a></td><td>Pine Ridge Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1624-6<a name=\"1624-6\"> </a></td><td>Pipestone Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1625-3<a name=\"1625-3\"> </a></td><td>Prairie Island Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1626-1<a name=\"1626-1\"> </a></td><td>Prior Lake Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1627-9<a name=\"1627-9\"> </a></td><td>Rosebud Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1628-7<a name=\"1628-7\"> </a></td><td>Sans Arc Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1629-5<a name=\"1629-5\"> </a></td><td>Santee Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1630-3<a name=\"1630-3\"> </a></td><td>Sisseton-Wahpeton</td><td/></tr>\r\n <tr><td>4</td><td>      1631-1<a name=\"1631-1\"> </a></td><td>Sisseton Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1632-9<a name=\"1632-9\"> </a></td><td>Spirit Lake Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1633-7<a name=\"1633-7\"> </a></td><td>Standing Rock Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1634-5<a name=\"1634-5\"> </a></td><td>Teton Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1635-2<a name=\"1635-2\"> </a></td><td>Two Kettle Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1636-0<a name=\"1636-0\"> </a></td><td>Upper Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1637-8<a name=\"1637-8\"> </a></td><td>Wahpekute Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1638-6<a name=\"1638-6\"> </a></td><td>Wahpeton Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1639-4<a name=\"1639-4\"> </a></td><td>Wazhaza Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1640-2<a name=\"1640-2\"> </a></td><td>Yankton Sioux</td><td/></tr>\r\n <tr><td>4</td><td>      1641-0<a name=\"1641-0\"> </a></td><td>Yanktonai Sioux</td><td/></tr>\r\n <tr><td>3</td><td>    1643-6<a name=\"1643-6\"> </a></td><td>Siuslaw</td><td/></tr>\r\n <tr><td>3</td><td>    1645-1<a name=\"1645-1\"> </a></td><td>Spokane</td><td/></tr>\r\n <tr><td>3</td><td>    1647-7<a name=\"1647-7\"> </a></td><td>Stewart</td><td/></tr>\r\n <tr><td>3</td><td>    1649-3<a name=\"1649-3\"> </a></td><td>Stockbridge</td><td/></tr>\r\n <tr><td>3</td><td>    1651-9<a name=\"1651-9\"> </a></td><td>Susanville</td><td/></tr>\r\n <tr><td>3</td><td>    1653-5<a name=\"1653-5\"> </a></td><td>Tohono O'Odham</td><td/></tr>\r\n <tr><td>4</td><td>      1654-3<a name=\"1654-3\"> </a></td><td>Ak-Chin</td><td/></tr>\r\n <tr><td>4</td><td>      1655-0<a name=\"1655-0\"> </a></td><td>Gila Bend</td><td/></tr>\r\n <tr><td>4</td><td>      1656-8<a name=\"1656-8\"> </a></td><td>San Xavier</td><td/></tr>\r\n <tr><td>4</td><td>      1657-6<a name=\"1657-6\"> </a></td><td>Sells</td><td/></tr>\r\n <tr><td>3</td><td>    1659-2<a name=\"1659-2\"> </a></td><td>Tolowa</td><td/></tr>\r\n <tr><td>3</td><td>    1661-8<a name=\"1661-8\"> </a></td><td>Tonkawa</td><td/></tr>\r\n <tr><td>3</td><td>    1663-4<a name=\"1663-4\"> </a></td><td>Tygh</td><td/></tr>\r\n <tr><td>3</td><td>    1665-9<a name=\"1665-9\"> </a></td><td>Umatilla</td><td/></tr>\r\n <tr><td>3</td><td>    1667-5<a name=\"1667-5\"> </a></td><td>Umpqua</td><td/></tr>\r\n <tr><td>4</td><td>      1668-3<a name=\"1668-3\"> </a></td><td>Cow Creek Umpqua</td><td/></tr>\r\n <tr><td>3</td><td>    1670-9<a name=\"1670-9\"> </a></td><td>Ute</td><td/></tr>\r\n <tr><td>4</td><td>      1671-7<a name=\"1671-7\"> </a></td><td>Allen Canyon</td><td/></tr>\r\n <tr><td>4</td><td>      1672-5<a name=\"1672-5\"> </a></td><td>Uintah Ute</td><td/></tr>\r\n <tr><td>4</td><td>      1673-3<a name=\"1673-3\"> </a></td><td>Ute Mountain Ute</td><td/></tr>\r\n <tr><td>3</td><td>    1675-8<a name=\"1675-8\"> </a></td><td>Wailaki</td><td/></tr>\r\n <tr><td>3</td><td>    1677-4<a name=\"1677-4\"> </a></td><td>Walla-Walla</td><td/></tr>\r\n <tr><td>3</td><td>    1679-0<a name=\"1679-0\"> </a></td><td>Wampanoag</td><td/></tr>\r\n <tr><td>4</td><td>      1680-8<a name=\"1680-8\"> </a></td><td>Gay Head Wampanoag</td><td/></tr>\r\n <tr><td>4</td><td>      1681-6<a name=\"1681-6\"> </a></td><td>Mashpee Wampanoag</td><td/></tr>\r\n <tr><td>3</td><td>    1683-2<a name=\"1683-2\"> </a></td><td>Warm Springs</td><td/></tr>\r\n <tr><td>3</td><td>    1685-7<a name=\"1685-7\"> </a></td><td>Wascopum</td><td/></tr>\r\n <tr><td>3</td><td>    1687-3<a name=\"1687-3\"> </a></td><td>Washoe</td><td/></tr>\r\n <tr><td>4</td><td>      1688-1<a name=\"1688-1\"> </a></td><td>Alpine</td><td/></tr>\r\n <tr><td>4</td><td>      1689-9<a name=\"1689-9\"> </a></td><td>Carson</td><td/></tr>\r\n <tr><td>4</td><td>      1690-7<a name=\"1690-7\"> </a></td><td>Dresslerville</td><td/></tr>\r\n <tr><td>3</td><td>    1692-3<a name=\"1692-3\"> </a></td><td>Wichita</td><td/></tr>\r\n <tr><td>3</td><td>    1694-9<a name=\"1694-9\"> </a></td><td>Wind River</td><td/></tr>\r\n <tr><td>3</td><td>    1696-4<a name=\"1696-4\"> </a></td><td>Winnebago</td><td/></tr>\r\n <tr><td>4</td><td>      1697-2<a name=\"1697-2\"> </a></td><td>Ho-chunk</td><td/></tr>\r\n <tr><td>4</td><td>      1698-0<a name=\"1698-0\"> </a></td><td>Nebraska Winnebago</td><td/></tr>\r\n <tr><td>3</td><td>    1700-4<a name=\"1700-4\"> </a></td><td>Winnemucca</td><td/></tr>\r\n <tr><td>3</td><td>    1702-0<a name=\"1702-0\"> </a></td><td>Wintun</td><td/></tr>\r\n <tr><td>3</td><td>    1704-6<a name=\"1704-6\"> </a></td><td>Wiyot</td><td/></tr>\r\n <tr><td>4</td><td>      1705-3<a name=\"1705-3\"> </a></td><td>Table Bluff</td><td/></tr>\r\n <tr><td>3</td><td>    1707-9<a name=\"1707-9\"> </a></td><td>Yakama</td><td/></tr>\r\n <tr><td>3</td><td>    1709-5<a name=\"1709-5\"> </a></td><td>Yakama Cowlitz</td><td/></tr>\r\n <tr><td>3</td><td>    1711-1<a name=\"1711-1\"> </a></td><td>Yaqui</td><td/></tr>\r\n <tr><td>4</td><td>      1712-9<a name=\"1712-9\"> </a></td><td>Barrio Libre</td><td/></tr>\r\n <tr><td>4</td><td>      1713-7<a name=\"1713-7\"> </a></td><td>Pascua Yaqui</td><td/></tr>\r\n <tr><td>3</td><td>    1715-2<a name=\"1715-2\"> </a></td><td>Yavapai Apache</td><td/></tr>\r\n <tr><td>3</td><td>    1717-8<a name=\"1717-8\"> </a></td><td>Yokuts</td><td/></tr>\r\n <tr><td>4</td><td>      1718-6<a name=\"1718-6\"> </a></td><td>Chukchansi</td><td/></tr>\r\n <tr><td>4</td><td>      1719-4<a name=\"1719-4\"> </a></td><td>Tachi</td><td/></tr>\r\n <tr><td>4</td><td>      1720-2<a name=\"1720-2\"> </a></td><td>Tule River</td><td/></tr>\r\n <tr><td>3</td><td>    1722-8<a name=\"1722-8\"> </a></td><td>Yuchi</td><td/></tr>\r\n <tr><td>3</td><td>    1724-4<a name=\"1724-4\"> </a></td><td>Yuman</td><td/></tr>\r\n <tr><td>4</td><td>      1725-1<a name=\"1725-1\"> </a></td><td>Cocopah</td><td/></tr>\r\n <tr><td>4</td><td>      1726-9<a name=\"1726-9\"> </a></td><td>Havasupai</td><td/></tr>\r\n <tr><td>4</td><td>      1727-7<a name=\"1727-7\"> </a></td><td>Hualapai</td><td/></tr>\r\n <tr><td>4</td><td>      1728-5<a name=\"1728-5\"> </a></td><td>Maricopa</td><td/></tr>\r\n <tr><td>4</td><td>      1729-3<a name=\"1729-3\"> </a></td><td>Mohave</td><td/></tr>\r\n <tr><td>4</td><td>      1730-1<a name=\"1730-1\"> </a></td><td>Quechan</td><td/></tr>\r\n <tr><td>4</td><td>      1731-9<a name=\"1731-9\"> </a></td><td>Yavapai</td><td/></tr>\r\n <tr><td>3</td><td>    1732-7<a name=\"1732-7\"> </a></td><td>Yurok</td><td/></tr>\r\n <tr><td>4</td><td>      1733-5<a name=\"1733-5\"> </a></td><td>Coast Yurok</td><td/></tr>\r\n <tr><td>2</td><td>  1735-0<a name=\"1735-0\"> </a></td><td>Alaska Native</td><td/></tr>\r\n <tr><td>3</td><td>    1737-6<a name=\"1737-6\"> </a></td><td>Alaska Indian</td><td/></tr>\r\n <tr><td>4</td><td>      1739-2<a name=\"1739-2\"> </a></td><td>Alaskan Athabascan</td><td/></tr>\r\n <tr><td>5</td><td>        1740-0<a name=\"1740-0\"> </a></td><td>Ahtna</td><td/></tr>\r\n <tr><td>4</td><td>      1811-9<a name=\"1811-9\"> </a></td><td>Southeast Alaska</td><td/></tr>\r\n <tr><td>5</td><td>        1813-5<a name=\"1813-5\"> </a></td><td>Tlingit-Haida</td><td/></tr>\r\n <tr><td>6</td><td>          1814-3<a name=\"1814-3\"> </a></td><td>Angoon</td><td/></tr>\r\n <tr><td>6</td><td>          1815-0<a name=\"1815-0\"> </a></td><td>Central Council of Tlingit and Haida Tribes</td><td/></tr>\r\n <tr><td>6</td><td>          1816-8<a name=\"1816-8\"> </a></td><td>Chilkat</td><td/></tr>\r\n <tr><td>6</td><td>          1817-6<a name=\"1817-6\"> </a></td><td>Chilkoot</td><td/></tr>\r\n <tr><td>6</td><td>          1818-4<a name=\"1818-4\"> </a></td><td>Craig</td><td/></tr>\r\n <tr><td>6</td><td>          1819-2<a name=\"1819-2\"> </a></td><td>Douglas</td><td/></tr>\r\n <tr><td>6</td><td>          1820-0<a name=\"1820-0\"> </a></td><td>Haida</td><td/></tr>\r\n <tr><td>6</td><td>          1821-8<a name=\"1821-8\"> </a></td><td>Hoonah</td><td/></tr>\r\n <tr><td>6</td><td>          1822-6<a name=\"1822-6\"> </a></td><td>Hydaburg</td><td/></tr>\r\n <tr><td>6</td><td>          1823-4<a name=\"1823-4\"> </a></td><td>Kake</td><td/></tr>\r\n <tr><td>6</td><td>          1824-2<a name=\"1824-2\"> </a></td><td>Kasaan</td><td/></tr>\r\n <tr><td>6</td><td>          1825-9<a name=\"1825-9\"> </a></td><td>Kenaitze</td><td/></tr>\r\n <tr><td>6</td><td>          1826-7<a name=\"1826-7\"> </a></td><td>Ketchikan</td><td/></tr>\r\n <tr><td>6</td><td>          1827-5<a name=\"1827-5\"> </a></td><td>Klawock</td><td/></tr>\r\n <tr><td>6</td><td>          1828-3<a name=\"1828-3\"> </a></td><td>Pelican</td><td/></tr>\r\n <tr><td>6</td><td>          1829-1<a name=\"1829-1\"> </a></td><td>Petersburg</td><td/></tr>\r\n <tr><td>6</td><td>          1830-9<a name=\"1830-9\"> </a></td><td>Saxman</td><td/></tr>\r\n <tr><td>6</td><td>          1831-7<a name=\"1831-7\"> </a></td><td>Sitka</td><td/></tr>\r\n <tr><td>6</td><td>          1832-5<a name=\"1832-5\"> </a></td><td>Tenakee Springs</td><td/></tr>\r\n <tr><td>6</td><td>          1833-3<a name=\"1833-3\"> </a></td><td>Tlingit</td><td/></tr>\r\n <tr><td>6</td><td>          1834-1<a name=\"1834-1\"> </a></td><td>Wrangell</td><td/></tr>\r\n <tr><td>6</td><td>          1835-8<a name=\"1835-8\"> </a></td><td>Yakutat</td><td/></tr>\r\n <tr><td>5</td><td>        1837-4<a name=\"1837-4\"> </a></td><td>Tsimshian</td><td/></tr>\r\n <tr><td>6</td><td>          1838-2<a name=\"1838-2\"> </a></td><td>Metlakatla</td><td/></tr>\r\n <tr><td>3</td><td>    1840-8<a name=\"1840-8\"> </a></td><td>Eskimo</td><td/></tr>\r\n <tr><td>4</td><td>      1842-4<a name=\"1842-4\"> </a></td><td>Greenland Eskimo</td><td/></tr>\r\n <tr><td>4</td><td>      1844-0<a name=\"1844-0\"> </a></td><td>Inupiat Eskimo</td><td/></tr>\r\n <tr><td>5</td><td>        1845-7<a name=\"1845-7\"> </a></td><td>Ambler</td><td/></tr>\r\n <tr><td>5</td><td>        1846-5<a name=\"1846-5\"> </a></td><td>Anaktuvuk</td><td/></tr>\r\n <tr><td>5</td><td>        1847-3<a name=\"1847-3\"> </a></td><td>Anaktuvuk Pass</td><td/></tr>\r\n <tr><td>5</td><td>        1848-1<a name=\"1848-1\"> </a></td><td>Arctic Slope Inupiat</td><td/></tr>\r\n <tr><td>5</td><td>        1849-9<a name=\"1849-9\"> </a></td><td>Arctic Slope Corporation</td><td/></tr>\r\n <tr><td>5</td><td>        1850-7<a name=\"1850-7\"> </a></td><td>Atqasuk</td><td/></tr>\r\n <tr><td>5</td><td>        1851-5<a name=\"1851-5\"> </a></td><td>Barrow</td><td/></tr>\r\n <tr><td>5</td><td>        1852-3<a name=\"1852-3\"> </a></td><td>Bering Straits Inupiat</td><td/></tr>\r\n <tr><td>5</td><td>        1853-1<a name=\"1853-1\"> </a></td><td>Brevig Mission</td><td/></tr>\r\n <tr><td>5</td><td>        1854-9<a name=\"1854-9\"> </a></td><td>Buckland</td><td/></tr>\r\n <tr><td>5</td><td>        1855-6<a name=\"1855-6\"> </a></td><td>Chinik</td><td/></tr>\r\n <tr><td>5</td><td>        1856-4<a name=\"1856-4\"> </a></td><td>Council</td><td/></tr>\r\n <tr><td>5</td><td>        1857-2<a name=\"1857-2\"> </a></td><td>Deering</td><td/></tr>\r\n <tr><td>5</td><td>        1858-0<a name=\"1858-0\"> </a></td><td>Elim</td><td/></tr>\r\n <tr><td>5</td><td>        1859-8<a name=\"1859-8\"> </a></td><td>Golovin</td><td/></tr>\r\n <tr><td>5</td><td>        1860-6<a name=\"1860-6\"> </a></td><td>Inalik Diomede</td><td/></tr>\r\n <tr><td>5</td><td>        1861-4<a name=\"1861-4\"> </a></td><td>Inupiaq</td><td/></tr>\r\n <tr><td>5</td><td>        1862-2<a name=\"1862-2\"> </a></td><td>Kaktovik</td><td/></tr>\r\n <tr><td>5</td><td>        1863-0<a name=\"1863-0\"> </a></td><td>Kawerak</td><td/></tr>\r\n <tr><td>5</td><td>        1864-8<a name=\"1864-8\"> </a></td><td>Kiana</td><td/></tr>\r\n <tr><td>5</td><td>        1865-5<a name=\"1865-5\"> </a></td><td>Kivalina</td><td/></tr>\r\n <tr><td>5</td><td>        1866-3<a name=\"1866-3\"> </a></td><td>Kobuk</td><td/></tr>\r\n <tr><td>5</td><td>        1867-1<a name=\"1867-1\"> </a></td><td>Kotzebue</td><td/></tr>\r\n <tr><td>5</td><td>        1868-9<a name=\"1868-9\"> </a></td><td>Koyuk</td><td/></tr>\r\n <tr><td>5</td><td>        1869-7<a name=\"1869-7\"> </a></td><td>Kwiguk</td><td/></tr>\r\n <tr><td>5</td><td>        1870-5<a name=\"1870-5\"> </a></td><td>Mauneluk Inupiat</td><td/></tr>\r\n <tr><td>5</td><td>        1871-3<a name=\"1871-3\"> </a></td><td>Nana Inupiat</td><td/></tr>\r\n <tr><td>5</td><td>        1872-1<a name=\"1872-1\"> </a></td><td>Noatak</td><td/></tr>\r\n <tr><td>5</td><td>        1873-9<a name=\"1873-9\"> </a></td><td>Nome</td><td/></tr>\r\n <tr><td>5</td><td>        1874-7<a name=\"1874-7\"> </a></td><td>Noorvik</td><td/></tr>\r\n <tr><td>5</td><td>        1875-4<a name=\"1875-4\"> </a></td><td>Nuiqsut</td><td/></tr>\r\n <tr><td>5</td><td>        1876-2<a name=\"1876-2\"> </a></td><td>Point Hope</td><td/></tr>\r\n <tr><td>5</td><td>        1877-0<a name=\"1877-0\"> </a></td><td>Point Lay</td><td/></tr>\r\n <tr><td>5</td><td>        1878-8<a name=\"1878-8\"> </a></td><td>Selawik</td><td/></tr>\r\n <tr><td>5</td><td>        1879-6<a name=\"1879-6\"> </a></td><td>Shaktoolik</td><td/></tr>\r\n <tr><td>5</td><td>        1880-4<a name=\"1880-4\"> </a></td><td>Shishmaref</td><td/></tr>\r\n <tr><td>5</td><td>        1881-2<a name=\"1881-2\"> </a></td><td>Shungnak</td><td/></tr>\r\n <tr><td>5</td><td>        1882-0<a name=\"1882-0\"> </a></td><td>Solomon</td><td/></tr>\r\n <tr><td>5</td><td>        1883-8<a name=\"1883-8\"> </a></td><td>Teller</td><td/></tr>\r\n <tr><td>5</td><td>        1884-6<a name=\"1884-6\"> </a></td><td>Unalakleet</td><td/></tr>\r\n <tr><td>5</td><td>        1885-3<a name=\"1885-3\"> </a></td><td>Wainwright</td><td/></tr>\r\n <tr><td>5</td><td>        1886-1<a name=\"1886-1\"> </a></td><td>Wales</td><td/></tr>\r\n <tr><td>5</td><td>        1887-9<a name=\"1887-9\"> </a></td><td>White Mountain</td><td/></tr>\r\n <tr><td>5</td><td>        1888-7<a name=\"1888-7\"> </a></td><td>White Mountain Inupiat</td><td/></tr>\r\n <tr><td>5</td><td>        1889-5<a name=\"1889-5\"> </a></td><td>Mary's Igloo</td><td/></tr>\r\n <tr><td>4</td><td>      1891-1<a name=\"1891-1\"> </a></td><td>Siberian Eskimo</td><td/></tr>\r\n <tr><td>5</td><td>        1892-9<a name=\"1892-9\"> </a></td><td>Gambell</td><td/></tr>\r\n <tr><td>5</td><td>        1893-7<a name=\"1893-7\"> </a></td><td>Savoonga</td><td/></tr>\r\n <tr><td>5</td><td>        1894-5<a name=\"1894-5\"> </a></td><td>Siberian Yupik</td><td/></tr>\r\n <tr><td>4</td><td>      1896-0<a name=\"1896-0\"> </a></td><td>Yupik Eskimo</td><td/></tr>\r\n <tr><td>5</td><td>        1897-8<a name=\"1897-8\"> </a></td><td>Akiachak</td><td/></tr>\r\n <tr><td>5</td><td>        1898-6<a name=\"1898-6\"> </a></td><td>Akiak</td><td/></tr>\r\n <tr><td>5</td><td>        1899-4<a name=\"1899-4\"> </a></td><td>Alakanuk</td><td/></tr>\r\n <tr><td>5</td><td>        1900-0<a name=\"1900-0\"> </a></td><td>Aleknagik</td><td/></tr>\r\n <tr><td>5</td><td>        1901-8<a name=\"1901-8\"> </a></td><td>Andreafsky</td><td/></tr>\r\n <tr><td>5</td><td>        1902-6<a name=\"1902-6\"> </a></td><td>Aniak</td><td/></tr>\r\n <tr><td>5</td><td>        1903-4<a name=\"1903-4\"> </a></td><td>Atmautluak</td><td/></tr>\r\n <tr><td>5</td><td>        1904-2<a name=\"1904-2\"> </a></td><td>Bethel</td><td/></tr>\r\n <tr><td>5</td><td>        1905-9<a name=\"1905-9\"> </a></td><td>Bill Moore's Slough</td><td/></tr>\r\n <tr><td>5</td><td>        1906-7<a name=\"1906-7\"> </a></td><td>Bristol Bay Yupik</td><td/></tr>\r\n <tr><td>5</td><td>        1907-5<a name=\"1907-5\"> </a></td><td>Calista Yupik</td><td/></tr>\r\n <tr><td>5</td><td>        1908-3<a name=\"1908-3\"> </a></td><td>Chefornak</td><td/></tr>\r\n <tr><td>5</td><td>        1909-1<a name=\"1909-1\"> </a></td><td>Chevak</td><td/></tr>\r\n <tr><td>5</td><td>        1910-9<a name=\"1910-9\"> </a></td><td>Chuathbaluk</td><td/></tr>\r\n <tr><td>5</td><td>        1911-7<a name=\"1911-7\"> </a></td><td>Clark's Point</td><td/></tr>\r\n <tr><td>5</td><td>        1912-5<a name=\"1912-5\"> </a></td><td>Crooked Creek</td><td/></tr>\r\n <tr><td>5</td><td>        1913-3<a name=\"1913-3\"> </a></td><td>Dillingham</td><td/></tr>\r\n <tr><td>5</td><td>        1914-1<a name=\"1914-1\"> </a></td><td>Eek</td><td/></tr>\r\n <tr><td>5</td><td>        1915-8<a name=\"1915-8\"> </a></td><td>Ekuk</td><td/></tr>\r\n <tr><td>5</td><td>        1916-6<a name=\"1916-6\"> </a></td><td>Ekwok</td><td/></tr>\r\n <tr><td>5</td><td>        1917-4<a name=\"1917-4\"> </a></td><td>Emmonak</td><td/></tr>\r\n <tr><td>5</td><td>        1918-2<a name=\"1918-2\"> </a></td><td>Goodnews Bay</td><td/></tr>\r\n <tr><td>5</td><td>        1919-0<a name=\"1919-0\"> </a></td><td>Hooper Bay</td><td/></tr>\r\n <tr><td>5</td><td>        1920-8<a name=\"1920-8\"> </a></td><td>Iqurmuit (Russian Mission)</td><td/></tr>\r\n <tr><td>5</td><td>        1921-6<a name=\"1921-6\"> </a></td><td>Kalskag</td><td/></tr>\r\n <tr><td>5</td><td>        1922-4<a name=\"1922-4\"> </a></td><td>Kasigluk</td><td/></tr>\r\n <tr><td>5</td><td>        1923-2<a name=\"1923-2\"> </a></td><td>Kipnuk</td><td/></tr>\r\n <tr><td>5</td><td>        1924-0<a name=\"1924-0\"> </a></td><td>Koliganek</td><td/></tr>\r\n <tr><td>5</td><td>        1925-7<a name=\"1925-7\"> </a></td><td>Kongiganak</td><td/></tr>\r\n <tr><td>5</td><td>        1926-5<a name=\"1926-5\"> </a></td><td>Kotlik</td><td/></tr>\r\n <tr><td>5</td><td>        1927-3<a name=\"1927-3\"> </a></td><td>Kwethluk</td><td/></tr>\r\n <tr><td>5</td><td>        1928-1<a name=\"1928-1\"> </a></td><td>Kwigillingok</td><td/></tr>\r\n <tr><td>5</td><td>        1929-9<a name=\"1929-9\"> </a></td><td>Levelock</td><td/></tr>\r\n <tr><td>5</td><td>        1930-7<a name=\"1930-7\"> </a></td><td>Lower Kalskag</td><td/></tr>\r\n <tr><td>5</td><td>        1931-5<a name=\"1931-5\"> </a></td><td>Manokotak</td><td/></tr>\r\n <tr><td>5</td><td>        1932-3<a name=\"1932-3\"> </a></td><td>Marshall</td><td/></tr>\r\n <tr><td>5</td><td>        1933-1<a name=\"1933-1\"> </a></td><td>Mekoryuk</td><td/></tr>\r\n <tr><td>5</td><td>        1934-9<a name=\"1934-9\"> </a></td><td>Mountain Village</td><td/></tr>\r\n <tr><td>5</td><td>        1935-6<a name=\"1935-6\"> </a></td><td>Naknek</td><td/></tr>\r\n <tr><td>5</td><td>        1936-4<a name=\"1936-4\"> </a></td><td>Napaumute</td><td/></tr>\r\n <tr><td>5</td><td>        1937-2<a name=\"1937-2\"> </a></td><td>Napakiak</td><td/></tr>\r\n <tr><td>5</td><td>        1938-0<a name=\"1938-0\"> </a></td><td>Napaskiak</td><td/></tr>\r\n <tr><td>5</td><td>        1939-8<a name=\"1939-8\"> </a></td><td>Newhalen</td><td/></tr>\r\n <tr><td>5</td><td>        1940-6<a name=\"1940-6\"> </a></td><td>New Stuyahok</td><td/></tr>\r\n <tr><td>5</td><td>        1941-4<a name=\"1941-4\"> </a></td><td>Newtok</td><td/></tr>\r\n <tr><td>5</td><td>        1942-2<a name=\"1942-2\"> </a></td><td>Nightmute</td><td/></tr>\r\n <tr><td>5</td><td>        1943-0<a name=\"1943-0\"> </a></td><td>Nunapitchukv</td><td/></tr>\r\n <tr><td>5</td><td>        1944-8<a name=\"1944-8\"> </a></td><td>Oscarville</td><td/></tr>\r\n <tr><td>5</td><td>        1945-5<a name=\"1945-5\"> </a></td><td>Pilot Station</td><td/></tr>\r\n <tr><td>5</td><td>        1946-3<a name=\"1946-3\"> </a></td><td>Pitkas Point</td><td/></tr>\r\n <tr><td>5</td><td>        1947-1<a name=\"1947-1\"> </a></td><td>Platinum</td><td/></tr>\r\n <tr><td>5</td><td>        1948-9<a name=\"1948-9\"> </a></td><td>Portage Creek</td><td/></tr>\r\n <tr><td>5</td><td>        1949-7<a name=\"1949-7\"> </a></td><td>Quinhagak</td><td/></tr>\r\n <tr><td>5</td><td>        1950-5<a name=\"1950-5\"> </a></td><td>Red Devil</td><td/></tr>\r\n <tr><td>5</td><td>        1951-3<a name=\"1951-3\"> </a></td><td>St. Michael</td><td/></tr>\r\n <tr><td>5</td><td>        1952-1<a name=\"1952-1\"> </a></td><td>Scammon Bay</td><td/></tr>\r\n <tr><td>5</td><td>        1953-9<a name=\"1953-9\"> </a></td><td>Sheldon's Point</td><td/></tr>\r\n <tr><td>5</td><td>        1954-7<a name=\"1954-7\"> </a></td><td>Sleetmute</td><td/></tr>\r\n <tr><td>5</td><td>        1955-4<a name=\"1955-4\"> </a></td><td>Stebbins</td><td/></tr>\r\n <tr><td>5</td><td>        1956-2<a name=\"1956-2\"> </a></td><td>Togiak</td><td/></tr>\r\n <tr><td>5</td><td>        1957-0<a name=\"1957-0\"> </a></td><td>Toksook</td><td/></tr>\r\n <tr><td>5</td><td>        1958-8<a name=\"1958-8\"> </a></td><td>Tulukskak</td><td/></tr>\r\n <tr><td>5</td><td>        1959-6<a name=\"1959-6\"> </a></td><td>Tuntutuliak</td><td/></tr>\r\n <tr><td>5</td><td>        1960-4<a name=\"1960-4\"> </a></td><td>Tununak</td><td/></tr>\r\n <tr><td>5</td><td>        1961-2<a name=\"1961-2\"> </a></td><td>Twin Hills</td><td/></tr>\r\n <tr><td>5</td><td>        1962-0<a name=\"1962-0\"> </a></td><td>Georgetown</td><td/></tr>\r\n <tr><td>5</td><td>        1963-8<a name=\"1963-8\"> </a></td><td>St. Mary's</td><td/></tr>\r\n <tr><td>5</td><td>        1964-6<a name=\"1964-6\"> </a></td><td>Umkumiate</td><td/></tr>\r\n <tr><td>3</td><td>    1966-1<a name=\"1966-1\"> </a></td><td>Aleut</td><td/></tr>\r\n <tr><td>4</td><td>      1968-7<a name=\"1968-7\"> </a></td><td>Alutiiq Aleut</td><td/></tr>\r\n <tr><td>5</td><td>        1969-5<a name=\"1969-5\"> </a></td><td>Tatitlek</td><td/></tr>\r\n <tr><td>5</td><td>        1970-3<a name=\"1970-3\"> </a></td><td>Ugashik</td><td/></tr>\r\n <tr><td>4</td><td>      1972-9<a name=\"1972-9\"> </a></td><td>Bristol Bay Aleut</td><td/></tr>\r\n <tr><td>5</td><td>        1973-7<a name=\"1973-7\"> </a></td><td>Chignik</td><td/></tr>\r\n <tr><td>5</td><td>        1974-5<a name=\"1974-5\"> </a></td><td>Chignik Lake</td><td/></tr>\r\n <tr><td>5</td><td>        1975-2<a name=\"1975-2\"> </a></td><td>Egegik</td><td/></tr>\r\n <tr><td>5</td><td>        1976-0<a name=\"1976-0\"> </a></td><td>Igiugig</td><td/></tr>\r\n <tr><td>5</td><td>        1977-8<a name=\"1977-8\"> </a></td><td>Ivanof Bay</td><td/></tr>\r\n <tr><td>5</td><td>        1978-6<a name=\"1978-6\"> </a></td><td>King Salmon</td><td/></tr>\r\n <tr><td>5</td><td>        1979-4<a name=\"1979-4\"> </a></td><td>Kokhanok</td><td/></tr>\r\n <tr><td>5</td><td>        1980-2<a name=\"1980-2\"> </a></td><td>Perryville</td><td/></tr>\r\n <tr><td>5</td><td>        1981-0<a name=\"1981-0\"> </a></td><td>Pilot Point</td><td/></tr>\r\n <tr><td>5</td><td>        1982-8<a name=\"1982-8\"> </a></td><td>Port Heiden</td><td/></tr>\r\n <tr><td>4</td><td>      1984-4<a name=\"1984-4\"> </a></td><td>Chugach Aleut</td><td/></tr>\r\n <tr><td>5</td><td>        1985-1<a name=\"1985-1\"> </a></td><td>Chenega</td><td/></tr>\r\n <tr><td>5</td><td>        1986-9<a name=\"1986-9\"> </a></td><td>Chugach Corporation</td><td/></tr>\r\n <tr><td>5</td><td>        1987-7<a name=\"1987-7\"> </a></td><td>English Bay</td><td/></tr>\r\n <tr><td>5</td><td>        1988-5<a name=\"1988-5\"> </a></td><td>Port Graham</td><td/></tr>\r\n <tr><td>4</td><td>      1990-1<a name=\"1990-1\"> </a></td><td>Eyak</td><td/></tr>\r\n <tr><td>4</td><td>      1992-7<a name=\"1992-7\"> </a></td><td>Koniag Aleut</td><td/></tr>\r\n <tr><td>5</td><td>        1993-5<a name=\"1993-5\"> </a></td><td>Akhiok</td><td/></tr>\r\n <tr><td>5</td><td>        1994-3<a name=\"1994-3\"> </a></td><td>Agdaagux</td><td/></tr>\r\n <tr><td>5</td><td>        1995-0<a name=\"1995-0\"> </a></td><td>Karluk</td><td/></tr>\r\n <tr><td>5</td><td>        1996-8<a name=\"1996-8\"> </a></td><td>Kodiak</td><td/></tr>\r\n <tr><td>5</td><td>        1997-6<a name=\"1997-6\"> </a></td><td>Larsen Bay</td><td/></tr>\r\n <tr><td>5</td><td>        1998-4<a name=\"1998-4\"> </a></td><td>Old Harbor</td><td/></tr>\r\n <tr><td>5</td><td>        1999-2<a name=\"1999-2\"> </a></td><td>Ouzinkie</td><td/></tr>\r\n <tr><td>5</td><td>        2000-8<a name=\"2000-8\"> </a></td><td>Port Lions</td><td/></tr>\r\n <tr><td>4</td><td>      2002-4<a name=\"2002-4\"> </a></td><td>Sugpiaq</td><td/></tr>\r\n <tr><td>4</td><td>      2004-0<a name=\"2004-0\"> </a></td><td>Suqpigaq</td><td/></tr>\r\n <tr><td>4</td><td>      2006-5<a name=\"2006-5\"> </a></td><td>Unangan Aleut</td><td/></tr>\r\n <tr><td>5</td><td>        2007-3<a name=\"2007-3\"> </a></td><td>Akutan</td><td/></tr>\r\n <tr><td>5</td><td>        2008-1<a name=\"2008-1\"> </a></td><td>Aleut Corporation</td><td/></tr>\r\n <tr><td>5</td><td>        2009-9<a name=\"2009-9\"> </a></td><td>Aleutian</td><td/></tr>\r\n <tr><td>5</td><td>        2010-7<a name=\"2010-7\"> </a></td><td>Aleutian Islander</td><td/></tr>\r\n <tr><td>5</td><td>        2011-5<a name=\"2011-5\"> </a></td><td>Atka</td><td/></tr>\r\n <tr><td>5</td><td>        2012-3<a name=\"2012-3\"> </a></td><td>Belkofski</td><td/></tr>\r\n <tr><td>5</td><td>        2013-1<a name=\"2013-1\"> </a></td><td>Chignik Lagoon</td><td/></tr>\r\n <tr><td>5</td><td>        2014-9<a name=\"2014-9\"> </a></td><td>King Cove</td><td/></tr>\r\n <tr><td>5</td><td>        2015-6<a name=\"2015-6\"> </a></td><td>False Pass</td><td/></tr>\r\n <tr><td>5</td><td>        2016-4<a name=\"2016-4\"> </a></td><td>Nelson Lagoon</td><td/></tr>\r\n <tr><td>5</td><td>        2017-2<a name=\"2017-2\"> </a></td><td>Nikolski</td><td/></tr>\r\n <tr><td>5</td><td>        2018-0<a name=\"2018-0\"> </a></td><td>Pauloff Harbor</td><td/></tr>\r\n <tr><td>5</td><td>        2019-8<a name=\"2019-8\"> </a></td><td>Qagan Toyagungin</td><td/></tr>\r\n <tr><td>5</td><td>        2020-6<a name=\"2020-6\"> </a></td><td>Qawalangin</td><td/></tr>\r\n <tr><td>5</td><td>        2021-4<a name=\"2021-4\"> </a></td><td>St. George</td><td/></tr>\r\n <tr><td>5</td><td>        2022-2<a name=\"2022-2\"> </a></td><td>St. Paul</td><td/></tr>\r\n <tr><td>5</td><td>        2023-0<a name=\"2023-0\"> </a></td><td>Sand Point</td><td/></tr>\r\n <tr><td>5</td><td>        2024-8<a name=\"2024-8\"> </a></td><td>South Naknek</td><td/></tr>\r\n <tr><td>5</td><td>        2025-5<a name=\"2025-5\"> </a></td><td>Unalaska</td><td/></tr>\r\n <tr><td>5</td><td>        2026-3<a name=\"2026-3\"> </a></td><td>Unga</td><td/></tr>\r\n <tr><td>1</td><td>2028-9<a name=\"2028-9\"> </a></td><td>Asian</td><td/></tr>\r\n <tr><td>2</td><td>  2029-7<a name=\"2029-7\"> </a></td><td>Asian Indian</td><td/></tr>\r\n <tr><td>2</td><td>  2030-5<a name=\"2030-5\"> </a></td><td>Bangladeshi</td><td/></tr>\r\n <tr><td>2</td><td>  2031-3<a name=\"2031-3\"> </a></td><td>Bhutanese</td><td/></tr>\r\n <tr><td>2</td><td>  2032-1<a name=\"2032-1\"> </a></td><td>Burmese</td><td/></tr>\r\n <tr><td>2</td><td>  2033-9<a name=\"2033-9\"> </a></td><td>Cambodian</td><td/></tr>\r\n <tr><td>2</td><td>  2034-7<a name=\"2034-7\"> </a></td><td>Chinese</td><td/></tr>\r\n <tr><td>2</td><td>  2035-4<a name=\"2035-4\"> </a></td><td>Taiwanese</td><td/></tr>\r\n <tr><td>2</td><td>  2036-2<a name=\"2036-2\"> </a></td><td>Filipino</td><td/></tr>\r\n <tr><td>2</td><td>  2037-0<a name=\"2037-0\"> </a></td><td>Hmong</td><td/></tr>\r\n <tr><td>2</td><td>  2038-8<a name=\"2038-8\"> </a></td><td>Indonesian</td><td/></tr>\r\n <tr><td>2</td><td>  2039-6<a name=\"2039-6\"> </a></td><td>Japanese</td><td/></tr>\r\n <tr><td>2</td><td>  2040-4<a name=\"2040-4\"> </a></td><td>Korean</td><td/></tr>\r\n <tr><td>2</td><td>  2041-2<a name=\"2041-2\"> </a></td><td>Laotian</td><td/></tr>\r\n <tr><td>2</td><td>  2042-0<a name=\"2042-0\"> </a></td><td>Malaysian</td><td/></tr>\r\n <tr><td>2</td><td>  2043-8<a name=\"2043-8\"> </a></td><td>Okinawan</td><td/></tr>\r\n <tr><td>2</td><td>  2044-6<a name=\"2044-6\"> </a></td><td>Pakistani</td><td/></tr>\r\n <tr><td>2</td><td>  2045-3<a name=\"2045-3\"> </a></td><td>Sri Lankan</td><td/></tr>\r\n <tr><td>2</td><td>  2046-1<a name=\"2046-1\"> </a></td><td>Thai</td><td/></tr>\r\n <tr><td>2</td><td>  2047-9<a name=\"2047-9\"> </a></td><td>Vietnamese</td><td/></tr>\r\n <tr><td>2</td><td>  2048-7<a name=\"2048-7\"> </a></td><td>Iwo Jiman</td><td/></tr>\r\n <tr><td>2</td><td>  2049-5<a name=\"2049-5\"> </a></td><td>Maldivian</td><td/></tr>\r\n <tr><td>2</td><td>  2050-3<a name=\"2050-3\"> </a></td><td>Nepalese</td><td/></tr>\r\n <tr><td>2</td><td>  2051-1<a name=\"2051-1\"> </a></td><td>Singaporean</td><td/></tr>\r\n <tr><td>2</td><td>  2052-9<a name=\"2052-9\"> </a></td><td>Madagascar</td><td/></tr>\r\n <tr><td>1</td><td>2054-5<a name=\"2054-5\"> </a></td><td>Black or African American</td><td/></tr>\r\n <tr><td>2</td><td>  2056-0<a name=\"2056-0\"> </a></td><td>Black</td><td/></tr>\r\n <tr><td>2</td><td>  2058-6<a name=\"2058-6\"> </a></td><td>African American</td><td/></tr>\r\n <tr><td>2</td><td>  2060-2<a name=\"2060-2\"> </a></td><td>African</td><td/></tr>\r\n <tr><td>3</td><td>    2061-0<a name=\"2061-0\"> </a></td><td>Botswanan</td><td/></tr>\r\n <tr><td>3</td><td>    2062-8<a name=\"2062-8\"> </a></td><td>Ethiopian</td><td/></tr>\r\n <tr><td>3</td><td>    2063-6<a name=\"2063-6\"> </a></td><td>Liberian</td><td/></tr>\r\n <tr><td>3</td><td>    2064-4<a name=\"2064-4\"> </a></td><td>Namibian</td><td/></tr>\r\n <tr><td>3</td><td>    2065-1<a name=\"2065-1\"> </a></td><td>Nigerian</td><td/></tr>\r\n <tr><td>3</td><td>    2066-9<a name=\"2066-9\"> </a></td><td>Zairean</td><td/></tr>\r\n <tr><td>2</td><td>  2067-7<a name=\"2067-7\"> </a></td><td>Bahamian</td><td/></tr>\r\n <tr><td>2</td><td>  2068-5<a name=\"2068-5\"> </a></td><td>Barbadian</td><td/></tr>\r\n <tr><td>2</td><td>  2069-3<a name=\"2069-3\"> </a></td><td>Dominican</td><td/></tr>\r\n <tr><td>2</td><td>  2070-1<a name=\"2070-1\"> </a></td><td>Dominica Islander</td><td/></tr>\r\n <tr><td>2</td><td>  2071-9<a name=\"2071-9\"> </a></td><td>Haitian</td><td/></tr>\r\n <tr><td>2</td><td>  2072-7<a name=\"2072-7\"> </a></td><td>Jamaican</td><td/></tr>\r\n <tr><td>2</td><td>  2073-5<a name=\"2073-5\"> </a></td><td>Tobagoan</td><td/></tr>\r\n <tr><td>2</td><td>  2074-3<a name=\"2074-3\"> </a></td><td>Trinidadian</td><td/></tr>\r\n <tr><td>2</td><td>  2075-0<a name=\"2075-0\"> </a></td><td>West Indian</td><td/></tr>\r\n <tr><td>1</td><td>2076-8<a name=\"2076-8\"> </a></td><td>Native Hawaiian or Other Pacific Islander</td><td/></tr>\r\n <tr><td>2</td><td>  2078-4<a name=\"2078-4\"> </a></td><td>Polynesian</td><td/></tr>\r\n <tr><td>3</td><td>    2079-2<a name=\"2079-2\"> </a></td><td>Native Hawaiian</td><td/></tr>\r\n <tr><td>3</td><td>    2080-0<a name=\"2080-0\"> </a></td><td>Samoan</td><td/></tr>\r\n <tr><td>3</td><td>    2081-8<a name=\"2081-8\"> </a></td><td>Tahitian</td><td/></tr>\r\n <tr><td>3</td><td>    2082-6<a name=\"2082-6\"> </a></td><td>Tongan</td><td/></tr>\r\n <tr><td>3</td><td>    2083-4<a name=\"2083-4\"> </a></td><td>Tokelauan</td><td/></tr>\r\n <tr><td>2</td><td>  2085-9<a name=\"2085-9\"> </a></td><td>Micronesian</td><td/></tr>\r\n <tr><td>3</td><td>    2086-7<a name=\"2086-7\"> </a></td><td>Guamanian or Chamorro</td><td/></tr>\r\n <tr><td>3</td><td>    2087-5<a name=\"2087-5\"> </a></td><td>Guamanian</td><td/></tr>\r\n <tr><td>3</td><td>    2088-3<a name=\"2088-3\"> </a></td><td>Chamorro</td><td/></tr>\r\n <tr><td>3</td><td>    2089-1<a name=\"2089-1\"> </a></td><td>Mariana Islander</td><td/></tr>\r\n <tr><td>3</td><td>    2090-9<a name=\"2090-9\"> </a></td><td>Marshallese</td><td/></tr>\r\n <tr><td>3</td><td>    2091-7<a name=\"2091-7\"> </a></td><td>Palauan</td><td/></tr>\r\n <tr><td>3</td><td>    2092-5<a name=\"2092-5\"> </a></td><td>Carolinian</td><td/></tr>\r\n <tr><td>3</td><td>    2093-3<a name=\"2093-3\"> </a></td><td>Kosraean</td><td/></tr>\r\n <tr><td>3</td><td>    2094-1<a name=\"2094-1\"> </a></td><td>Pohnpeian</td><td/></tr>\r\n <tr><td>3</td><td>    2095-8<a name=\"2095-8\"> </a></td><td>Saipanese</td><td/></tr>\r\n <tr><td>3</td><td>    2096-6<a name=\"2096-6\"> </a></td><td>Kiribati</td><td/></tr>\r\n <tr><td>3</td><td>    2097-4<a name=\"2097-4\"> </a></td><td>Chuukese</td><td/></tr>\r\n <tr><td>3</td><td>    2098-2<a name=\"2098-2\"> </a></td><td>Yapese</td><td/></tr>\r\n <tr><td>2</td><td>  2100-6<a name=\"2100-6\"> </a></td><td>Melanesian</td><td/></tr>\r\n <tr><td>3</td><td>    2101-4<a name=\"2101-4\"> </a></td><td>Fijian</td><td/></tr>\r\n <tr><td>3</td><td>    2102-2<a name=\"2102-2\"> </a></td><td>Papua New Guinean</td><td/></tr>\r\n <tr><td>3</td><td>    2103-0<a name=\"2103-0\"> </a></td><td>Solomon Islander</td><td/></tr>\r\n <tr><td>3</td><td>    2104-8<a name=\"2104-8\"> </a></td><td>New Hebrides</td><td/></tr>\r\n <tr><td>2</td><td>  2500-7<a name=\"2500-7\"> </a></td><td>Other Pacific Islander</td><td>\n                        Note that this term remains in the table for completeness, even though within HL7, the notion of Other code is deprecated.<br/>\r\n\n                     </td></tr>\r\n <tr><td>1</td><td>2106-3<a name=\"2106-3\"> </a></td><td>White</td><td/></tr>\r\n <tr><td>2</td><td>  2108-9<a name=\"2108-9\"> </a></td><td>European</td><td/></tr>\r\n <tr><td>3</td><td>    2109-7<a name=\"2109-7\"> </a></td><td>Armenian</td><td/></tr>\r\n <tr><td>3</td><td>    2110-5<a name=\"2110-5\"> </a></td><td>English</td><td/></tr>\r\n <tr><td>3</td><td>    2111-3<a name=\"2111-3\"> </a></td><td>French</td><td/></tr>\r\n <tr><td>3</td><td>    2112-1<a name=\"2112-1\"> </a></td><td>German</td><td/></tr>\r\n <tr><td>3</td><td>    2113-9<a name=\"2113-9\"> </a></td><td>Irish</td><td/></tr>\r\n <tr><td>3</td><td>    2114-7<a name=\"2114-7\"> </a></td><td>Italian</td><td/></tr>\r\n <tr><td>3</td><td>    2115-4<a name=\"2115-4\"> </a></td><td>Polish</td><td/></tr>\r\n <tr><td>3</td><td>    2116-2<a name=\"2116-2\"> </a></td><td>Scottish</td><td/></tr>\r\n <tr><td>2</td><td>  2118-8<a name=\"2118-8\"> </a></td><td>Middle Eastern or North African</td><td/></tr>\r\n <tr><td>3</td><td>    2119-6<a name=\"2119-6\"> </a></td><td>Assyrian</td><td/></tr>\r\n <tr><td>3</td><td>    2120-4<a name=\"2120-4\"> </a></td><td>Egyptian</td><td/></tr>\r\n <tr><td>3</td><td>    2121-2<a name=\"2121-2\"> </a></td><td>Iranian</td><td/></tr>\r\n <tr><td>3</td><td>    2122-0<a name=\"2122-0\"> </a></td><td>Iraqi</td><td/></tr>\r\n <tr><td>3</td><td>    2123-8<a name=\"2123-8\"> </a></td><td>Lebanese</td><td/></tr>\r\n <tr><td>3</td><td>    2124-6<a name=\"2124-6\"> </a></td><td>Palestinian</td><td/></tr>\r\n <tr><td>3</td><td>    2125-3<a name=\"2125-3\"> </a></td><td>Syrian</td><td/></tr>\r\n <tr><td>3</td><td>    2126-1<a name=\"2126-1\"> </a></td><td>Afghanistani</td><td/></tr>\r\n <tr><td>3</td><td>    2127-9<a name=\"2127-9\"> </a></td><td>Israeili</td><td/></tr>\r\n <tr><td>2</td><td>  2129-5<a name=\"2129-5\"> </a></td><td>Arab</td><td/></tr>\r\n <tr><td>1</td><td>2131-1<a name=\"2131-1\"> </a></td><td>Other Race</td><td>\n                        Note that this term remains in the table for completeness, even though within HL7, the notion of Other code is deprecated.<br/>\r\n\n                     </td></tr>\r\n</table>\r\n</div>"
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-ballot-status",
+      "valueString": "External"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+      "valueInteger": 0
+    }
+  ],
+  "url": "http://hl7.org/fhir/v3/Race",
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:oid:2.16.840.1.113883.5.104"
+  },
+  "version": "2016-11-11",
+  "name": "v3 Code System Race",
+  "status": "active",
+  "experimental": false,
+  "date": "2016-11-11T00:00:00+11:00",
+  "publisher": "HL7, Inc",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://hl7.org"
+        }
+      ]
+    }
+  ],
+  "description": " In the United States, federal standards for classifying data on race determine the categories used by federal agencies and exert a strong influence on categorization by state and local agencies and private sector organizations.  The federal standards do not conceptually define race, and they recognize the absence of an anthropological or scientific basis for racial classification.  Instead, the federal standards acknowledge that race is a social-political construct in which an individual's own identification with one more race categories is preferred to observer identification. The standards use a variety of features to define five minimum race categories. Among these features are descent from \"the original peoples\" of a specified region or nation.  The minimum race categories are American Indian or Alaska Native, Asian, Black or African American, Native Hawaiian or Other Pacific Islander, and White.  The federal standards stipulate that race data need not be limited to the five minimum categories, but any expansion must be collapsible to those categories.",
+  "caseSensitive": true,
+  "valueSet": "http://hl7.org/fhir/ValueSet/v3-Race",
+  "hierarchyMeaning": "is-a",
+  "content": "complete",
+  "concept": [
+    {
+      "code": "1002-5",
+      "display": "American Indian or Alaska Native",
+      "definition": "American Indian or Alaska Native",
+      "concept": [
+        {
+          "code": "1004-1",
+          "display": "American Indian",
+          "definition": "American Indian",
+          "concept": [
+            {
+              "code": "1006-6",
+              "display": "Abenaki",
+              "definition": "Abenaki"
+            },
+            {
+              "code": "1008-2",
+              "display": "Algonquian",
+              "definition": "Algonquian"
+            },
+            {
+              "code": "1010-8",
+              "display": "Apache",
+              "definition": "Apache",
+              "concept": [
+                {
+                  "code": "1011-6",
+                  "display": "Chiricahua",
+                  "definition": "Chiricahua"
+                },
+                {
+                  "code": "1012-4",
+                  "display": "Fort Sill Apache",
+                  "definition": "Fort Sill Apache"
+                },
+                {
+                  "code": "1013-2",
+                  "display": "Jicarilla Apache",
+                  "definition": "Jicarilla Apache"
+                },
+                {
+                  "code": "1014-0",
+                  "display": "Lipan Apache",
+                  "definition": "Lipan Apache"
+                },
+                {
+                  "code": "1015-7",
+                  "display": "Mescalero Apache",
+                  "definition": "Mescalero Apache"
+                },
+                {
+                  "code": "1016-5",
+                  "display": "Oklahoma Apache",
+                  "definition": "Oklahoma Apache"
+                },
+                {
+                  "code": "1017-3",
+                  "display": "Payson Apache",
+                  "definition": "Payson Apache"
+                },
+                {
+                  "code": "1018-1",
+                  "display": "San Carlos Apache",
+                  "definition": "San Carlos Apache"
+                },
+                {
+                  "code": "1019-9",
+                  "display": "White Mountain Apache",
+                  "definition": "White Mountain Apache"
+                }
+              ]
+            },
+            {
+              "code": "1021-5",
+              "display": "Arapaho",
+              "definition": "Arapaho",
+              "concept": [
+                {
+                  "code": "1022-3",
+                  "display": "Northern Arapaho",
+                  "definition": "Northern Arapaho"
+                },
+                {
+                  "code": "1023-1",
+                  "display": "Southern Arapaho",
+                  "definition": "Southern Arapaho"
+                },
+                {
+                  "code": "1024-9",
+                  "display": "Wind River Arapaho",
+                  "definition": "Wind River Arapaho"
+                }
+              ]
+            },
+            {
+              "code": "1026-4",
+              "display": "Arikara",
+              "definition": "Arikara"
+            },
+            {
+              "code": "1028-0",
+              "display": "Assiniboine",
+              "definition": "Assiniboine"
+            },
+            {
+              "code": "1030-6",
+              "display": "Assiniboine Sioux",
+              "definition": "Assiniboine Sioux",
+              "concept": [
+                {
+                  "code": "1031-4",
+                  "display": "Fort Peck Assiniboine Sioux",
+                  "definition": "Fort Peck Assiniboine Sioux"
+                }
+              ]
+            },
+            {
+              "code": "1033-0",
+              "display": "Bannock",
+              "definition": "Bannock"
+            },
+            {
+              "code": "1035-5",
+              "display": "Blackfeet",
+              "definition": "Blackfeet"
+            },
+            {
+              "code": "1037-1",
+              "display": "Brotherton",
+              "definition": "Brotherton"
+            },
+            {
+              "code": "1039-7",
+              "display": "Burt Lake Band",
+              "definition": "Burt Lake Band"
+            },
+            {
+              "code": "1041-3",
+              "display": "Caddo",
+              "definition": "Caddo",
+              "concept": [
+                {
+                  "code": "1042-1",
+                  "display": "Oklahoma Cado",
+                  "definition": "Oklahoma Cado"
+                }
+              ]
+            },
+            {
+              "code": "1044-7",
+              "display": "Cahuilla",
+              "definition": "Cahuilla",
+              "concept": [
+                {
+                  "code": "1045-4",
+                  "display": "Agua Caliente Cahuilla",
+                  "definition": "Agua Caliente Cahuilla"
+                },
+                {
+                  "code": "1046-2",
+                  "display": "Augustine",
+                  "definition": "Augustine"
+                },
+                {
+                  "code": "1047-0",
+                  "display": "Cabazon",
+                  "definition": "Cabazon"
+                },
+                {
+                  "code": "1048-8",
+                  "display": "Los Coyotes",
+                  "definition": "Los Coyotes"
+                },
+                {
+                  "code": "1049-6",
+                  "display": "Morongo",
+                  "definition": "Morongo"
+                },
+                {
+                  "code": "1050-4",
+                  "display": "Santa Rosa Cahuilla",
+                  "definition": "Santa Rosa Cahuilla"
+                },
+                {
+                  "code": "1051-2",
+                  "display": "Torres-Martinez",
+                  "definition": "Torres-Martinez"
+                }
+              ]
+            },
+            {
+              "code": "1053-8",
+              "display": "California Tribes",
+              "definition": "California Tribes",
+              "concept": [
+                {
+                  "code": "1054-6",
+                  "display": "Cahto",
+                  "definition": "Cahto"
+                },
+                {
+                  "code": "1055-3",
+                  "display": "Chimariko",
+                  "definition": "Chimariko"
+                },
+                {
+                  "code": "1056-1",
+                  "display": "Coast Miwok",
+                  "definition": "Coast Miwok"
+                },
+                {
+                  "code": "1057-9",
+                  "display": "Digger",
+                  "definition": "Digger"
+                },
+                {
+                  "code": "1058-7",
+                  "display": "Kawaiisu",
+                  "definition": "Kawaiisu"
+                },
+                {
+                  "code": "1059-5",
+                  "display": "Kern River",
+                  "definition": "Kern River"
+                },
+                {
+                  "code": "1060-3",
+                  "display": "Mattole",
+                  "definition": "Mattole"
+                },
+                {
+                  "code": "1061-1",
+                  "display": "Red Wood",
+                  "definition": "Red Wood"
+                },
+                {
+                  "code": "1062-9",
+                  "display": "Santa Rosa",
+                  "definition": "Santa Rosa"
+                },
+                {
+                  "code": "1063-7",
+                  "display": "Takelma",
+                  "definition": "Takelma"
+                },
+                {
+                  "code": "1064-5",
+                  "display": "Wappo",
+                  "definition": "Wappo"
+                },
+                {
+                  "code": "1065-2",
+                  "display": "Yana",
+                  "definition": "Yana"
+                },
+                {
+                  "code": "1066-0",
+                  "display": "Yuki",
+                  "definition": "Yuki"
+                }
+              ]
+            },
+            {
+              "code": "1068-6",
+              "display": "Canadian and Latin American Indian",
+              "definition": "Canadian and Latin American Indian",
+              "concept": [
+                {
+                  "code": "1069-4",
+                  "display": "Canadian Indian",
+                  "definition": "Canadian Indian"
+                },
+                {
+                  "code": "1070-2",
+                  "display": "Central American Indian",
+                  "definition": "Central American Indian"
+                },
+                {
+                  "code": "1071-0",
+                  "display": "French American Indian",
+                  "definition": "French American Indian"
+                },
+                {
+                  "code": "1072-8",
+                  "display": "Mexican American Indian",
+                  "definition": "Mexican American Indian"
+                },
+                {
+                  "code": "1073-6",
+                  "display": "South American Indian",
+                  "definition": "South American Indian"
+                }
+              ]
+            },
+            {
+              "code": "1074-4",
+              "display": "Spanish American Indian",
+              "definition": "Spanish American Indian"
+            },
+            {
+              "code": "1076-9",
+              "display": "Catawba",
+              "definition": "Catawba",
+              "concept": [
+                {
+                  "code": "1741-8",
+                  "display": "Alatna",
+                  "definition": "Alatna"
+                },
+                {
+                  "code": "1742-6",
+                  "display": "Alexander",
+                  "definition": "Alexander"
+                },
+                {
+                  "code": "1743-4",
+                  "display": "Allakaket",
+                  "definition": "Allakaket"
+                },
+                {
+                  "code": "1744-2",
+                  "display": "Alanvik",
+                  "definition": "Alanvik"
+                },
+                {
+                  "code": "1745-9",
+                  "display": "Anvik",
+                  "definition": "Anvik"
+                },
+                {
+                  "code": "1746-7",
+                  "display": "Arctic",
+                  "definition": "Arctic"
+                },
+                {
+                  "code": "1747-5",
+                  "display": "Beaver",
+                  "definition": "Beaver"
+                },
+                {
+                  "code": "1748-3",
+                  "display": "Birch Creek",
+                  "definition": "Birch Creek"
+                },
+                {
+                  "code": "1749-1",
+                  "display": "Cantwell",
+                  "definition": "Cantwell"
+                },
+                {
+                  "code": "1750-9",
+                  "display": "Chalkyitsik",
+                  "definition": "Chalkyitsik"
+                },
+                {
+                  "code": "1751-7",
+                  "display": "Chickaloon",
+                  "definition": "Chickaloon"
+                },
+                {
+                  "code": "1752-5",
+                  "display": "Chistochina",
+                  "definition": "Chistochina"
+                },
+                {
+                  "code": "1753-3",
+                  "display": "Chitina",
+                  "definition": "Chitina"
+                },
+                {
+                  "code": "1754-1",
+                  "display": "Circle",
+                  "definition": "Circle"
+                },
+                {
+                  "code": "1755-8",
+                  "display": "Cook Inlet",
+                  "definition": "Cook Inlet"
+                },
+                {
+                  "code": "1756-6",
+                  "display": "Copper Center",
+                  "definition": "Copper Center"
+                },
+                {
+                  "code": "1757-4",
+                  "display": "Copper River",
+                  "definition": "Copper River"
+                },
+                {
+                  "code": "1758-2",
+                  "display": "Dot Lake",
+                  "definition": "Dot Lake"
+                },
+                {
+                  "code": "1759-0",
+                  "display": "Doyon",
+                  "definition": "Doyon"
+                },
+                {
+                  "code": "1760-8",
+                  "display": "Eagle",
+                  "definition": "Eagle"
+                },
+                {
+                  "code": "1761-6",
+                  "display": "Eklutna",
+                  "definition": "Eklutna"
+                },
+                {
+                  "code": "1762-4",
+                  "display": "Evansville",
+                  "definition": "Evansville"
+                },
+                {
+                  "code": "1763-2",
+                  "display": "Fort Yukon",
+                  "definition": "Fort Yukon"
+                },
+                {
+                  "code": "1764-0",
+                  "display": "Gakona",
+                  "definition": "Gakona"
+                },
+                {
+                  "code": "1765-7",
+                  "display": "Galena",
+                  "definition": "Galena"
+                },
+                {
+                  "code": "1766-5",
+                  "display": "Grayling",
+                  "definition": "Grayling"
+                },
+                {
+                  "code": "1767-3",
+                  "display": "Gulkana",
+                  "definition": "Gulkana"
+                },
+                {
+                  "code": "1768-1",
+                  "display": "Healy Lake",
+                  "definition": "Healy Lake"
+                },
+                {
+                  "code": "1769-9",
+                  "display": "Holy Cross",
+                  "definition": "Holy Cross"
+                },
+                {
+                  "code": "1770-7",
+                  "display": "Hughes",
+                  "definition": "Hughes"
+                },
+                {
+                  "code": "1771-5",
+                  "display": "Huslia",
+                  "definition": "Huslia"
+                },
+                {
+                  "code": "1772-3",
+                  "display": "Iliamna",
+                  "definition": "Iliamna"
+                },
+                {
+                  "code": "1773-1",
+                  "display": "Kaltag",
+                  "definition": "Kaltag"
+                },
+                {
+                  "code": "1774-9",
+                  "display": "Kluti Kaah",
+                  "definition": "Kluti Kaah"
+                },
+                {
+                  "code": "1775-6",
+                  "display": "Knik",
+                  "definition": "Knik"
+                },
+                {
+                  "code": "1776-4",
+                  "display": "Koyukuk",
+                  "definition": "Koyukuk"
+                },
+                {
+                  "code": "1777-2",
+                  "display": "Lake Minchumina",
+                  "definition": "Lake Minchumina"
+                },
+                {
+                  "code": "1778-0",
+                  "display": "Lime",
+                  "definition": "Lime"
+                },
+                {
+                  "code": "1779-8",
+                  "display": "Mcgrath",
+                  "definition": "Mcgrath"
+                },
+                {
+                  "code": "1780-6",
+                  "display": "Manley Hot Springs",
+                  "definition": "Manley Hot Springs"
+                },
+                {
+                  "code": "1781-4",
+                  "display": "Mentasta Lake",
+                  "definition": "Mentasta Lake"
+                },
+                {
+                  "code": "1782-2",
+                  "display": "Minto",
+                  "definition": "Minto"
+                },
+                {
+                  "code": "1783-0",
+                  "display": "Nenana",
+                  "definition": "Nenana"
+                },
+                {
+                  "code": "1784-8",
+                  "display": "Nikolai",
+                  "definition": "Nikolai"
+                },
+                {
+                  "code": "1785-5",
+                  "display": "Ninilchik",
+                  "definition": "Ninilchik"
+                },
+                {
+                  "code": "1786-3",
+                  "display": "Nondalton",
+                  "definition": "Nondalton"
+                },
+                {
+                  "code": "1787-1",
+                  "display": "Northway",
+                  "definition": "Northway"
+                },
+                {
+                  "code": "1788-9",
+                  "display": "Nulato",
+                  "definition": "Nulato"
+                },
+                {
+                  "code": "1789-7",
+                  "display": "Pedro Bay",
+                  "definition": "Pedro Bay"
+                },
+                {
+                  "code": "1790-5",
+                  "display": "Rampart",
+                  "definition": "Rampart"
+                },
+                {
+                  "code": "1791-3",
+                  "display": "Ruby",
+                  "definition": "Ruby"
+                },
+                {
+                  "code": "1792-1",
+                  "display": "Salamatof",
+                  "definition": "Salamatof"
+                },
+                {
+                  "code": "1793-9",
+                  "display": "Seldovia",
+                  "definition": "Seldovia"
+                },
+                {
+                  "code": "1794-7",
+                  "display": "Slana",
+                  "definition": "Slana"
+                },
+                {
+                  "code": "1795-4",
+                  "display": "Shageluk",
+                  "definition": "Shageluk"
+                },
+                {
+                  "code": "1796-2",
+                  "display": "Stevens",
+                  "definition": "Stevens"
+                },
+                {
+                  "code": "1797-0",
+                  "display": "Stony River",
+                  "definition": "Stony River"
+                },
+                {
+                  "code": "1798-8",
+                  "display": "Takotna",
+                  "definition": "Takotna"
+                },
+                {
+                  "code": "1799-6",
+                  "display": "Tanacross",
+                  "definition": "Tanacross"
+                },
+                {
+                  "code": "1800-2",
+                  "display": "Tanaina",
+                  "definition": "Tanaina"
+                },
+                {
+                  "code": "1801-0",
+                  "display": "Tanana",
+                  "definition": "Tanana"
+                },
+                {
+                  "code": "1802-8",
+                  "display": "Tanana Chiefs",
+                  "definition": "Tanana Chiefs"
+                },
+                {
+                  "code": "1803-6",
+                  "display": "Tazlina",
+                  "definition": "Tazlina"
+                },
+                {
+                  "code": "1804-4",
+                  "display": "Telida",
+                  "definition": "Telida"
+                },
+                {
+                  "code": "1805-1",
+                  "display": "Tetlin",
+                  "definition": "Tetlin"
+                },
+                {
+                  "code": "1806-9",
+                  "display": "Tok",
+                  "definition": "Tok"
+                },
+                {
+                  "code": "1807-7",
+                  "display": "Tyonek",
+                  "definition": "Tyonek"
+                },
+                {
+                  "code": "1808-5",
+                  "display": "Venetie",
+                  "definition": "Venetie"
+                },
+                {
+                  "code": "1809-3",
+                  "display": "Wiseman",
+                  "definition": "Wiseman"
+                }
+              ]
+            },
+            {
+              "code": "1078-5",
+              "display": "Cayuse",
+              "definition": "Cayuse"
+            },
+            {
+              "code": "1080-1",
+              "display": "Chehalis",
+              "definition": "Chehalis"
+            },
+            {
+              "code": "1082-7",
+              "display": "Chemakuan",
+              "definition": "Chemakuan",
+              "concept": [
+                {
+                  "code": "1083-5",
+                  "display": "Hoh",
+                  "definition": "Hoh"
+                },
+                {
+                  "code": "1084-3",
+                  "display": "Quileute",
+                  "definition": "Quileute"
+                }
+              ]
+            },
+            {
+              "code": "1086-8",
+              "display": "Chemehuevi",
+              "definition": "Chemehuevi"
+            },
+            {
+              "code": "1088-4",
+              "display": "Cherokee",
+              "definition": "Cherokee",
+              "concept": [
+                {
+                  "code": "1089-2",
+                  "display": "Cherokee Alabama",
+                  "definition": "Cherokee Alabama"
+                },
+                {
+                  "code": "1090-0",
+                  "display": "Cherokees of Northeast Alabama",
+                  "definition": "Cherokees of Northeast Alabama"
+                },
+                {
+                  "code": "1091-8",
+                  "display": "Cherokees of Southeast Alabama",
+                  "definition": "Cherokees of Southeast Alabama"
+                },
+                {
+                  "code": "1092-6",
+                  "display": "Eastern Cherokee",
+                  "definition": "Eastern Cherokee"
+                },
+                {
+                  "code": "1093-4",
+                  "display": "Echota Cherokee",
+                  "definition": "Echota Cherokee"
+                },
+                {
+                  "code": "1094-2",
+                  "display": "Etowah Cherokee",
+                  "definition": "Etowah Cherokee"
+                },
+                {
+                  "code": "1095-9",
+                  "display": "Northern Cherokee",
+                  "definition": "Northern Cherokee"
+                },
+                {
+                  "code": "1096-7",
+                  "display": "Tuscola",
+                  "definition": "Tuscola"
+                },
+                {
+                  "code": "1097-5",
+                  "display": "United Keetowah Band of Cherokee",
+                  "definition": "United Keetowah Band of Cherokee"
+                },
+                {
+                  "code": "1098-3",
+                  "display": "Western Cherokee",
+                  "definition": "Western Cherokee"
+                }
+              ]
+            },
+            {
+              "code": "1100-7",
+              "display": "Cherokee Shawnee",
+              "definition": "Cherokee Shawnee"
+            },
+            {
+              "code": "1102-3",
+              "display": "Cheyenne",
+              "definition": "Cheyenne",
+              "concept": [
+                {
+                  "code": "1103-1",
+                  "display": "Northern Cheyenne",
+                  "definition": "Northern Cheyenne"
+                },
+                {
+                  "code": "1104-9",
+                  "display": "Southern Cheyenne",
+                  "definition": "Southern Cheyenne"
+                }
+              ]
+            },
+            {
+              "code": "1106-4",
+              "display": "Cheyenne-Arapaho",
+              "definition": "Cheyenne-Arapaho"
+            },
+            {
+              "code": "1108-0",
+              "display": "Chickahominy",
+              "definition": "Chickahominy",
+              "concept": [
+                {
+                  "code": "1109-8",
+                  "display": "Eastern Chickahominy",
+                  "definition": "Eastern Chickahominy"
+                },
+                {
+                  "code": "1110-6",
+                  "display": "Western Chickahominy",
+                  "definition": "Western Chickahominy"
+                }
+              ]
+            },
+            {
+              "code": "1112-2",
+              "display": "Chickasaw",
+              "definition": "Chickasaw"
+            },
+            {
+              "code": "1114-8",
+              "display": "Chinook",
+              "definition": "Chinook",
+              "concept": [
+                {
+                  "code": "1115-5",
+                  "display": "Clatsop",
+                  "definition": "Clatsop"
+                },
+                {
+                  "code": "1116-3",
+                  "display": "Columbia River Chinook",
+                  "definition": "Columbia River Chinook"
+                },
+                {
+                  "code": "1117-1",
+                  "display": "Kathlamet",
+                  "definition": "Kathlamet"
+                },
+                {
+                  "code": "1118-9",
+                  "display": "Upper Chinook",
+                  "definition": "Upper Chinook"
+                },
+                {
+                  "code": "1119-7",
+                  "display": "Wakiakum Chinook",
+                  "definition": "Wakiakum Chinook"
+                },
+                {
+                  "code": "1120-5",
+                  "display": "Willapa Chinook",
+                  "definition": "Willapa Chinook"
+                },
+                {
+                  "code": "1121-3",
+                  "display": "Wishram",
+                  "definition": "Wishram"
+                }
+              ]
+            },
+            {
+              "code": "1123-9",
+              "display": "Chippewa",
+              "definition": "Chippewa",
+              "concept": [
+                {
+                  "code": "1124-7",
+                  "display": "Bad River",
+                  "definition": "Bad River"
+                },
+                {
+                  "code": "1125-4",
+                  "display": "Bay Mills Chippewa",
+                  "definition": "Bay Mills Chippewa"
+                },
+                {
+                  "code": "1126-2",
+                  "display": "Bois Forte",
+                  "definition": "Bois Forte"
+                },
+                {
+                  "code": "1127-0",
+                  "display": "Burt Lake Chippewa",
+                  "definition": "Burt Lake Chippewa"
+                },
+                {
+                  "code": "1128-8",
+                  "display": "Fond du Lac",
+                  "definition": "Fond du Lac"
+                },
+                {
+                  "code": "1129-6",
+                  "display": "Grand Portage",
+                  "definition": "Grand Portage"
+                },
+                {
+                  "code": "1130-4",
+                  "display": "Grand Traverse Band of Ottawa-Chippewa",
+                  "definition": "Grand Traverse Band of Ottawa-Chippewa"
+                },
+                {
+                  "code": "1131-2",
+                  "display": "Keweenaw",
+                  "definition": "Keweenaw"
+                },
+                {
+                  "code": "1132-0",
+                  "display": "Lac Courte Oreilles",
+                  "definition": "Lac Courte Oreilles"
+                },
+                {
+                  "code": "1133-8",
+                  "display": "Lac du Flambeau",
+                  "definition": "Lac du Flambeau"
+                },
+                {
+                  "code": "1134-6",
+                  "display": "Lac Vieux Desert Chippewa",
+                  "definition": "Lac Vieux Desert Chippewa"
+                },
+                {
+                  "code": "1135-3",
+                  "display": "Lake Superior",
+                  "definition": "Lake Superior"
+                },
+                {
+                  "code": "1136-1",
+                  "display": "Leech Lake",
+                  "definition": "Leech Lake"
+                },
+                {
+                  "code": "1137-9",
+                  "display": "Little Shell Chippewa",
+                  "definition": "Little Shell Chippewa"
+                },
+                {
+                  "code": "1138-7",
+                  "display": "Mille Lacs",
+                  "definition": "Mille Lacs"
+                },
+                {
+                  "code": "1139-5",
+                  "display": "Minnesota Chippewa",
+                  "definition": "Minnesota Chippewa"
+                },
+                {
+                  "code": "1140-3",
+                  "display": "Ontonagon",
+                  "definition": "Ontonagon"
+                },
+                {
+                  "code": "1141-1",
+                  "display": "Red Cliff Chippewa",
+                  "definition": "Red Cliff Chippewa"
+                },
+                {
+                  "code": "1142-9",
+                  "display": "Red Lake Chippewa",
+                  "definition": "Red Lake Chippewa"
+                },
+                {
+                  "code": "1143-7",
+                  "display": "Saginaw Chippewa",
+                  "definition": "Saginaw Chippewa"
+                },
+                {
+                  "code": "1144-5",
+                  "display": "St. Croix Chippewa",
+                  "definition": "St. Croix Chippewa"
+                },
+                {
+                  "code": "1145-2",
+                  "display": "Sault Ste. Marie Chippewa",
+                  "definition": "Sault Ste. Marie Chippewa"
+                },
+                {
+                  "code": "1146-0",
+                  "display": "Sokoagon Chippewa",
+                  "definition": "Sokoagon Chippewa"
+                },
+                {
+                  "code": "1147-8",
+                  "display": "Turtle Mountain",
+                  "definition": "Turtle Mountain"
+                },
+                {
+                  "code": "1148-6",
+                  "display": "White Earth",
+                  "definition": "White Earth"
+                }
+              ]
+            },
+            {
+              "code": "1150-2",
+              "display": "Chippewa Cree",
+              "definition": "Chippewa Cree",
+              "concept": [
+                {
+                  "code": "1151-0",
+                  "display": "Rocky Boy's Chippewa Cree",
+                  "definition": "Rocky Boy's Chippewa Cree"
+                }
+              ]
+            },
+            {
+              "code": "1153-6",
+              "display": "Chitimacha",
+              "definition": "Chitimacha"
+            },
+            {
+              "code": "1155-1",
+              "display": "Choctaw",
+              "definition": "Choctaw",
+              "concept": [
+                {
+                  "code": "1156-9",
+                  "display": "Clifton Choctaw",
+                  "definition": "Clifton Choctaw"
+                },
+                {
+                  "code": "1157-7",
+                  "display": "Jena Choctaw",
+                  "definition": "Jena Choctaw"
+                },
+                {
+                  "code": "1158-5",
+                  "display": "Mississippi Choctaw",
+                  "definition": "Mississippi Choctaw"
+                },
+                {
+                  "code": "1159-3",
+                  "display": "Mowa Band of Choctaw",
+                  "definition": "Mowa Band of Choctaw"
+                },
+                {
+                  "code": "1160-1",
+                  "display": "Oklahoma Choctaw",
+                  "definition": "Oklahoma Choctaw"
+                }
+              ]
+            },
+            {
+              "code": "1162-7",
+              "display": "Chumash",
+              "definition": "Chumash",
+              "concept": [
+                {
+                  "code": "1163-5",
+                  "display": "Santa Ynez",
+                  "definition": "Santa Ynez"
+                }
+              ]
+            },
+            {
+              "code": "1165-0",
+              "display": "Clear Lake",
+              "definition": "Clear Lake"
+            },
+            {
+              "code": "1167-6",
+              "display": "Coeur D'Alene",
+              "definition": "Coeur D'Alene"
+            },
+            {
+              "code": "1169-2",
+              "display": "Coharie",
+              "definition": "Coharie"
+            },
+            {
+              "code": "1171-8",
+              "display": "Colorado River",
+              "definition": "Colorado River"
+            },
+            {
+              "code": "1173-4",
+              "display": "Colville",
+              "definition": "Colville"
+            },
+            {
+              "code": "1175-9",
+              "display": "Comanche",
+              "definition": "Comanche",
+              "concept": [
+                {
+                  "code": "1176-7",
+                  "display": "Oklahoma Comanche",
+                  "definition": "Oklahoma Comanche"
+                }
+              ]
+            },
+            {
+              "code": "1178-3",
+              "display": "Coos, Lower Umpqua, Siuslaw",
+              "definition": "Coos, Lower Umpqua, Siuslaw"
+            },
+            {
+              "code": "1180-9",
+              "display": "Coos",
+              "definition": "Coos"
+            },
+            {
+              "code": "1182-5",
+              "display": "Coquilles",
+              "definition": "Coquilles"
+            },
+            {
+              "code": "1184-1",
+              "display": "Costanoan",
+              "definition": "Costanoan"
+            },
+            {
+              "code": "1186-6",
+              "display": "Coushatta",
+              "definition": "Coushatta",
+              "concept": [
+                {
+                  "code": "1187-4",
+                  "display": "Alabama Coushatta",
+                  "definition": "Alabama Coushatta"
+                }
+              ]
+            },
+            {
+              "code": "1189-0",
+              "display": "Cowlitz",
+              "definition": "Cowlitz"
+            },
+            {
+              "code": "1191-6",
+              "display": "Cree",
+              "definition": "Cree"
+            },
+            {
+              "code": "1193-2",
+              "display": "Creek",
+              "definition": "Creek",
+              "concept": [
+                {
+                  "code": "1194-0",
+                  "display": "Alabama Creek",
+                  "definition": "Alabama Creek"
+                },
+                {
+                  "code": "1195-7",
+                  "display": "Alabama Quassarte",
+                  "definition": "Alabama Quassarte"
+                },
+                {
+                  "code": "1196-5",
+                  "display": "Eastern Creek",
+                  "definition": "Eastern Creek"
+                },
+                {
+                  "code": "1197-3",
+                  "display": "Eastern Muscogee",
+                  "definition": "Eastern Muscogee"
+                },
+                {
+                  "code": "1198-1",
+                  "display": "Kialegee",
+                  "definition": "Kialegee"
+                },
+                {
+                  "code": "1199-9",
+                  "display": "Lower Muscogee",
+                  "definition": "Lower Muscogee"
+                },
+                {
+                  "code": "1200-5",
+                  "display": "Machis Lower Creek Indian",
+                  "definition": "Machis Lower Creek Indian"
+                },
+                {
+                  "code": "1201-3",
+                  "display": "Poarch Band",
+                  "definition": "Poarch Band"
+                },
+                {
+                  "code": "1202-1",
+                  "display": "Principal Creek Indian Nation",
+                  "definition": "Principal Creek Indian Nation"
+                },
+                {
+                  "code": "1203-9",
+                  "display": "Star Clan of Muscogee Creeks",
+                  "definition": "Star Clan of Muscogee Creeks"
+                },
+                {
+                  "code": "1204-7",
+                  "display": "Thlopthlocco",
+                  "definition": "Thlopthlocco"
+                },
+                {
+                  "code": "1205-4",
+                  "display": "Tuckabachee",
+                  "definition": "Tuckabachee"
+                }
+              ]
+            },
+            {
+              "code": "1207-0",
+              "display": "Croatan",
+              "definition": "Croatan"
+            },
+            {
+              "code": "1209-6",
+              "display": "Crow",
+              "definition": "Crow"
+            },
+            {
+              "code": "1211-2",
+              "display": "Cupeno",
+              "definition": "Cupeno",
+              "concept": [
+                {
+                  "code": "1212-0",
+                  "display": "Agua Caliente",
+                  "definition": "Agua Caliente"
+                }
+              ]
+            },
+            {
+              "code": "1214-6",
+              "display": "Delaware",
+              "definition": "Delaware",
+              "concept": [
+                {
+                  "code": "1215-3",
+                  "display": "Eastern Delaware",
+                  "definition": "Eastern Delaware"
+                },
+                {
+                  "code": "1216-1",
+                  "display": "Lenni-Lenape",
+                  "definition": "Lenni-Lenape"
+                },
+                {
+                  "code": "1217-9",
+                  "display": "Munsee",
+                  "definition": "Munsee"
+                },
+                {
+                  "code": "1218-7",
+                  "display": "Oklahoma Delaware",
+                  "definition": "Oklahoma Delaware"
+                },
+                {
+                  "code": "1219-5",
+                  "display": "Rampough Mountain",
+                  "definition": "Rampough Mountain"
+                },
+                {
+                  "code": "1220-3",
+                  "display": "Sand Hill",
+                  "definition": "Sand Hill"
+                }
+              ]
+            },
+            {
+              "code": "1222-9",
+              "display": "Diegueno",
+              "definition": "Diegueno",
+              "concept": [
+                {
+                  "code": "1223-7",
+                  "display": "Campo",
+                  "definition": "Campo"
+                },
+                {
+                  "code": "1224-5",
+                  "display": "Capitan Grande",
+                  "definition": "Capitan Grande"
+                },
+                {
+                  "code": "1225-2",
+                  "display": "Cuyapaipe",
+                  "definition": "Cuyapaipe"
+                },
+                {
+                  "code": "1226-0",
+                  "display": "La Posta",
+                  "definition": "La Posta"
+                },
+                {
+                  "code": "1227-8",
+                  "display": "Manzanita",
+                  "definition": "Manzanita"
+                },
+                {
+                  "code": "1228-6",
+                  "display": "Mesa Grande",
+                  "definition": "Mesa Grande"
+                },
+                {
+                  "code": "1229-4",
+                  "display": "San Pasqual",
+                  "definition": "San Pasqual"
+                },
+                {
+                  "code": "1230-2",
+                  "display": "Santa Ysabel",
+                  "definition": "Santa Ysabel"
+                },
+                {
+                  "code": "1231-0",
+                  "display": "Sycuan",
+                  "definition": "Sycuan"
+                }
+              ]
+            },
+            {
+              "code": "1233-6",
+              "display": "Eastern Tribes",
+              "definition": "Eastern Tribes",
+              "concept": [
+                {
+                  "code": "1234-4",
+                  "display": "Attacapa",
+                  "definition": "Attacapa"
+                },
+                {
+                  "code": "1235-1",
+                  "display": "Biloxi",
+                  "definition": "Biloxi"
+                },
+                {
+                  "code": "1236-9",
+                  "display": "Georgetown",
+                  "definition": "Georgetown"
+                },
+                {
+                  "code": "1237-7",
+                  "display": "Moor",
+                  "definition": "Moor"
+                },
+                {
+                  "code": "1238-5",
+                  "display": "Nansemond",
+                  "definition": "Nansemond"
+                },
+                {
+                  "code": "1239-3",
+                  "display": "Natchez",
+                  "definition": "Natchez"
+                },
+                {
+                  "code": "1240-1",
+                  "display": "Nausu Waiwash",
+                  "definition": "Nausu Waiwash"
+                },
+                {
+                  "code": "1241-9",
+                  "display": "Nipmuc",
+                  "definition": "Nipmuc"
+                },
+                {
+                  "code": "1242-7",
+                  "display": "Paugussett",
+                  "definition": "Paugussett"
+                },
+                {
+                  "code": "1243-5",
+                  "display": "Pocomoke Acohonock",
+                  "definition": "Pocomoke Acohonock"
+                },
+                {
+                  "code": "1244-3",
+                  "display": "Southeastern Indians",
+                  "definition": "Southeastern Indians"
+                },
+                {
+                  "code": "1245-0",
+                  "display": "Susquehanock",
+                  "definition": "Susquehanock"
+                },
+                {
+                  "code": "1246-8",
+                  "display": "Tunica Biloxi",
+                  "definition": "Tunica Biloxi"
+                },
+                {
+                  "code": "1247-6",
+                  "display": "Waccamaw-Siousan",
+                  "definition": "Waccamaw-Siousan"
+                },
+                {
+                  "code": "1248-4",
+                  "display": "Wicomico",
+                  "definition": "Wicomico"
+                }
+              ]
+            },
+            {
+              "code": "1250-0",
+              "display": "Esselen",
+              "definition": "Esselen"
+            },
+            {
+              "code": "1252-6",
+              "display": "Fort Belknap",
+              "definition": "Fort Belknap"
+            },
+            {
+              "code": "1254-2",
+              "display": "Fort Berthold",
+              "definition": "Fort Berthold"
+            },
+            {
+              "code": "1256-7",
+              "display": "Fort Mcdowell",
+              "definition": "Fort Mcdowell"
+            },
+            {
+              "code": "1258-3",
+              "display": "Fort Hall",
+              "definition": "Fort Hall"
+            },
+            {
+              "code": "1260-9",
+              "display": "Gabrieleno",
+              "definition": "Gabrieleno"
+            },
+            {
+              "code": "1262-5",
+              "display": "Grand Ronde",
+              "definition": "Grand Ronde"
+            },
+            {
+              "code": "1264-1",
+              "display": "Gros Ventres",
+              "definition": "Gros Ventres",
+              "concept": [
+                {
+                  "code": "1265-8",
+                  "display": "Atsina",
+                  "definition": "Atsina"
+                }
+              ]
+            },
+            {
+              "code": "1267-4",
+              "display": "Haliwa",
+              "definition": "Haliwa"
+            },
+            {
+              "code": "1269-0",
+              "display": "Hidatsa",
+              "definition": "Hidatsa"
+            },
+            {
+              "code": "1271-6",
+              "display": "Hoopa",
+              "definition": "Hoopa",
+              "concept": [
+                {
+                  "code": "1272-4",
+                  "display": "Trinity",
+                  "definition": "Trinity"
+                },
+                {
+                  "code": "1273-2",
+                  "display": "Whilkut",
+                  "definition": "Whilkut"
+                }
+              ]
+            },
+            {
+              "code": "1275-7",
+              "display": "Hoopa Extension",
+              "definition": "Hoopa Extension"
+            },
+            {
+              "code": "1277-3",
+              "display": "Houma",
+              "definition": "Houma"
+            },
+            {
+              "code": "1279-9",
+              "display": "Inaja-Cosmit",
+              "definition": "Inaja-Cosmit"
+            },
+            {
+              "code": "1281-5",
+              "display": "Iowa",
+              "definition": "Iowa",
+              "concept": [
+                {
+                  "code": "1282-3",
+                  "display": "Iowa of Kansas-Nebraska",
+                  "definition": "Iowa of Kansas-Nebraska"
+                },
+                {
+                  "code": "1283-1",
+                  "display": "Iowa of Oklahoma",
+                  "definition": "Iowa of Oklahoma"
+                }
+              ]
+            },
+            {
+              "code": "1285-6",
+              "display": "Iroquois",
+              "definition": "Iroquois",
+              "concept": [
+                {
+                  "code": "1286-4",
+                  "display": "Cayuga",
+                  "definition": "Cayuga"
+                },
+                {
+                  "code": "1287-2",
+                  "display": "Mohawk",
+                  "definition": "Mohawk"
+                },
+                {
+                  "code": "1288-0",
+                  "display": "Oneida",
+                  "definition": "Oneida"
+                },
+                {
+                  "code": "1289-8",
+                  "display": "Onondaga",
+                  "definition": "Onondaga"
+                },
+                {
+                  "code": "1290-6",
+                  "display": "Seneca",
+                  "definition": "Seneca"
+                },
+                {
+                  "code": "1291-4",
+                  "display": "Seneca Nation",
+                  "definition": "Seneca Nation"
+                },
+                {
+                  "code": "1292-2",
+                  "display": "Seneca-Cayuga",
+                  "definition": "Seneca-Cayuga"
+                },
+                {
+                  "code": "1293-0",
+                  "display": "Tonawanda Seneca",
+                  "definition": "Tonawanda Seneca"
+                },
+                {
+                  "code": "1294-8",
+                  "display": "Tuscarora",
+                  "definition": "Tuscarora"
+                },
+                {
+                  "code": "1295-5",
+                  "display": "Wyandotte",
+                  "definition": "Wyandotte"
+                }
+              ]
+            },
+            {
+              "code": "1297-1",
+              "display": "Juaneno",
+              "definition": "Juaneno"
+            },
+            {
+              "code": "1299-7",
+              "display": "Kalispel",
+              "definition": "Kalispel"
+            },
+            {
+              "code": "1301-1",
+              "display": "Karuk",
+              "definition": "Karuk"
+            },
+            {
+              "code": "1303-7",
+              "display": "Kaw",
+              "definition": "Kaw"
+            },
+            {
+              "code": "1305-2",
+              "display": "Kickapoo",
+              "definition": "Kickapoo",
+              "concept": [
+                {
+                  "code": "1306-0",
+                  "display": "Oklahoma Kickapoo",
+                  "definition": "Oklahoma Kickapoo"
+                },
+                {
+                  "code": "1307-8",
+                  "display": "Texas Kickapoo",
+                  "definition": "Texas Kickapoo"
+                }
+              ]
+            },
+            {
+              "code": "1309-4",
+              "display": "Kiowa",
+              "definition": "Kiowa",
+              "concept": [
+                {
+                  "code": "1310-2",
+                  "display": "Oklahoma Kiowa",
+                  "definition": "Oklahoma Kiowa"
+                }
+              ]
+            },
+            {
+              "code": "1312-8",
+              "display": "Klallam",
+              "definition": "Klallam",
+              "concept": [
+                {
+                  "code": "1313-6",
+                  "display": "Jamestown",
+                  "definition": "Jamestown"
+                },
+                {
+                  "code": "1314-4",
+                  "display": "Lower Elwha",
+                  "definition": "Lower Elwha"
+                },
+                {
+                  "code": "1315-1",
+                  "display": "Port Gamble Klallam",
+                  "definition": "Port Gamble Klallam"
+                }
+              ]
+            },
+            {
+              "code": "1317-7",
+              "display": "Klamath",
+              "definition": "Klamath"
+            },
+            {
+              "code": "1319-3",
+              "display": "Konkow",
+              "definition": "Konkow"
+            },
+            {
+              "code": "1321-9",
+              "display": "Kootenai",
+              "definition": "Kootenai"
+            },
+            {
+              "code": "1323-5",
+              "display": "Lassik",
+              "definition": "Lassik"
+            },
+            {
+              "code": "1325-0",
+              "display": "Long Island",
+              "definition": "Long Island",
+              "concept": [
+                {
+                  "code": "1326-8",
+                  "display": "Matinecock",
+                  "definition": "Matinecock"
+                },
+                {
+                  "code": "1327-6",
+                  "display": "Montauk",
+                  "definition": "Montauk"
+                },
+                {
+                  "code": "1328-4",
+                  "display": "Poospatuck",
+                  "definition": "Poospatuck"
+                },
+                {
+                  "code": "1329-2",
+                  "display": "Setauket",
+                  "definition": "Setauket"
+                }
+              ]
+            },
+            {
+              "code": "1331-8",
+              "display": "Luiseno",
+              "definition": "Luiseno",
+              "concept": [
+                {
+                  "code": "1332-6",
+                  "display": "La Jolla",
+                  "definition": "La Jolla"
+                },
+                {
+                  "code": "1333-4",
+                  "display": "Pala",
+                  "definition": "Pala"
+                },
+                {
+                  "code": "1334-2",
+                  "display": "Pauma",
+                  "definition": "Pauma"
+                },
+                {
+                  "code": "1335-9",
+                  "display": "Pechanga",
+                  "definition": "Pechanga"
+                },
+                {
+                  "code": "1336-7",
+                  "display": "Soboba",
+                  "definition": "Soboba"
+                },
+                {
+                  "code": "1337-5",
+                  "display": "Twenty-Nine Palms",
+                  "definition": "Twenty-Nine Palms"
+                },
+                {
+                  "code": "1338-3",
+                  "display": "Temecula",
+                  "definition": "Temecula"
+                }
+              ]
+            },
+            {
+              "code": "1340-9",
+              "display": "Lumbee",
+              "definition": "Lumbee"
+            },
+            {
+              "code": "1342-5",
+              "display": "Lummi",
+              "definition": "Lummi"
+            },
+            {
+              "code": "1344-1",
+              "display": "Maidu",
+              "definition": "Maidu",
+              "concept": [
+                {
+                  "code": "1345-8",
+                  "display": "Mountain Maidu",
+                  "definition": "Mountain Maidu"
+                },
+                {
+                  "code": "1346-6",
+                  "display": "Nishinam",
+                  "definition": "Nishinam"
+                }
+              ]
+            },
+            {
+              "code": "1348-2",
+              "display": "Makah",
+              "definition": "Makah"
+            },
+            {
+              "code": "1350-8",
+              "display": "Maliseet",
+              "definition": "Maliseet"
+            },
+            {
+              "code": "1352-4",
+              "display": "Mandan",
+              "definition": "Mandan"
+            },
+            {
+              "code": "1354-0",
+              "display": "Mattaponi",
+              "definition": "Mattaponi"
+            },
+            {
+              "code": "1356-5",
+              "display": "Menominee",
+              "definition": "Menominee"
+            },
+            {
+              "code": "1358-1",
+              "display": "Miami",
+              "definition": "Miami",
+              "concept": [
+                {
+                  "code": "1359-9",
+                  "display": "Illinois Miami",
+                  "definition": "Illinois Miami"
+                },
+                {
+                  "code": "1360-7",
+                  "display": "Indiana Miami",
+                  "definition": "Indiana Miami"
+                },
+                {
+                  "code": "1361-5",
+                  "display": "Oklahoma Miami",
+                  "definition": "Oklahoma Miami"
+                }
+              ]
+            },
+            {
+              "code": "1363-1",
+              "display": "Miccosukee",
+              "definition": "Miccosukee"
+            },
+            {
+              "code": "1365-6",
+              "display": "Micmac",
+              "definition": "Micmac",
+              "concept": [
+                {
+                  "code": "1366-4",
+                  "display": "Aroostook",
+                  "definition": "Aroostook"
+                }
+              ]
+            },
+            {
+              "code": "1368-0",
+              "display": "Mission Indians",
+              "definition": "Mission Indians"
+            },
+            {
+              "code": "1370-6",
+              "display": "Miwok",
+              "definition": "Miwok"
+            },
+            {
+              "code": "1372-2",
+              "display": "Modoc",
+              "definition": "Modoc"
+            },
+            {
+              "code": "1374-8",
+              "display": "Mohegan",
+              "definition": "Mohegan"
+            },
+            {
+              "code": "1376-3",
+              "display": "Mono",
+              "definition": "Mono"
+            },
+            {
+              "code": "1378-9",
+              "display": "Nanticoke",
+              "definition": "Nanticoke"
+            },
+            {
+              "code": "1380-5",
+              "display": "Narragansett",
+              "definition": "Narragansett"
+            },
+            {
+              "code": "1382-1",
+              "display": "Navajo",
+              "definition": "Navajo",
+              "concept": [
+                {
+                  "code": "1383-9",
+                  "display": "Alamo Navajo",
+                  "definition": "Alamo Navajo"
+                },
+                {
+                  "code": "1384-7",
+                  "display": "Canoncito Navajo",
+                  "definition": "Canoncito Navajo"
+                },
+                {
+                  "code": "1385-4",
+                  "display": "Ramah Navajo",
+                  "definition": "Ramah Navajo"
+                }
+              ]
+            },
+            {
+              "code": "1387-0",
+              "display": "Nez Perce",
+              "definition": "Nez Perce"
+            },
+            {
+              "code": "1389-6",
+              "display": "Nomalaki",
+              "definition": "Nomalaki"
+            },
+            {
+              "code": "1391-2",
+              "display": "Northwest Tribes",
+              "definition": "Northwest Tribes",
+              "concept": [
+                {
+                  "code": "1392-0",
+                  "display": "Alsea",
+                  "definition": "Alsea"
+                },
+                {
+                  "code": "1393-8",
+                  "display": "Celilo",
+                  "definition": "Celilo"
+                },
+                {
+                  "code": "1394-6",
+                  "display": "Columbia",
+                  "definition": "Columbia"
+                },
+                {
+                  "code": "1395-3",
+                  "display": "Kalapuya",
+                  "definition": "Kalapuya"
+                },
+                {
+                  "code": "1396-1",
+                  "display": "Molala",
+                  "definition": "Molala"
+                },
+                {
+                  "code": "1397-9",
+                  "display": "Talakamish",
+                  "definition": "Talakamish"
+                },
+                {
+                  "code": "1398-7",
+                  "display": "Tenino",
+                  "definition": "Tenino"
+                },
+                {
+                  "code": "1399-5",
+                  "display": "Tillamook",
+                  "definition": "Tillamook"
+                },
+                {
+                  "code": "1400-1",
+                  "display": "Wenatchee",
+                  "definition": "Wenatchee"
+                },
+                {
+                  "code": "1401-9",
+                  "display": "Yahooskin",
+                  "definition": "Yahooskin"
+                }
+              ]
+            },
+            {
+              "code": "1403-5",
+              "display": "Omaha",
+              "definition": "Omaha"
+            },
+            {
+              "code": "1405-0",
+              "display": "Oregon Athabaskan",
+              "definition": "Oregon Athabaskan"
+            },
+            {
+              "code": "1407-6",
+              "display": "Osage",
+              "definition": "Osage"
+            },
+            {
+              "code": "1409-2",
+              "display": "Otoe-Missouria",
+              "definition": "Otoe-Missouria"
+            },
+            {
+              "code": "1411-8",
+              "display": "Ottawa",
+              "definition": "Ottawa",
+              "concept": [
+                {
+                  "code": "1412-6",
+                  "display": "Burt Lake Ottawa",
+                  "definition": "Burt Lake Ottawa"
+                },
+                {
+                  "code": "1413-4",
+                  "display": "Michigan Ottawa",
+                  "definition": "Michigan Ottawa"
+                },
+                {
+                  "code": "1414-2",
+                  "display": "Oklahoma Ottawa",
+                  "definition": "Oklahoma Ottawa"
+                }
+              ]
+            },
+            {
+              "code": "1416-7",
+              "display": "Paiute",
+              "definition": "Paiute",
+              "concept": [
+                {
+                  "code": "1417-5",
+                  "display": "Bishop",
+                  "definition": "Bishop"
+                },
+                {
+                  "code": "1418-3",
+                  "display": "Bridgeport",
+                  "definition": "Bridgeport"
+                },
+                {
+                  "code": "1419-1",
+                  "display": "Burns Paiute",
+                  "definition": "Burns Paiute"
+                },
+                {
+                  "code": "1420-9",
+                  "display": "Cedarville",
+                  "definition": "Cedarville"
+                },
+                {
+                  "code": "1421-7",
+                  "display": "Fort Bidwell",
+                  "definition": "Fort Bidwell"
+                },
+                {
+                  "code": "1422-5",
+                  "display": "Fort Independence",
+                  "definition": "Fort Independence"
+                },
+                {
+                  "code": "1423-3",
+                  "display": "Kaibab",
+                  "definition": "Kaibab"
+                },
+                {
+                  "code": "1424-1",
+                  "display": "Las Vegas",
+                  "definition": "Las Vegas"
+                },
+                {
+                  "code": "1425-8",
+                  "display": "Lone Pine",
+                  "definition": "Lone Pine"
+                },
+                {
+                  "code": "1426-6",
+                  "display": "Lovelock",
+                  "definition": "Lovelock"
+                },
+                {
+                  "code": "1427-4",
+                  "display": "Malheur Paiute",
+                  "definition": "Malheur Paiute"
+                },
+                {
+                  "code": "1428-2",
+                  "display": "Moapa",
+                  "definition": "Moapa"
+                },
+                {
+                  "code": "1429-0",
+                  "display": "Northern Paiute",
+                  "definition": "Northern Paiute"
+                },
+                {
+                  "code": "1430-8",
+                  "display": "Owens Valley",
+                  "definition": "Owens Valley"
+                },
+                {
+                  "code": "1431-6",
+                  "display": "Pyramid Lake",
+                  "definition": "Pyramid Lake"
+                },
+                {
+                  "code": "1432-4",
+                  "display": "San Juan Southern Paiute",
+                  "definition": "San Juan Southern Paiute"
+                },
+                {
+                  "code": "1433-2",
+                  "display": "Southern Paiute",
+                  "definition": "Southern Paiute"
+                },
+                {
+                  "code": "1434-0",
+                  "display": "Summit Lake",
+                  "definition": "Summit Lake"
+                },
+                {
+                  "code": "1435-7",
+                  "display": "Utu Utu Gwaitu Paiute",
+                  "definition": "Utu Utu Gwaitu Paiute"
+                },
+                {
+                  "code": "1436-5",
+                  "display": "Walker River",
+                  "definition": "Walker River"
+                },
+                {
+                  "code": "1437-3",
+                  "display": "Yerington Paiute",
+                  "definition": "Yerington Paiute"
+                }
+              ]
+            },
+            {
+              "code": "1439-9",
+              "display": "Pamunkey",
+              "definition": "Pamunkey"
+            },
+            {
+              "code": "1441-5",
+              "display": "Passamaquoddy",
+              "definition": "Passamaquoddy",
+              "concept": [
+                {
+                  "code": "1442-3",
+                  "display": "Indian Township",
+                  "definition": "Indian Township"
+                },
+                {
+                  "code": "1443-1",
+                  "display": "Pleasant Point Passamaquoddy",
+                  "definition": "Pleasant Point Passamaquoddy"
+                }
+              ]
+            },
+            {
+              "code": "1445-6",
+              "display": "Pawnee",
+              "definition": "Pawnee",
+              "concept": [
+                {
+                  "code": "1446-4",
+                  "display": "Oklahoma Pawnee",
+                  "definition": "Oklahoma Pawnee"
+                }
+              ]
+            },
+            {
+              "code": "1448-0",
+              "display": "Penobscot",
+              "definition": "Penobscot"
+            },
+            {
+              "code": "1450-6",
+              "display": "Peoria",
+              "definition": "Peoria",
+              "concept": [
+                {
+                  "code": "1451-4",
+                  "display": "Oklahoma Peoria",
+                  "definition": "Oklahoma Peoria"
+                }
+              ]
+            },
+            {
+              "code": "1453-0",
+              "display": "Pequot",
+              "definition": "Pequot",
+              "concept": [
+                {
+                  "code": "1454-8",
+                  "display": "Marshantucket Pequot",
+                  "definition": "Marshantucket Pequot"
+                }
+              ]
+            },
+            {
+              "code": "1456-3",
+              "display": "Pima",
+              "definition": "Pima",
+              "concept": [
+                {
+                  "code": "1457-1",
+                  "display": "Gila River Pima-Maricopa",
+                  "definition": "Gila River Pima-Maricopa"
+                },
+                {
+                  "code": "1458-9",
+                  "display": "Salt River Pima-Maricopa",
+                  "definition": "Salt River Pima-Maricopa"
+                }
+              ]
+            },
+            {
+              "code": "1460-5",
+              "display": "Piscataway",
+              "definition": "Piscataway"
+            },
+            {
+              "code": "1462-1",
+              "display": "Pit River",
+              "definition": "Pit River"
+            },
+            {
+              "code": "1464-7",
+              "display": "Pomo",
+              "definition": "Pomo",
+              "concept": [
+                {
+                  "code": "1465-4",
+                  "display": "Central Pomo",
+                  "definition": "Central Pomo"
+                },
+                {
+                  "code": "1466-2",
+                  "display": "Dry Creek",
+                  "definition": "Dry Creek"
+                },
+                {
+                  "code": "1467-0",
+                  "display": "Eastern Pomo",
+                  "definition": "Eastern Pomo"
+                },
+                {
+                  "code": "1468-8",
+                  "display": "Kashia",
+                  "definition": "Kashia"
+                },
+                {
+                  "code": "1469-6",
+                  "display": "Northern Pomo",
+                  "definition": "Northern Pomo"
+                },
+                {
+                  "code": "1470-4",
+                  "display": "Scotts Valley",
+                  "definition": "Scotts Valley"
+                },
+                {
+                  "code": "1471-2",
+                  "display": "Stonyford",
+                  "definition": "Stonyford"
+                },
+                {
+                  "code": "1472-0",
+                  "display": "Sulphur Bank",
+                  "definition": "Sulphur Bank"
+                }
+              ]
+            },
+            {
+              "code": "1474-6",
+              "display": "Ponca",
+              "definition": "Ponca",
+              "concept": [
+                {
+                  "code": "1475-3",
+                  "display": "Nebraska Ponca",
+                  "definition": "Nebraska Ponca"
+                },
+                {
+                  "code": "1476-1",
+                  "display": "Oklahoma Ponca",
+                  "definition": "Oklahoma Ponca"
+                }
+              ]
+            },
+            {
+              "code": "1478-7",
+              "display": "Potawatomi",
+              "definition": "Potawatomi",
+              "concept": [
+                {
+                  "code": "1479-5",
+                  "display": "Citizen Band Potawatomi",
+                  "definition": "Citizen Band Potawatomi"
+                },
+                {
+                  "code": "1480-3",
+                  "display": "Forest County",
+                  "definition": "Forest County"
+                },
+                {
+                  "code": "1481-1",
+                  "display": "Hannahville",
+                  "definition": "Hannahville"
+                },
+                {
+                  "code": "1482-9",
+                  "display": "Huron Potawatomi",
+                  "definition": "Huron Potawatomi"
+                },
+                {
+                  "code": "1483-7",
+                  "display": "Pokagon Potawatomi",
+                  "definition": "Pokagon Potawatomi"
+                },
+                {
+                  "code": "1484-5",
+                  "display": "Prairie Band",
+                  "definition": "Prairie Band"
+                },
+                {
+                  "code": "1485-2",
+                  "display": "Wisconsin Potawatomi",
+                  "definition": "Wisconsin Potawatomi"
+                }
+              ]
+            },
+            {
+              "code": "1487-8",
+              "display": "Powhatan",
+              "definition": "Powhatan"
+            },
+            {
+              "code": "1489-4",
+              "display": "Pueblo",
+              "definition": "Pueblo",
+              "concept": [
+                {
+                  "code": "1490-2",
+                  "display": "Acoma",
+                  "definition": "Acoma"
+                },
+                {
+                  "code": "1491-0",
+                  "display": "Arizona Tewa",
+                  "definition": "Arizona Tewa"
+                },
+                {
+                  "code": "1492-8",
+                  "display": "Cochiti",
+                  "definition": "Cochiti"
+                },
+                {
+                  "code": "1493-6",
+                  "display": "Hopi",
+                  "definition": "Hopi"
+                },
+                {
+                  "code": "1494-4",
+                  "display": "Isleta",
+                  "definition": "Isleta"
+                },
+                {
+                  "code": "1495-1",
+                  "display": "Jemez",
+                  "definition": "Jemez"
+                },
+                {
+                  "code": "1496-9",
+                  "display": "Keres",
+                  "definition": "Keres"
+                },
+                {
+                  "code": "1497-7",
+                  "display": "Laguna",
+                  "definition": "Laguna"
+                },
+                {
+                  "code": "1498-5",
+                  "display": "Nambe",
+                  "definition": "Nambe"
+                },
+                {
+                  "code": "1499-3",
+                  "display": "Picuris",
+                  "definition": "Picuris"
+                },
+                {
+                  "code": "1500-8",
+                  "display": "Piro",
+                  "definition": "Piro"
+                },
+                {
+                  "code": "1501-6",
+                  "display": "Pojoaque",
+                  "definition": "Pojoaque"
+                },
+                {
+                  "code": "1502-4",
+                  "display": "San Felipe",
+                  "definition": "San Felipe"
+                },
+                {
+                  "code": "1503-2",
+                  "display": "San Ildefonso",
+                  "definition": "San Ildefonso"
+                },
+                {
+                  "code": "1504-0",
+                  "display": "San Juan Pueblo",
+                  "definition": "San Juan Pueblo"
+                },
+                {
+                  "code": "1505-7",
+                  "display": "San Juan De",
+                  "definition": "San Juan De"
+                },
+                {
+                  "code": "1506-5",
+                  "display": "San Juan",
+                  "definition": "San Juan"
+                },
+                {
+                  "code": "1507-3",
+                  "display": "Sandia",
+                  "definition": "Sandia"
+                },
+                {
+                  "code": "1508-1",
+                  "display": "Santa Ana",
+                  "definition": "Santa Ana"
+                },
+                {
+                  "code": "1509-9",
+                  "display": "Santa Clara",
+                  "definition": "Santa Clara"
+                },
+                {
+                  "code": "1510-7",
+                  "display": "Santo Domingo",
+                  "definition": "Santo Domingo"
+                },
+                {
+                  "code": "1511-5",
+                  "display": "Taos",
+                  "definition": "Taos"
+                },
+                {
+                  "code": "1512-3",
+                  "display": "Tesuque",
+                  "definition": "Tesuque"
+                },
+                {
+                  "code": "1513-1",
+                  "display": "Tewa",
+                  "definition": "Tewa"
+                },
+                {
+                  "code": "1514-9",
+                  "display": "Tigua",
+                  "definition": "Tigua"
+                },
+                {
+                  "code": "1515-6",
+                  "display": "Zia",
+                  "definition": "Zia"
+                },
+                {
+                  "code": "1516-4",
+                  "display": "Zuni",
+                  "definition": "Zuni"
+                }
+              ]
+            },
+            {
+              "code": "1518-0",
+              "display": "Puget Sound Salish",
+              "definition": "Puget Sound Salish",
+              "concept": [
+                {
+                  "code": "1519-8",
+                  "display": "Duwamish",
+                  "definition": "Duwamish"
+                },
+                {
+                  "code": "1520-6",
+                  "display": "Kikiallus",
+                  "definition": "Kikiallus"
+                },
+                {
+                  "code": "1521-4",
+                  "display": "Lower Skagit",
+                  "definition": "Lower Skagit"
+                },
+                {
+                  "code": "1522-2",
+                  "display": "Muckleshoot",
+                  "definition": "Muckleshoot"
+                },
+                {
+                  "code": "1523-0",
+                  "display": "Nisqually",
+                  "definition": "Nisqually"
+                },
+                {
+                  "code": "1524-8",
+                  "display": "Nooksack",
+                  "definition": "Nooksack"
+                },
+                {
+                  "code": "1525-5",
+                  "display": "Port Madison",
+                  "definition": "Port Madison"
+                },
+                {
+                  "code": "1526-3",
+                  "display": "Puyallup",
+                  "definition": "Puyallup"
+                },
+                {
+                  "code": "1527-1",
+                  "display": "Samish",
+                  "definition": "Samish"
+                },
+                {
+                  "code": "1528-9",
+                  "display": "Sauk-Suiattle",
+                  "definition": "Sauk-Suiattle"
+                },
+                {
+                  "code": "1529-7",
+                  "display": "Skokomish",
+                  "definition": "Skokomish"
+                },
+                {
+                  "code": "1530-5",
+                  "display": "Skykomish",
+                  "definition": "Skykomish"
+                },
+                {
+                  "code": "1531-3",
+                  "display": "Snohomish",
+                  "definition": "Snohomish"
+                },
+                {
+                  "code": "1532-1",
+                  "display": "Snoqualmie",
+                  "definition": "Snoqualmie"
+                },
+                {
+                  "code": "1533-9",
+                  "display": "Squaxin Island",
+                  "definition": "Squaxin Island"
+                },
+                {
+                  "code": "1534-7",
+                  "display": "Steilacoom",
+                  "definition": "Steilacoom"
+                },
+                {
+                  "code": "1535-4",
+                  "display": "Stillaguamish",
+                  "definition": "Stillaguamish"
+                },
+                {
+                  "code": "1536-2",
+                  "display": "Suquamish",
+                  "definition": "Suquamish"
+                },
+                {
+                  "code": "1537-0",
+                  "display": "Swinomish",
+                  "definition": "Swinomish"
+                },
+                {
+                  "code": "1538-8",
+                  "display": "Tulalip",
+                  "definition": "Tulalip"
+                },
+                {
+                  "code": "1539-6",
+                  "display": "Upper Skagit",
+                  "definition": "Upper Skagit"
+                }
+              ]
+            },
+            {
+              "code": "1541-2",
+              "display": "Quapaw",
+              "definition": "Quapaw"
+            },
+            {
+              "code": "1543-8",
+              "display": "Quinault",
+              "definition": "Quinault"
+            },
+            {
+              "code": "1545-3",
+              "display": "Rappahannock",
+              "definition": "Rappahannock"
+            },
+            {
+              "code": "1547-9",
+              "display": "Reno-Sparks",
+              "definition": "Reno-Sparks"
+            },
+            {
+              "code": "1549-5",
+              "display": "Round Valley",
+              "definition": "Round Valley"
+            },
+            {
+              "code": "1551-1",
+              "display": "Sac and Fox",
+              "definition": "Sac and Fox",
+              "concept": [
+                {
+                  "code": "1552-9",
+                  "display": "Iowa Sac and Fox",
+                  "definition": "Iowa Sac and Fox"
+                },
+                {
+                  "code": "1553-7",
+                  "display": "Missouri Sac and Fox",
+                  "definition": "Missouri Sac and Fox"
+                },
+                {
+                  "code": "1554-5",
+                  "display": "Oklahoma Sac and Fox",
+                  "definition": "Oklahoma Sac and Fox"
+                }
+              ]
+            },
+            {
+              "code": "1556-0",
+              "display": "Salinan",
+              "definition": "Salinan"
+            },
+            {
+              "code": "1558-6",
+              "display": "Salish",
+              "definition": "Salish"
+            },
+            {
+              "code": "1560-2",
+              "display": "Salish and Kootenai",
+              "definition": "Salish and Kootenai"
+            },
+            {
+              "code": "1562-8",
+              "display": "Schaghticoke",
+              "definition": "Schaghticoke"
+            },
+            {
+              "code": "1564-4",
+              "display": "Scott Valley",
+              "definition": "Scott Valley"
+            },
+            {
+              "code": "1566-9",
+              "display": "Seminole",
+              "definition": "Seminole",
+              "concept": [
+                {
+                  "code": "1567-7",
+                  "display": "Big Cypress",
+                  "definition": "Big Cypress"
+                },
+                {
+                  "code": "1568-5",
+                  "display": "Brighton",
+                  "definition": "Brighton"
+                },
+                {
+                  "code": "1569-3",
+                  "display": "Florida Seminole",
+                  "definition": "Florida Seminole"
+                },
+                {
+                  "code": "1570-1",
+                  "display": "Hollywood Seminole",
+                  "definition": "Hollywood Seminole"
+                },
+                {
+                  "code": "1571-9",
+                  "display": "Oklahoma Seminole",
+                  "definition": "Oklahoma Seminole"
+                }
+              ]
+            },
+            {
+              "code": "1573-5",
+              "display": "Serrano",
+              "definition": "Serrano",
+              "concept": [
+                {
+                  "code": "1574-3",
+                  "display": "San Manual",
+                  "definition": "San Manual"
+                }
+              ]
+            },
+            {
+              "code": "1576-8",
+              "display": "Shasta",
+              "definition": "Shasta"
+            },
+            {
+              "code": "1578-4",
+              "display": "Shawnee",
+              "definition": "Shawnee",
+              "concept": [
+                {
+                  "code": "1579-2",
+                  "display": "Absentee Shawnee",
+                  "definition": "Absentee Shawnee"
+                },
+                {
+                  "code": "1580-0",
+                  "display": "Eastern Shawnee",
+                  "definition": "Eastern Shawnee"
+                }
+              ]
+            },
+            {
+              "code": "1582-6",
+              "display": "Shinnecock",
+              "definition": "Shinnecock"
+            },
+            {
+              "code": "1584-2",
+              "display": "Shoalwater Bay",
+              "definition": "Shoalwater Bay"
+            },
+            {
+              "code": "1586-7",
+              "display": "Shoshone",
+              "definition": "Shoshone",
+              "concept": [
+                {
+                  "code": "1587-5",
+                  "display": "Battle Mountain",
+                  "definition": "Battle Mountain"
+                },
+                {
+                  "code": "1588-3",
+                  "display": "Duckwater",
+                  "definition": "Duckwater"
+                },
+                {
+                  "code": "1589-1",
+                  "display": "Elko",
+                  "definition": "Elko"
+                },
+                {
+                  "code": "1590-9",
+                  "display": "Ely",
+                  "definition": "Ely"
+                },
+                {
+                  "code": "1591-7",
+                  "display": "Goshute",
+                  "definition": "Goshute"
+                },
+                {
+                  "code": "1592-5",
+                  "display": "Panamint",
+                  "definition": "Panamint"
+                },
+                {
+                  "code": "1593-3",
+                  "display": "Ruby Valley",
+                  "definition": "Ruby Valley"
+                },
+                {
+                  "code": "1594-1",
+                  "display": "Skull Valley",
+                  "definition": "Skull Valley"
+                },
+                {
+                  "code": "1595-8",
+                  "display": "South Fork Shoshone",
+                  "definition": "South Fork Shoshone"
+                },
+                {
+                  "code": "1596-6",
+                  "display": "Te-Moak Western Shoshone",
+                  "definition": "Te-Moak Western Shoshone"
+                },
+                {
+                  "code": "1597-4",
+                  "display": "Timbi-Sha Shoshone",
+                  "definition": "Timbi-Sha Shoshone"
+                },
+                {
+                  "code": "1598-2",
+                  "display": "Washakie",
+                  "definition": "Washakie"
+                },
+                {
+                  "code": "1599-0",
+                  "display": "Wind River Shoshone",
+                  "definition": "Wind River Shoshone"
+                },
+                {
+                  "code": "1600-6",
+                  "display": "Yomba",
+                  "definition": "Yomba"
+                }
+              ]
+            },
+            {
+              "code": "1602-2",
+              "display": "Shoshone Paiute",
+              "definition": "Shoshone Paiute",
+              "concept": [
+                {
+                  "code": "1603-0",
+                  "display": "Duck Valley",
+                  "definition": "Duck Valley"
+                },
+                {
+                  "code": "1604-8",
+                  "display": "Fallon",
+                  "definition": "Fallon"
+                },
+                {
+                  "code": "1605-5",
+                  "display": "Fort McDermitt",
+                  "definition": "Fort McDermitt"
+                }
+              ]
+            },
+            {
+              "code": "1607-1",
+              "display": "Siletz",
+              "definition": "Siletz"
+            },
+            {
+              "code": "1609-7",
+              "display": "Sioux",
+              "definition": "Sioux",
+              "concept": [
+                {
+                  "code": "1610-5",
+                  "display": "Blackfoot Sioux",
+                  "definition": "Blackfoot Sioux"
+                },
+                {
+                  "code": "1611-3",
+                  "display": "Brule Sioux",
+                  "definition": "Brule Sioux"
+                },
+                {
+                  "code": "1612-1",
+                  "display": "Cheyenne River Sioux",
+                  "definition": "Cheyenne River Sioux"
+                },
+                {
+                  "code": "1613-9",
+                  "display": "Crow Creek Sioux",
+                  "definition": "Crow Creek Sioux"
+                },
+                {
+                  "code": "1614-7",
+                  "display": "Dakota Sioux",
+                  "definition": "Dakota Sioux"
+                },
+                {
+                  "code": "1615-4",
+                  "display": "Flandreau Santee",
+                  "definition": "Flandreau Santee"
+                },
+                {
+                  "code": "1616-2",
+                  "display": "Fort Peck",
+                  "definition": "Fort Peck"
+                },
+                {
+                  "code": "1617-0",
+                  "display": "Lake Traverse Sioux",
+                  "definition": "Lake Traverse Sioux"
+                },
+                {
+                  "code": "1618-8",
+                  "display": "Lower Brule Sioux",
+                  "definition": "Lower Brule Sioux"
+                },
+                {
+                  "code": "1619-6",
+                  "display": "Lower Sioux",
+                  "definition": "Lower Sioux"
+                },
+                {
+                  "code": "1620-4",
+                  "display": "Mdewakanton Sioux",
+                  "definition": "Mdewakanton Sioux"
+                },
+                {
+                  "code": "1621-2",
+                  "display": "Miniconjou",
+                  "definition": "Miniconjou"
+                },
+                {
+                  "code": "1622-0",
+                  "display": "Oglala Sioux",
+                  "definition": "Oglala Sioux"
+                },
+                {
+                  "code": "1623-8",
+                  "display": "Pine Ridge Sioux",
+                  "definition": "Pine Ridge Sioux"
+                },
+                {
+                  "code": "1624-6",
+                  "display": "Pipestone Sioux",
+                  "definition": "Pipestone Sioux"
+                },
+                {
+                  "code": "1625-3",
+                  "display": "Prairie Island Sioux",
+                  "definition": "Prairie Island Sioux"
+                },
+                {
+                  "code": "1626-1",
+                  "display": "Prior Lake Sioux",
+                  "definition": "Prior Lake Sioux"
+                },
+                {
+                  "code": "1627-9",
+                  "display": "Rosebud Sioux",
+                  "definition": "Rosebud Sioux"
+                },
+                {
+                  "code": "1628-7",
+                  "display": "Sans Arc Sioux",
+                  "definition": "Sans Arc Sioux"
+                },
+                {
+                  "code": "1629-5",
+                  "display": "Santee Sioux",
+                  "definition": "Santee Sioux"
+                },
+                {
+                  "code": "1630-3",
+                  "display": "Sisseton-Wahpeton",
+                  "definition": "Sisseton-Wahpeton"
+                },
+                {
+                  "code": "1631-1",
+                  "display": "Sisseton Sioux",
+                  "definition": "Sisseton Sioux"
+                },
+                {
+                  "code": "1632-9",
+                  "display": "Spirit Lake Sioux",
+                  "definition": "Spirit Lake Sioux"
+                },
+                {
+                  "code": "1633-7",
+                  "display": "Standing Rock Sioux",
+                  "definition": "Standing Rock Sioux"
+                },
+                {
+                  "code": "1634-5",
+                  "display": "Teton Sioux",
+                  "definition": "Teton Sioux"
+                },
+                {
+                  "code": "1635-2",
+                  "display": "Two Kettle Sioux",
+                  "definition": "Two Kettle Sioux"
+                },
+                {
+                  "code": "1636-0",
+                  "display": "Upper Sioux",
+                  "definition": "Upper Sioux"
+                },
+                {
+                  "code": "1637-8",
+                  "display": "Wahpekute Sioux",
+                  "definition": "Wahpekute Sioux"
+                },
+                {
+                  "code": "1638-6",
+                  "display": "Wahpeton Sioux",
+                  "definition": "Wahpeton Sioux"
+                },
+                {
+                  "code": "1639-4",
+                  "display": "Wazhaza Sioux",
+                  "definition": "Wazhaza Sioux"
+                },
+                {
+                  "code": "1640-2",
+                  "display": "Yankton Sioux",
+                  "definition": "Yankton Sioux"
+                },
+                {
+                  "code": "1641-0",
+                  "display": "Yanktonai Sioux",
+                  "definition": "Yanktonai Sioux"
+                }
+              ]
+            },
+            {
+              "code": "1643-6",
+              "display": "Siuslaw",
+              "definition": "Siuslaw"
+            },
+            {
+              "code": "1645-1",
+              "display": "Spokane",
+              "definition": "Spokane"
+            },
+            {
+              "code": "1647-7",
+              "display": "Stewart",
+              "definition": "Stewart"
+            },
+            {
+              "code": "1649-3",
+              "display": "Stockbridge",
+              "definition": "Stockbridge"
+            },
+            {
+              "code": "1651-9",
+              "display": "Susanville",
+              "definition": "Susanville"
+            },
+            {
+              "code": "1653-5",
+              "display": "Tohono O'Odham",
+              "definition": "Tohono O'Odham",
+              "concept": [
+                {
+                  "code": "1654-3",
+                  "display": "Ak-Chin",
+                  "definition": "Ak-Chin"
+                },
+                {
+                  "code": "1655-0",
+                  "display": "Gila Bend",
+                  "definition": "Gila Bend"
+                },
+                {
+                  "code": "1656-8",
+                  "display": "San Xavier",
+                  "definition": "San Xavier"
+                },
+                {
+                  "code": "1657-6",
+                  "display": "Sells",
+                  "definition": "Sells"
+                }
+              ]
+            },
+            {
+              "code": "1659-2",
+              "display": "Tolowa",
+              "definition": "Tolowa"
+            },
+            {
+              "code": "1661-8",
+              "display": "Tonkawa",
+              "definition": "Tonkawa"
+            },
+            {
+              "code": "1663-4",
+              "display": "Tygh",
+              "definition": "Tygh"
+            },
+            {
+              "code": "1665-9",
+              "display": "Umatilla",
+              "definition": "Umatilla"
+            },
+            {
+              "code": "1667-5",
+              "display": "Umpqua",
+              "definition": "Umpqua",
+              "concept": [
+                {
+                  "code": "1668-3",
+                  "display": "Cow Creek Umpqua",
+                  "definition": "Cow Creek Umpqua"
+                }
+              ]
+            },
+            {
+              "code": "1670-9",
+              "display": "Ute",
+              "definition": "Ute",
+              "concept": [
+                {
+                  "code": "1671-7",
+                  "display": "Allen Canyon",
+                  "definition": "Allen Canyon"
+                },
+                {
+                  "code": "1672-5",
+                  "display": "Uintah Ute",
+                  "definition": "Uintah Ute"
+                },
+                {
+                  "code": "1673-3",
+                  "display": "Ute Mountain Ute",
+                  "definition": "Ute Mountain Ute"
+                }
+              ]
+            },
+            {
+              "code": "1675-8",
+              "display": "Wailaki",
+              "definition": "Wailaki"
+            },
+            {
+              "code": "1677-4",
+              "display": "Walla-Walla",
+              "definition": "Walla-Walla"
+            },
+            {
+              "code": "1679-0",
+              "display": "Wampanoag",
+              "definition": "Wampanoag",
+              "concept": [
+                {
+                  "code": "1680-8",
+                  "display": "Gay Head Wampanoag",
+                  "definition": "Gay Head Wampanoag"
+                },
+                {
+                  "code": "1681-6",
+                  "display": "Mashpee Wampanoag",
+                  "definition": "Mashpee Wampanoag"
+                }
+              ]
+            },
+            {
+              "code": "1683-2",
+              "display": "Warm Springs",
+              "definition": "Warm Springs"
+            },
+            {
+              "code": "1685-7",
+              "display": "Wascopum",
+              "definition": "Wascopum"
+            },
+            {
+              "code": "1687-3",
+              "display": "Washoe",
+              "definition": "Washoe",
+              "concept": [
+                {
+                  "code": "1688-1",
+                  "display": "Alpine",
+                  "definition": "Alpine"
+                },
+                {
+                  "code": "1689-9",
+                  "display": "Carson",
+                  "definition": "Carson"
+                },
+                {
+                  "code": "1690-7",
+                  "display": "Dresslerville",
+                  "definition": "Dresslerville"
+                }
+              ]
+            },
+            {
+              "code": "1692-3",
+              "display": "Wichita",
+              "definition": "Wichita"
+            },
+            {
+              "code": "1694-9",
+              "display": "Wind River",
+              "definition": "Wind River"
+            },
+            {
+              "code": "1696-4",
+              "display": "Winnebago",
+              "definition": "Winnebago",
+              "concept": [
+                {
+                  "code": "1697-2",
+                  "display": "Ho-chunk",
+                  "definition": "Ho-chunk"
+                },
+                {
+                  "code": "1698-0",
+                  "display": "Nebraska Winnebago",
+                  "definition": "Nebraska Winnebago"
+                }
+              ]
+            },
+            {
+              "code": "1700-4",
+              "display": "Winnemucca",
+              "definition": "Winnemucca"
+            },
+            {
+              "code": "1702-0",
+              "display": "Wintun",
+              "definition": "Wintun"
+            },
+            {
+              "code": "1704-6",
+              "display": "Wiyot",
+              "definition": "Wiyot",
+              "concept": [
+                {
+                  "code": "1705-3",
+                  "display": "Table Bluff",
+                  "definition": "Table Bluff"
+                }
+              ]
+            },
+            {
+              "code": "1707-9",
+              "display": "Yakama",
+              "definition": "Yakama"
+            },
+            {
+              "code": "1709-5",
+              "display": "Yakama Cowlitz",
+              "definition": "Yakama Cowlitz"
+            },
+            {
+              "code": "1711-1",
+              "display": "Yaqui",
+              "definition": "Yaqui",
+              "concept": [
+                {
+                  "code": "1712-9",
+                  "display": "Barrio Libre",
+                  "definition": "Barrio Libre"
+                },
+                {
+                  "code": "1713-7",
+                  "display": "Pascua Yaqui",
+                  "definition": "Pascua Yaqui"
+                }
+              ]
+            },
+            {
+              "code": "1715-2",
+              "display": "Yavapai Apache",
+              "definition": "Yavapai Apache"
+            },
+            {
+              "code": "1717-8",
+              "display": "Yokuts",
+              "definition": "Yokuts",
+              "concept": [
+                {
+                  "code": "1718-6",
+                  "display": "Chukchansi",
+                  "definition": "Chukchansi"
+                },
+                {
+                  "code": "1719-4",
+                  "display": "Tachi",
+                  "definition": "Tachi"
+                },
+                {
+                  "code": "1720-2",
+                  "display": "Tule River",
+                  "definition": "Tule River"
+                }
+              ]
+            },
+            {
+              "code": "1722-8",
+              "display": "Yuchi",
+              "definition": "Yuchi"
+            },
+            {
+              "code": "1724-4",
+              "display": "Yuman",
+              "definition": "Yuman",
+              "concept": [
+                {
+                  "code": "1725-1",
+                  "display": "Cocopah",
+                  "definition": "Cocopah"
+                },
+                {
+                  "code": "1726-9",
+                  "display": "Havasupai",
+                  "definition": "Havasupai"
+                },
+                {
+                  "code": "1727-7",
+                  "display": "Hualapai",
+                  "definition": "Hualapai"
+                },
+                {
+                  "code": "1728-5",
+                  "display": "Maricopa",
+                  "definition": "Maricopa"
+                },
+                {
+                  "code": "1729-3",
+                  "display": "Mohave",
+                  "definition": "Mohave"
+                },
+                {
+                  "code": "1730-1",
+                  "display": "Quechan",
+                  "definition": "Quechan"
+                },
+                {
+                  "code": "1731-9",
+                  "display": "Yavapai",
+                  "definition": "Yavapai"
+                }
+              ]
+            },
+            {
+              "code": "1732-7",
+              "display": "Yurok",
+              "definition": "Yurok",
+              "concept": [
+                {
+                  "code": "1733-5",
+                  "display": "Coast Yurok",
+                  "definition": "Coast Yurok"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "code": "1735-0",
+          "display": "Alaska Native",
+          "definition": "Alaska Native",
+          "concept": [
+            {
+              "code": "1737-6",
+              "display": "Alaska Indian",
+              "definition": "Alaska Indian",
+              "concept": [
+                {
+                  "code": "1739-2",
+                  "display": "Alaskan Athabascan",
+                  "definition": "Alaskan Athabascan",
+                  "concept": [
+                    {
+                      "code": "1740-0",
+                      "display": "Ahtna",
+                      "definition": "Ahtna"
+                    }
+                  ]
+                },
+                {
+                  "code": "1811-9",
+                  "display": "Southeast Alaska",
+                  "definition": "Southeast Alaska",
+                  "concept": [
+                    {
+                      "code": "1813-5",
+                      "display": "Tlingit-Haida",
+                      "definition": "Tlingit-Haida",
+                      "concept": [
+                        {
+                          "code": "1814-3",
+                          "display": "Angoon",
+                          "definition": "Angoon"
+                        },
+                        {
+                          "code": "1815-0",
+                          "display": "Central Council of Tlingit and Haida Tribes",
+                          "definition": "Central Council of Tlingit and Haida Tribes"
+                        },
+                        {
+                          "code": "1816-8",
+                          "display": "Chilkat",
+                          "definition": "Chilkat"
+                        },
+                        {
+                          "code": "1817-6",
+                          "display": "Chilkoot",
+                          "definition": "Chilkoot"
+                        },
+                        {
+                          "code": "1818-4",
+                          "display": "Craig",
+                          "definition": "Craig"
+                        },
+                        {
+                          "code": "1819-2",
+                          "display": "Douglas",
+                          "definition": "Douglas"
+                        },
+                        {
+                          "code": "1820-0",
+                          "display": "Haida",
+                          "definition": "Haida"
+                        },
+                        {
+                          "code": "1821-8",
+                          "display": "Hoonah",
+                          "definition": "Hoonah"
+                        },
+                        {
+                          "code": "1822-6",
+                          "display": "Hydaburg",
+                          "definition": "Hydaburg"
+                        },
+                        {
+                          "code": "1823-4",
+                          "display": "Kake",
+                          "definition": "Kake"
+                        },
+                        {
+                          "code": "1824-2",
+                          "display": "Kasaan",
+                          "definition": "Kasaan"
+                        },
+                        {
+                          "code": "1825-9",
+                          "display": "Kenaitze",
+                          "definition": "Kenaitze"
+                        },
+                        {
+                          "code": "1826-7",
+                          "display": "Ketchikan",
+                          "definition": "Ketchikan"
+                        },
+                        {
+                          "code": "1827-5",
+                          "display": "Klawock",
+                          "definition": "Klawock"
+                        },
+                        {
+                          "code": "1828-3",
+                          "display": "Pelican",
+                          "definition": "Pelican"
+                        },
+                        {
+                          "code": "1829-1",
+                          "display": "Petersburg",
+                          "definition": "Petersburg"
+                        },
+                        {
+                          "code": "1830-9",
+                          "display": "Saxman",
+                          "definition": "Saxman"
+                        },
+                        {
+                          "code": "1831-7",
+                          "display": "Sitka",
+                          "definition": "Sitka"
+                        },
+                        {
+                          "code": "1832-5",
+                          "display": "Tenakee Springs",
+                          "definition": "Tenakee Springs"
+                        },
+                        {
+                          "code": "1833-3",
+                          "display": "Tlingit",
+                          "definition": "Tlingit"
+                        },
+                        {
+                          "code": "1834-1",
+                          "display": "Wrangell",
+                          "definition": "Wrangell"
+                        },
+                        {
+                          "code": "1835-8",
+                          "display": "Yakutat",
+                          "definition": "Yakutat"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "1837-4",
+                      "display": "Tsimshian",
+                      "definition": "Tsimshian",
+                      "concept": [
+                        {
+                          "code": "1838-2",
+                          "display": "Metlakatla",
+                          "definition": "Metlakatla"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "code": "1840-8",
+              "display": "Eskimo",
+              "definition": "Eskimo",
+              "concept": [
+                {
+                  "code": "1842-4",
+                  "display": "Greenland Eskimo",
+                  "definition": "Greenland Eskimo"
+                },
+                {
+                  "code": "1844-0",
+                  "display": "Inupiat Eskimo",
+                  "definition": "Inupiat Eskimo",
+                  "concept": [
+                    {
+                      "code": "1845-7",
+                      "display": "Ambler",
+                      "definition": "Ambler"
+                    },
+                    {
+                      "code": "1846-5",
+                      "display": "Anaktuvuk",
+                      "definition": "Anaktuvuk"
+                    },
+                    {
+                      "code": "1847-3",
+                      "display": "Anaktuvuk Pass",
+                      "definition": "Anaktuvuk Pass"
+                    },
+                    {
+                      "code": "1848-1",
+                      "display": "Arctic Slope Inupiat",
+                      "definition": "Arctic Slope Inupiat"
+                    },
+                    {
+                      "code": "1849-9",
+                      "display": "Arctic Slope Corporation",
+                      "definition": "Arctic Slope Corporation"
+                    },
+                    {
+                      "code": "1850-7",
+                      "display": "Atqasuk",
+                      "definition": "Atqasuk"
+                    },
+                    {
+                      "code": "1851-5",
+                      "display": "Barrow",
+                      "definition": "Barrow"
+                    },
+                    {
+                      "code": "1852-3",
+                      "display": "Bering Straits Inupiat",
+                      "definition": "Bering Straits Inupiat"
+                    },
+                    {
+                      "code": "1853-1",
+                      "display": "Brevig Mission",
+                      "definition": "Brevig Mission"
+                    },
+                    {
+                      "code": "1854-9",
+                      "display": "Buckland",
+                      "definition": "Buckland"
+                    },
+                    {
+                      "code": "1855-6",
+                      "display": "Chinik",
+                      "definition": "Chinik"
+                    },
+                    {
+                      "code": "1856-4",
+                      "display": "Council",
+                      "definition": "Council"
+                    },
+                    {
+                      "code": "1857-2",
+                      "display": "Deering",
+                      "definition": "Deering"
+                    },
+                    {
+                      "code": "1858-0",
+                      "display": "Elim",
+                      "definition": "Elim"
+                    },
+                    {
+                      "code": "1859-8",
+                      "display": "Golovin",
+                      "definition": "Golovin"
+                    },
+                    {
+                      "code": "1860-6",
+                      "display": "Inalik Diomede",
+                      "definition": "Inalik Diomede"
+                    },
+                    {
+                      "code": "1861-4",
+                      "display": "Inupiaq",
+                      "definition": "Inupiaq"
+                    },
+                    {
+                      "code": "1862-2",
+                      "display": "Kaktovik",
+                      "definition": "Kaktovik"
+                    },
+                    {
+                      "code": "1863-0",
+                      "display": "Kawerak",
+                      "definition": "Kawerak"
+                    },
+                    {
+                      "code": "1864-8",
+                      "display": "Kiana",
+                      "definition": "Kiana"
+                    },
+                    {
+                      "code": "1865-5",
+                      "display": "Kivalina",
+                      "definition": "Kivalina"
+                    },
+                    {
+                      "code": "1866-3",
+                      "display": "Kobuk",
+                      "definition": "Kobuk"
+                    },
+                    {
+                      "code": "1867-1",
+                      "display": "Kotzebue",
+                      "definition": "Kotzebue"
+                    },
+                    {
+                      "code": "1868-9",
+                      "display": "Koyuk",
+                      "definition": "Koyuk"
+                    },
+                    {
+                      "code": "1869-7",
+                      "display": "Kwiguk",
+                      "definition": "Kwiguk"
+                    },
+                    {
+                      "code": "1870-5",
+                      "display": "Mauneluk Inupiat",
+                      "definition": "Mauneluk Inupiat"
+                    },
+                    {
+                      "code": "1871-3",
+                      "display": "Nana Inupiat",
+                      "definition": "Nana Inupiat"
+                    },
+                    {
+                      "code": "1872-1",
+                      "display": "Noatak",
+                      "definition": "Noatak"
+                    },
+                    {
+                      "code": "1873-9",
+                      "display": "Nome",
+                      "definition": "Nome"
+                    },
+                    {
+                      "code": "1874-7",
+                      "display": "Noorvik",
+                      "definition": "Noorvik"
+                    },
+                    {
+                      "code": "1875-4",
+                      "display": "Nuiqsut",
+                      "definition": "Nuiqsut"
+                    },
+                    {
+                      "code": "1876-2",
+                      "display": "Point Hope",
+                      "definition": "Point Hope"
+                    },
+                    {
+                      "code": "1877-0",
+                      "display": "Point Lay",
+                      "definition": "Point Lay"
+                    },
+                    {
+                      "code": "1878-8",
+                      "display": "Selawik",
+                      "definition": "Selawik"
+                    },
+                    {
+                      "code": "1879-6",
+                      "display": "Shaktoolik",
+                      "definition": "Shaktoolik"
+                    },
+                    {
+                      "code": "1880-4",
+                      "display": "Shishmaref",
+                      "definition": "Shishmaref"
+                    },
+                    {
+                      "code": "1881-2",
+                      "display": "Shungnak",
+                      "definition": "Shungnak"
+                    },
+                    {
+                      "code": "1882-0",
+                      "display": "Solomon",
+                      "definition": "Solomon"
+                    },
+                    {
+                      "code": "1883-8",
+                      "display": "Teller",
+                      "definition": "Teller"
+                    },
+                    {
+                      "code": "1884-6",
+                      "display": "Unalakleet",
+                      "definition": "Unalakleet"
+                    },
+                    {
+                      "code": "1885-3",
+                      "display": "Wainwright",
+                      "definition": "Wainwright"
+                    },
+                    {
+                      "code": "1886-1",
+                      "display": "Wales",
+                      "definition": "Wales"
+                    },
+                    {
+                      "code": "1887-9",
+                      "display": "White Mountain",
+                      "definition": "White Mountain"
+                    },
+                    {
+                      "code": "1888-7",
+                      "display": "White Mountain Inupiat",
+                      "definition": "White Mountain Inupiat"
+                    },
+                    {
+                      "code": "1889-5",
+                      "display": "Mary's Igloo",
+                      "definition": "Mary's Igloo"
+                    }
+                  ]
+                },
+                {
+                  "code": "1891-1",
+                  "display": "Siberian Eskimo",
+                  "definition": "Siberian Eskimo",
+                  "concept": [
+                    {
+                      "code": "1892-9",
+                      "display": "Gambell",
+                      "definition": "Gambell"
+                    },
+                    {
+                      "code": "1893-7",
+                      "display": "Savoonga",
+                      "definition": "Savoonga"
+                    },
+                    {
+                      "code": "1894-5",
+                      "display": "Siberian Yupik",
+                      "definition": "Siberian Yupik"
+                    }
+                  ]
+                },
+                {
+                  "code": "1896-0",
+                  "display": "Yupik Eskimo",
+                  "definition": "Yupik Eskimo",
+                  "concept": [
+                    {
+                      "code": "1897-8",
+                      "display": "Akiachak",
+                      "definition": "Akiachak"
+                    },
+                    {
+                      "code": "1898-6",
+                      "display": "Akiak",
+                      "definition": "Akiak"
+                    },
+                    {
+                      "code": "1899-4",
+                      "display": "Alakanuk",
+                      "definition": "Alakanuk"
+                    },
+                    {
+                      "code": "1900-0",
+                      "display": "Aleknagik",
+                      "definition": "Aleknagik"
+                    },
+                    {
+                      "code": "1901-8",
+                      "display": "Andreafsky",
+                      "definition": "Andreafsky"
+                    },
+                    {
+                      "code": "1902-6",
+                      "display": "Aniak",
+                      "definition": "Aniak"
+                    },
+                    {
+                      "code": "1903-4",
+                      "display": "Atmautluak",
+                      "definition": "Atmautluak"
+                    },
+                    {
+                      "code": "1904-2",
+                      "display": "Bethel",
+                      "definition": "Bethel"
+                    },
+                    {
+                      "code": "1905-9",
+                      "display": "Bill Moore's Slough",
+                      "definition": "Bill Moore's Slough"
+                    },
+                    {
+                      "code": "1906-7",
+                      "display": "Bristol Bay Yupik",
+                      "definition": "Bristol Bay Yupik"
+                    },
+                    {
+                      "code": "1907-5",
+                      "display": "Calista Yupik",
+                      "definition": "Calista Yupik"
+                    },
+                    {
+                      "code": "1908-3",
+                      "display": "Chefornak",
+                      "definition": "Chefornak"
+                    },
+                    {
+                      "code": "1909-1",
+                      "display": "Chevak",
+                      "definition": "Chevak"
+                    },
+                    {
+                      "code": "1910-9",
+                      "display": "Chuathbaluk",
+                      "definition": "Chuathbaluk"
+                    },
+                    {
+                      "code": "1911-7",
+                      "display": "Clark's Point",
+                      "definition": "Clark's Point"
+                    },
+                    {
+                      "code": "1912-5",
+                      "display": "Crooked Creek",
+                      "definition": "Crooked Creek"
+                    },
+                    {
+                      "code": "1913-3",
+                      "display": "Dillingham",
+                      "definition": "Dillingham"
+                    },
+                    {
+                      "code": "1914-1",
+                      "display": "Eek",
+                      "definition": "Eek"
+                    },
+                    {
+                      "code": "1915-8",
+                      "display": "Ekuk",
+                      "definition": "Ekuk"
+                    },
+                    {
+                      "code": "1916-6",
+                      "display": "Ekwok",
+                      "definition": "Ekwok"
+                    },
+                    {
+                      "code": "1917-4",
+                      "display": "Emmonak",
+                      "definition": "Emmonak"
+                    },
+                    {
+                      "code": "1918-2",
+                      "display": "Goodnews Bay",
+                      "definition": "Goodnews Bay"
+                    },
+                    {
+                      "code": "1919-0",
+                      "display": "Hooper Bay",
+                      "definition": "Hooper Bay"
+                    },
+                    {
+                      "code": "1920-8",
+                      "display": "Iqurmuit (Russian Mission)",
+                      "definition": "Iqurmuit (Russian Mission)"
+                    },
+                    {
+                      "code": "1921-6",
+                      "display": "Kalskag",
+                      "definition": "Kalskag"
+                    },
+                    {
+                      "code": "1922-4",
+                      "display": "Kasigluk",
+                      "definition": "Kasigluk"
+                    },
+                    {
+                      "code": "1923-2",
+                      "display": "Kipnuk",
+                      "definition": "Kipnuk"
+                    },
+                    {
+                      "code": "1924-0",
+                      "display": "Koliganek",
+                      "definition": "Koliganek"
+                    },
+                    {
+                      "code": "1925-7",
+                      "display": "Kongiganak",
+                      "definition": "Kongiganak"
+                    },
+                    {
+                      "code": "1926-5",
+                      "display": "Kotlik",
+                      "definition": "Kotlik"
+                    },
+                    {
+                      "code": "1927-3",
+                      "display": "Kwethluk",
+                      "definition": "Kwethluk"
+                    },
+                    {
+                      "code": "1928-1",
+                      "display": "Kwigillingok",
+                      "definition": "Kwigillingok"
+                    },
+                    {
+                      "code": "1929-9",
+                      "display": "Levelock",
+                      "definition": "Levelock"
+                    },
+                    {
+                      "code": "1930-7",
+                      "display": "Lower Kalskag",
+                      "definition": "Lower Kalskag"
+                    },
+                    {
+                      "code": "1931-5",
+                      "display": "Manokotak",
+                      "definition": "Manokotak"
+                    },
+                    {
+                      "code": "1932-3",
+                      "display": "Marshall",
+                      "definition": "Marshall"
+                    },
+                    {
+                      "code": "1933-1",
+                      "display": "Mekoryuk",
+                      "definition": "Mekoryuk"
+                    },
+                    {
+                      "code": "1934-9",
+                      "display": "Mountain Village",
+                      "definition": "Mountain Village"
+                    },
+                    {
+                      "code": "1935-6",
+                      "display": "Naknek",
+                      "definition": "Naknek"
+                    },
+                    {
+                      "code": "1936-4",
+                      "display": "Napaumute",
+                      "definition": "Napaumute"
+                    },
+                    {
+                      "code": "1937-2",
+                      "display": "Napakiak",
+                      "definition": "Napakiak"
+                    },
+                    {
+                      "code": "1938-0",
+                      "display": "Napaskiak",
+                      "definition": "Napaskiak"
+                    },
+                    {
+                      "code": "1939-8",
+                      "display": "Newhalen",
+                      "definition": "Newhalen"
+                    },
+                    {
+                      "code": "1940-6",
+                      "display": "New Stuyahok",
+                      "definition": "New Stuyahok"
+                    },
+                    {
+                      "code": "1941-4",
+                      "display": "Newtok",
+                      "definition": "Newtok"
+                    },
+                    {
+                      "code": "1942-2",
+                      "display": "Nightmute",
+                      "definition": "Nightmute"
+                    },
+                    {
+                      "code": "1943-0",
+                      "display": "Nunapitchukv",
+                      "definition": "Nunapitchukv"
+                    },
+                    {
+                      "code": "1944-8",
+                      "display": "Oscarville",
+                      "definition": "Oscarville"
+                    },
+                    {
+                      "code": "1945-5",
+                      "display": "Pilot Station",
+                      "definition": "Pilot Station"
+                    },
+                    {
+                      "code": "1946-3",
+                      "display": "Pitkas Point",
+                      "definition": "Pitkas Point"
+                    },
+                    {
+                      "code": "1947-1",
+                      "display": "Platinum",
+                      "definition": "Platinum"
+                    },
+                    {
+                      "code": "1948-9",
+                      "display": "Portage Creek",
+                      "definition": "Portage Creek"
+                    },
+                    {
+                      "code": "1949-7",
+                      "display": "Quinhagak",
+                      "definition": "Quinhagak"
+                    },
+                    {
+                      "code": "1950-5",
+                      "display": "Red Devil",
+                      "definition": "Red Devil"
+                    },
+                    {
+                      "code": "1951-3",
+                      "display": "St. Michael",
+                      "definition": "St. Michael"
+                    },
+                    {
+                      "code": "1952-1",
+                      "display": "Scammon Bay",
+                      "definition": "Scammon Bay"
+                    },
+                    {
+                      "code": "1953-9",
+                      "display": "Sheldon's Point",
+                      "definition": "Sheldon's Point"
+                    },
+                    {
+                      "code": "1954-7",
+                      "display": "Sleetmute",
+                      "definition": "Sleetmute"
+                    },
+                    {
+                      "code": "1955-4",
+                      "display": "Stebbins",
+                      "definition": "Stebbins"
+                    },
+                    {
+                      "code": "1956-2",
+                      "display": "Togiak",
+                      "definition": "Togiak"
+                    },
+                    {
+                      "code": "1957-0",
+                      "display": "Toksook",
+                      "definition": "Toksook"
+                    },
+                    {
+                      "code": "1958-8",
+                      "display": "Tulukskak",
+                      "definition": "Tulukskak"
+                    },
+                    {
+                      "code": "1959-6",
+                      "display": "Tuntutuliak",
+                      "definition": "Tuntutuliak"
+                    },
+                    {
+                      "code": "1960-4",
+                      "display": "Tununak",
+                      "definition": "Tununak"
+                    },
+                    {
+                      "code": "1961-2",
+                      "display": "Twin Hills",
+                      "definition": "Twin Hills"
+                    },
+                    {
+                      "code": "1962-0",
+                      "display": "Georgetown",
+                      "definition": "Georgetown"
+                    },
+                    {
+                      "code": "1963-8",
+                      "display": "St. Mary's",
+                      "definition": "St. Mary's"
+                    },
+                    {
+                      "code": "1964-6",
+                      "display": "Umkumiate",
+                      "definition": "Umkumiate"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "code": "1966-1",
+              "display": "Aleut",
+              "definition": "Aleut",
+              "concept": [
+                {
+                  "code": "1968-7",
+                  "display": "Alutiiq Aleut",
+                  "definition": "Alutiiq Aleut",
+                  "concept": [
+                    {
+                      "code": "1969-5",
+                      "display": "Tatitlek",
+                      "definition": "Tatitlek"
+                    },
+                    {
+                      "code": "1970-3",
+                      "display": "Ugashik",
+                      "definition": "Ugashik"
+                    }
+                  ]
+                },
+                {
+                  "code": "1972-9",
+                  "display": "Bristol Bay Aleut",
+                  "definition": "Bristol Bay Aleut",
+                  "concept": [
+                    {
+                      "code": "1973-7",
+                      "display": "Chignik",
+                      "definition": "Chignik"
+                    },
+                    {
+                      "code": "1974-5",
+                      "display": "Chignik Lake",
+                      "definition": "Chignik Lake"
+                    },
+                    {
+                      "code": "1975-2",
+                      "display": "Egegik",
+                      "definition": "Egegik"
+                    },
+                    {
+                      "code": "1976-0",
+                      "display": "Igiugig",
+                      "definition": "Igiugig"
+                    },
+                    {
+                      "code": "1977-8",
+                      "display": "Ivanof Bay",
+                      "definition": "Ivanof Bay"
+                    },
+                    {
+                      "code": "1978-6",
+                      "display": "King Salmon",
+                      "definition": "King Salmon"
+                    },
+                    {
+                      "code": "1979-4",
+                      "display": "Kokhanok",
+                      "definition": "Kokhanok"
+                    },
+                    {
+                      "code": "1980-2",
+                      "display": "Perryville",
+                      "definition": "Perryville"
+                    },
+                    {
+                      "code": "1981-0",
+                      "display": "Pilot Point",
+                      "definition": "Pilot Point"
+                    },
+                    {
+                      "code": "1982-8",
+                      "display": "Port Heiden",
+                      "definition": "Port Heiden"
+                    }
+                  ]
+                },
+                {
+                  "code": "1984-4",
+                  "display": "Chugach Aleut",
+                  "definition": "Chugach Aleut",
+                  "concept": [
+                    {
+                      "code": "1985-1",
+                      "display": "Chenega",
+                      "definition": "Chenega"
+                    },
+                    {
+                      "code": "1986-9",
+                      "display": "Chugach Corporation",
+                      "definition": "Chugach Corporation"
+                    },
+                    {
+                      "code": "1987-7",
+                      "display": "English Bay",
+                      "definition": "English Bay"
+                    },
+                    {
+                      "code": "1988-5",
+                      "display": "Port Graham",
+                      "definition": "Port Graham"
+                    }
+                  ]
+                },
+                {
+                  "code": "1990-1",
+                  "display": "Eyak",
+                  "definition": "Eyak"
+                },
+                {
+                  "code": "1992-7",
+                  "display": "Koniag Aleut",
+                  "definition": "Koniag Aleut",
+                  "concept": [
+                    {
+                      "code": "1993-5",
+                      "display": "Akhiok",
+                      "definition": "Akhiok"
+                    },
+                    {
+                      "code": "1994-3",
+                      "display": "Agdaagux",
+                      "definition": "Agdaagux"
+                    },
+                    {
+                      "code": "1995-0",
+                      "display": "Karluk",
+                      "definition": "Karluk"
+                    },
+                    {
+                      "code": "1996-8",
+                      "display": "Kodiak",
+                      "definition": "Kodiak"
+                    },
+                    {
+                      "code": "1997-6",
+                      "display": "Larsen Bay",
+                      "definition": "Larsen Bay"
+                    },
+                    {
+                      "code": "1998-4",
+                      "display": "Old Harbor",
+                      "definition": "Old Harbor"
+                    },
+                    {
+                      "code": "1999-2",
+                      "display": "Ouzinkie",
+                      "definition": "Ouzinkie"
+                    },
+                    {
+                      "code": "2000-8",
+                      "display": "Port Lions",
+                      "definition": "Port Lions"
+                    }
+                  ]
+                },
+                {
+                  "code": "2002-4",
+                  "display": "Sugpiaq",
+                  "definition": "Sugpiaq"
+                },
+                {
+                  "code": "2004-0",
+                  "display": "Suqpigaq",
+                  "definition": "Suqpigaq"
+                },
+                {
+                  "code": "2006-5",
+                  "display": "Unangan Aleut",
+                  "definition": "Unangan Aleut",
+                  "concept": [
+                    {
+                      "code": "2007-3",
+                      "display": "Akutan",
+                      "definition": "Akutan"
+                    },
+                    {
+                      "code": "2008-1",
+                      "display": "Aleut Corporation",
+                      "definition": "Aleut Corporation"
+                    },
+                    {
+                      "code": "2009-9",
+                      "display": "Aleutian",
+                      "definition": "Aleutian"
+                    },
+                    {
+                      "code": "2010-7",
+                      "display": "Aleutian Islander",
+                      "definition": "Aleutian Islander"
+                    },
+                    {
+                      "code": "2011-5",
+                      "display": "Atka",
+                      "definition": "Atka"
+                    },
+                    {
+                      "code": "2012-3",
+                      "display": "Belkofski",
+                      "definition": "Belkofski"
+                    },
+                    {
+                      "code": "2013-1",
+                      "display": "Chignik Lagoon",
+                      "definition": "Chignik Lagoon"
+                    },
+                    {
+                      "code": "2014-9",
+                      "display": "King Cove",
+                      "definition": "King Cove"
+                    },
+                    {
+                      "code": "2015-6",
+                      "display": "False Pass",
+                      "definition": "False Pass"
+                    },
+                    {
+                      "code": "2016-4",
+                      "display": "Nelson Lagoon",
+                      "definition": "Nelson Lagoon"
+                    },
+                    {
+                      "code": "2017-2",
+                      "display": "Nikolski",
+                      "definition": "Nikolski"
+                    },
+                    {
+                      "code": "2018-0",
+                      "display": "Pauloff Harbor",
+                      "definition": "Pauloff Harbor"
+                    },
+                    {
+                      "code": "2019-8",
+                      "display": "Qagan Toyagungin",
+                      "definition": "Qagan Toyagungin"
+                    },
+                    {
+                      "code": "2020-6",
+                      "display": "Qawalangin",
+                      "definition": "Qawalangin"
+                    },
+                    {
+                      "code": "2021-4",
+                      "display": "St. George",
+                      "definition": "St. George"
+                    },
+                    {
+                      "code": "2022-2",
+                      "display": "St. Paul",
+                      "definition": "St. Paul"
+                    },
+                    {
+                      "code": "2023-0",
+                      "display": "Sand Point",
+                      "definition": "Sand Point"
+                    },
+                    {
+                      "code": "2024-8",
+                      "display": "South Naknek",
+                      "definition": "South Naknek"
+                    },
+                    {
+                      "code": "2025-5",
+                      "display": "Unalaska",
+                      "definition": "Unalaska"
+                    },
+                    {
+                      "code": "2026-3",
+                      "display": "Unga",
+                      "definition": "Unga"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "code": "2028-9",
+      "display": "Asian",
+      "definition": "Asian",
+      "concept": [
+        {
+          "code": "2029-7",
+          "display": "Asian Indian",
+          "definition": "Asian Indian"
+        },
+        {
+          "code": "2030-5",
+          "display": "Bangladeshi",
+          "definition": "Bangladeshi"
+        },
+        {
+          "code": "2031-3",
+          "display": "Bhutanese",
+          "definition": "Bhutanese"
+        },
+        {
+          "code": "2032-1",
+          "display": "Burmese",
+          "definition": "Burmese"
+        },
+        {
+          "code": "2033-9",
+          "display": "Cambodian",
+          "definition": "Cambodian"
+        },
+        {
+          "code": "2034-7",
+          "display": "Chinese",
+          "definition": "Chinese"
+        },
+        {
+          "code": "2035-4",
+          "display": "Taiwanese",
+          "definition": "Taiwanese"
+        },
+        {
+          "code": "2036-2",
+          "display": "Filipino",
+          "definition": "Filipino"
+        },
+        {
+          "code": "2037-0",
+          "display": "Hmong",
+          "definition": "Hmong"
+        },
+        {
+          "code": "2038-8",
+          "display": "Indonesian",
+          "definition": "Indonesian"
+        },
+        {
+          "code": "2039-6",
+          "display": "Japanese",
+          "definition": "Japanese"
+        },
+        {
+          "code": "2040-4",
+          "display": "Korean",
+          "definition": "Korean"
+        },
+        {
+          "code": "2041-2",
+          "display": "Laotian",
+          "definition": "Laotian"
+        },
+        {
+          "code": "2042-0",
+          "display": "Malaysian",
+          "definition": "Malaysian"
+        },
+        {
+          "code": "2043-8",
+          "display": "Okinawan",
+          "definition": "Okinawan"
+        },
+        {
+          "code": "2044-6",
+          "display": "Pakistani",
+          "definition": "Pakistani"
+        },
+        {
+          "code": "2045-3",
+          "display": "Sri Lankan",
+          "definition": "Sri Lankan"
+        },
+        {
+          "code": "2046-1",
+          "display": "Thai",
+          "definition": "Thai"
+        },
+        {
+          "code": "2047-9",
+          "display": "Vietnamese",
+          "definition": "Vietnamese"
+        },
+        {
+          "code": "2048-7",
+          "display": "Iwo Jiman",
+          "definition": "Iwo Jiman"
+        },
+        {
+          "code": "2049-5",
+          "display": "Maldivian",
+          "definition": "Maldivian"
+        },
+        {
+          "code": "2050-3",
+          "display": "Nepalese",
+          "definition": "Nepalese"
+        },
+        {
+          "code": "2051-1",
+          "display": "Singaporean",
+          "definition": "Singaporean"
+        },
+        {
+          "code": "2052-9",
+          "display": "Madagascar",
+          "definition": "Madagascar"
+        }
+      ]
+    },
+    {
+      "code": "2054-5",
+      "display": "Black or African American",
+      "definition": "Black or African American",
+      "concept": [
+        {
+          "code": "2056-0",
+          "display": "Black",
+          "definition": "Black"
+        },
+        {
+          "code": "2058-6",
+          "display": "African American",
+          "definition": "African American"
+        },
+        {
+          "code": "2060-2",
+          "display": "African",
+          "definition": "African",
+          "concept": [
+            {
+              "code": "2061-0",
+              "display": "Botswanan",
+              "definition": "Botswanan"
+            },
+            {
+              "code": "2062-8",
+              "display": "Ethiopian",
+              "definition": "Ethiopian"
+            },
+            {
+              "code": "2063-6",
+              "display": "Liberian",
+              "definition": "Liberian"
+            },
+            {
+              "code": "2064-4",
+              "display": "Namibian",
+              "definition": "Namibian"
+            },
+            {
+              "code": "2065-1",
+              "display": "Nigerian",
+              "definition": "Nigerian"
+            },
+            {
+              "code": "2066-9",
+              "display": "Zairean",
+              "definition": "Zairean"
+            }
+          ]
+        },
+        {
+          "code": "2067-7",
+          "display": "Bahamian",
+          "definition": "Bahamian"
+        },
+        {
+          "code": "2068-5",
+          "display": "Barbadian",
+          "definition": "Barbadian"
+        },
+        {
+          "code": "2069-3",
+          "display": "Dominican",
+          "definition": "Dominican"
+        },
+        {
+          "code": "2070-1",
+          "display": "Dominica Islander",
+          "definition": "Dominica Islander"
+        },
+        {
+          "code": "2071-9",
+          "display": "Haitian",
+          "definition": "Haitian"
+        },
+        {
+          "code": "2072-7",
+          "display": "Jamaican",
+          "definition": "Jamaican"
+        },
+        {
+          "code": "2073-5",
+          "display": "Tobagoan",
+          "definition": "Tobagoan"
+        },
+        {
+          "code": "2074-3",
+          "display": "Trinidadian",
+          "definition": "Trinidadian"
+        },
+        {
+          "code": "2075-0",
+          "display": "West Indian",
+          "definition": "West Indian"
+        }
+      ]
+    },
+    {
+      "code": "2076-8",
+      "display": "Native Hawaiian or Other Pacific Islander",
+      "definition": "Native Hawaiian or Other Pacific Islander",
+      "concept": [
+        {
+          "code": "2078-4",
+          "display": "Polynesian",
+          "definition": "Polynesian",
+          "concept": [
+            {
+              "code": "2079-2",
+              "display": "Native Hawaiian",
+              "definition": "Native Hawaiian"
+            },
+            {
+              "code": "2080-0",
+              "display": "Samoan",
+              "definition": "Samoan"
+            },
+            {
+              "code": "2081-8",
+              "display": "Tahitian",
+              "definition": "Tahitian"
+            },
+            {
+              "code": "2082-6",
+              "display": "Tongan",
+              "definition": "Tongan"
+            },
+            {
+              "code": "2083-4",
+              "display": "Tokelauan",
+              "definition": "Tokelauan"
+            }
+          ]
+        },
+        {
+          "code": "2085-9",
+          "display": "Micronesian",
+          "definition": "Micronesian",
+          "concept": [
+            {
+              "code": "2086-7",
+              "display": "Guamanian or Chamorro",
+              "definition": "Guamanian or Chamorro"
+            },
+            {
+              "code": "2087-5",
+              "display": "Guamanian",
+              "definition": "Guamanian"
+            },
+            {
+              "code": "2088-3",
+              "display": "Chamorro",
+              "definition": "Chamorro"
+            },
+            {
+              "code": "2089-1",
+              "display": "Mariana Islander",
+              "definition": "Mariana Islander"
+            },
+            {
+              "code": "2090-9",
+              "display": "Marshallese",
+              "definition": "Marshallese"
+            },
+            {
+              "code": "2091-7",
+              "display": "Palauan",
+              "definition": "Palauan"
+            },
+            {
+              "code": "2092-5",
+              "display": "Carolinian",
+              "definition": "Carolinian"
+            },
+            {
+              "code": "2093-3",
+              "display": "Kosraean",
+              "definition": "Kosraean"
+            },
+            {
+              "code": "2094-1",
+              "display": "Pohnpeian",
+              "definition": "Pohnpeian"
+            },
+            {
+              "code": "2095-8",
+              "display": "Saipanese",
+              "definition": "Saipanese"
+            },
+            {
+              "code": "2096-6",
+              "display": "Kiribati",
+              "definition": "Kiribati"
+            },
+            {
+              "code": "2097-4",
+              "display": "Chuukese",
+              "definition": "Chuukese"
+            },
+            {
+              "code": "2098-2",
+              "display": "Yapese",
+              "definition": "Yapese"
+            }
+          ]
+        },
+        {
+          "code": "2100-6",
+          "display": "Melanesian",
+          "definition": "Melanesian",
+          "concept": [
+            {
+              "code": "2101-4",
+              "display": "Fijian",
+              "definition": "Fijian"
+            },
+            {
+              "code": "2102-2",
+              "display": "Papua New Guinean",
+              "definition": "Papua New Guinean"
+            },
+            {
+              "code": "2103-0",
+              "display": "Solomon Islander",
+              "definition": "Solomon Islander"
+            },
+            {
+              "code": "2104-8",
+              "display": "New Hebrides",
+              "definition": "New Hebrides"
+            }
+          ]
+        },
+        {
+          "code": "2500-7",
+          "display": "Other Pacific Islander",
+          "definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of Other code is deprecated."
+        }
+      ]
+    },
+    {
+      "code": "2106-3",
+      "display": "White",
+      "definition": "White",
+      "concept": [
+        {
+          "code": "2108-9",
+          "display": "European",
+          "definition": "European",
+          "concept": [
+            {
+              "code": "2109-7",
+              "display": "Armenian",
+              "definition": "Armenian"
+            },
+            {
+              "code": "2110-5",
+              "display": "English",
+              "definition": "English"
+            },
+            {
+              "code": "2111-3",
+              "display": "French",
+              "definition": "French"
+            },
+            {
+              "code": "2112-1",
+              "display": "German",
+              "definition": "German"
+            },
+            {
+              "code": "2113-9",
+              "display": "Irish",
+              "definition": "Irish"
+            },
+            {
+              "code": "2114-7",
+              "display": "Italian",
+              "definition": "Italian"
+            },
+            {
+              "code": "2115-4",
+              "display": "Polish",
+              "definition": "Polish"
+            },
+            {
+              "code": "2116-2",
+              "display": "Scottish",
+              "definition": "Scottish"
+            }
+          ]
+        },
+        {
+          "code": "2118-8",
+          "display": "Middle Eastern or North African",
+          "definition": "Middle Eastern or North African",
+          "concept": [
+            {
+              "code": "2119-6",
+              "display": "Assyrian",
+              "definition": "Assyrian"
+            },
+            {
+              "code": "2120-4",
+              "display": "Egyptian",
+              "definition": "Egyptian"
+            },
+            {
+              "code": "2121-2",
+              "display": "Iranian",
+              "definition": "Iranian"
+            },
+            {
+              "code": "2122-0",
+              "display": "Iraqi",
+              "definition": "Iraqi"
+            },
+            {
+              "code": "2123-8",
+              "display": "Lebanese",
+              "definition": "Lebanese"
+            },
+            {
+              "code": "2124-6",
+              "display": "Palestinian",
+              "definition": "Palestinian"
+            },
+            {
+              "code": "2125-3",
+              "display": "Syrian",
+              "definition": "Syrian"
+            },
+            {
+              "code": "2126-1",
+              "display": "Afghanistani",
+              "definition": "Afghanistani"
+            },
+            {
+              "code": "2127-9",
+              "display": "Israeili",
+              "definition": "Israeili"
+            }
+          ]
+        },
+        {
+          "code": "2129-5",
+          "display": "Arab",
+          "definition": "Arab"
+        }
+      ]
+    },
+    {
+      "code": "2131-1",
+      "display": "Other Race",
+      "definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of Other code is deprecated."
+    }
+  ]
+}


### PR DESCRIPTION
The previously available value sets for ethnicity and race, hosted at hl7.org, are no longer available for automated download.

Dumped contents to filesystem for a reliable import on deploy.