### PR TITLE
Upgrade Celery

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ before_script:
 # test templates
 .test_template: &test_definition
   # track debian stable version of python3
-  image: python:3.7
+  image: python:3.9
   script: tox
   stage: test
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -25,6 +25,11 @@ snowballstemmer==2.0.0    # via sphinx
 sphinx-rtd-theme==0.5.1
 sphinx==3.3.1
 sphinxcontrib-websupport==1.1.2  # via sphinx
+sphinxcontrib-applehelp==1.0.4 # via sphinx
+sphinxcontrib-devhelp==1.0.2 # via sphinx
+sphinxcontrib-htmlhelp==2.0.1 # via sphinx
+sphinxcontrib-qthelp==1.0.3 # via sphinx
+sphinxcontrib-serializinghtml==1.1.5 # via sphinx
 tox==3.23.0
 typing==3.7.4.3             # via sphinx
 virtualenv==20.4.2        # via tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
 # base application dependencies
 
 alembic==1.4.3            # via flask-migrate
-amqp==2.5.2               # via kombu
 babel==2.9.0              # via flask-babel, sphinx
 bcrypt==3.2.0             # via flask-user
-billiard==3.6.3.0         # pyup: < 4.0  # pin until celery upgraded # via celery
 blinker==1.4              # via flask-mail, flask-webtest
-celery==4.3.0
 certifi==2019.9.11        # via requests
 cffi==1.14.6              # via bcrypt
 chardet==3.0.4            # via requests
@@ -38,7 +35,6 @@ itsdangerous==1.1.0        # via flask
 jinja2==2.11.3              # via flask, flask-babel, sphinx
 jsonschema==3.0.2
 json-logging==1.3.0
-kombu==4.6.6              # pyup: < 5.0 # via celery
 mako==1.1.0               # via alembic
 markupsafe==1.1.1           # via jinja2, mako
 oauthlib==2.1.0 # pyup: < 3.0.0  # pin until flask-oauthlib, flask-dance, requests-oauthlib upgraded
@@ -52,7 +48,7 @@ python-editor==1.0.4      # via alembic
 python-levenshtein==0.12.0
 python-memcached==1.59    # via flask-dogpile-cache
 python-statemachine==0.8.0	# via python-statemachine
-pytz==2020.5              # via babel, celery
+pytz==2020.5              # via babel
 pyyaml==5.4              # via flask-swagger, swagger-spec-validator
 redis==3.5.3
 requests-cache==0.5.2
@@ -63,6 +59,5 @@ sqlalchemy==1.3.11         # via alembic, flask-sqlalchemy
 swagger-spec-validator==2.7.3
 urllib3==1.26.5             # via requests
 validators==0.14.0 # pyup: <=0.10.1 # pin until require_tld supported again
-vine==1.3.0               # via amqp
 werkzeug==1.0.1           # via flask
 wtforms==2.2.1            # via flask-wtf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,30 @@
 # base application dependencies
 
 alembic==1.4.3            # via flask-migrate
+amqp==5.2.0
+    # via kombu
 babel==2.9.0              # via flask-babel, sphinx
 bcrypt==3.2.0             # via flask-user
+billiard==4.2.0
+    # via celery
 blinker==1.4              # via flask-mail, flask-webtest
+celery==5.3.1
+    # via portal (setup.py)
 certifi==2019.9.11        # via requests
 cffi==1.14.6              # via bcrypt
 chardet==3.0.4            # via requests
-click==7.1.2                # via flask
+click==8.1.7
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+click-didyoumean==0.3.1
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.3.0
+    # via celery
 coverage==5.4
 decorator==4.4.0          # via validators
 dogpile.cache==0.9.0      # via flask-sqlalchemy-caching
@@ -35,15 +52,20 @@ itsdangerous==1.1.0        # via flask
 jinja2==2.11.3              # via flask, flask-babel, sphinx
 jsonschema==3.0.2
 json-logging==1.3.0
+kombu==5.3.7
+    # via celery
 mako==1.1.0               # via alembic
 markupsafe==1.1.1           # via jinja2, mako
 oauthlib==2.1.0 # pyup: < 3.0.0  # pin until flask-oauthlib, flask-dance, requests-oauthlib upgraded
 onetimepass==1.0.1
 passlib==1.7.1            # via flask-user
 polib==1.1.1
+prompt-toolkit==3.0.47
+    # via click-repl
 pycparser==2.20           # via cffi
 pycryptodome==3.9.9       # via flask-user
-python-dateutil==2.8.0
+python-dateutil==2.9.0.post0
+    # via celery
 python-editor==1.0.4      # via alembic
 python-levenshtein==0.12.0
 python-memcached==1.59    # via flask-dogpile-cache
@@ -54,10 +76,22 @@ redis==3.5.3
 requests-cache==0.5.2
 requests-oauthlib==1.1.0  # pyup: <1.2.0 # pin until OAuthlib>=3.0.0 # via flask-oauthlib
 requests==2.25.1          # via flask-recaptcha, requests-cache, requests-oauthlib, sphinx
-six==1.14.0               # via bcrypt, packaging, python-dateutil, python-memcached, sphinx, swagger-spec-validator, tox, validators, webtest
+six==1.14.0
+    # via bcrypt, packaging, python-dateutil, python-memcached, sphinx, swagger-spec-validator, tox, validators, webtest
 sqlalchemy==1.3.11         # via alembic, flask-sqlalchemy
 swagger-spec-validator==2.7.3
+typing-extensions==4.12.2
+    # via kombu
+tzdata==2024.1
+    # via celery
 urllib3==1.26.5             # via requests
 validators==0.14.0 # pyup: <=0.10.1 # pin until require_tld supported again
+vine==5.1.0
+    # via
+    #   amqp
+    #   celery
+    #   kombu
+wcwidth==0.2.13
+    # via prompt-toolkit
 werkzeug==1.0.1           # via flask
 wtforms==2.2.1            # via flask-wtf

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ setup_requires =
 # concrete requirements belong in requirements.txt
 # https://caremad.io/posts/2013/07/setup-vs-requirement/
 install_requires =
+    celery
     enum34
     flask
     flask-babel

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ setup_requires =
 # concrete requirements belong in requirements.txt
 # https://caremad.io/posts/2013/07/setup-vs-requirement/
 install_requires =
-    celery
     enum34
     flask
     flask-babel

--- a/tox.ini
+++ b/tox.ini
@@ -76,9 +76,10 @@ commands =
     # Todo: migrate tests to fixtures
     sh -c ' \
         if [ "$CI" = true ]; then \
-            celery worker \
-                --detach \
+            celery \
                 --app portal.celery_worker.celery \
+            worker \
+                --detach \
                 --queues celery,low_priority \
                 --loglevel info ; \
         fi \


### PR DESCRIPTION
- Upgrade celery & dependencies to next major version
  - Modified `setup.cfg` and used `pip-compile` to generate a new set of dependencies
- Upgrade version of python used for testing to match container
