### PR TITLE
TN-3305 substudy clinician follow-up doesn't update adherence cache

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -593,7 +593,7 @@ def patient_research_study_status(
             rs_status['ready'] = True
 
         # Apply business rules specific to EMPRO
-        if rs == EMPRO_RS_ID:
+        if rs == EMPRO_RS_ID and 0 in results:
             if results[0]['ready']:
                 # Clear ready status when base has pending work
                 rs_status['ready'] = False

--- a/portal/models/questionnaire_response.py
+++ b/portal/models/questionnaire_response.py
@@ -31,7 +31,7 @@ from .questionnaire_bank import (
     trigger_date,
     visit_name,
 )
-from .research_study import research_study_id_from_questionnaire
+from .research_study import EMPRO_RS_ID, research_study_id_from_questionnaire
 from .reference import Reference
 from .user import User, current_user, patients_query
 from .user_consent import consent_withdrawal_dates
@@ -110,6 +110,7 @@ class QuestionnaireResponse(db.Model):
             # special case for the EMPRO Staff QB
             from ..trigger_states.empro_states import empro_staff_qbd_accessor
             qbd_accessor = empro_staff_qbd_accessor(self)
+            research_study_id = EMPRO_RS_ID
         elif qbd_accessor is None:
             from .qb_status import QB_Status  # avoid cycle
             if self.questionnaire_bank is not None:


### PR DESCRIPTION
the special case to handle assignment of questionnaire response to the trigger_state row (for the post EMPRO clinician follow-up QNR) failed to set the correct research study.  this resulted in missing updates on the adherence report after clinicians took action.