### PR TITLE
longitudinal report opt out changes

### DIFF
--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -98,6 +98,7 @@ export default { /*global $ */
             ).fail(function() {
                 if (callback) {
                     callback({"error": DEFAULT_SERVER_DATA_ERROR});
+                    fieldHelper.showError(targetField);
                 }
             });
             return;
@@ -159,7 +160,7 @@ export default { /*global $ */
                     loadingField.animate({"opacity": 0}, __timeout, function() {
                         successField.animate({"opacity": 1}, __timeout, function() {
                             setTimeout(function() {
-                                successField.animate({"opacity": 0}, __timeout * 2);
+                                successField.animate({"opacity": 0}, __timeout * 4);
                             }, __timeout * 2);
                         });
                     });
@@ -182,7 +183,7 @@ export default { /*global $ */
                     loadingField.animate({"opacity": 0}, __timeout, function() {
                         errorField.animate({"opacity": 1}, __timeout, function() {
                             setTimeout(function() {
-                                errorField.animate({"opacity": 0}, __timeout * 2);
+                                errorField.animate({"opacity": 0}, __timeout * 4);
                             }, __timeout * 2);
                         });
                     });

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -3805,11 +3805,11 @@ section.header {
     }
   }
   .answer {
-    border-radius: 32px;
+    border-radius: 50vmax;
     background: @muterColor;
     display: inline-block;
-    padding: 8px 16px;
-    min-width: 132px;
+    padding: 8px 24px;
+    min-width: 180px;
     text-align: center;
     &.warning {
       background-color: darken(@warningColor, 1%);


### PR DESCRIPTION
Address [TN-3242 story](https://movember.atlassian.net/browse/TN-3242?atlOrigin=eyJpIjoiOTE5YzI5Y2E1OTM5NDg4YWI4NTU2MWQ1NDljMTNkNzciLCJwIjoiaiJ9)

Changes:
- An opted out hard trigger now has one asterisk only – indicating ‘Support needed
- hide navigation buttons when there is only responses for one date
- de-bouncing window resize event call
- general report styling fixes

Example screenshot after fixes:

![Optout](https://github.com/uwcirg/truenth-portal/assets/12942714/be3775fb-1caf-4d67-9a33-207c74fb560b)
