### PR TITLE
Update test dependency

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,7 +8,7 @@ flask-testing==0.8.1
 flask-webtest==0.0.9
 imagesize==1.1.0          # via sphinx
 mock==4.0.3
-packaging==19.2           # via sphinx, tox
+packaging>=22           # via sphinx, tox
 page-objects==1.1.0
 pluggy==0.13.1             # via tox
 # use pre-compiled binary for testing, build from source for prod

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -17,7 +17,7 @@ psycopg2-binary==2.8.6
 py==1.10.0                # via tox
 pygments==2.7.4           # via sphinx
 pyparsing==2.4.7          # via packaging
-pytest==5.2.2
+pytest==5.4.0
 pytest-flask==0.15.1
 pytest-timeout==1.4.2
 selenium==3.141.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -17,7 +17,7 @@ psycopg2-binary==2.8.6
 py==1.10.0                # via tox
 pygments==2.7.4           # via sphinx
 pyparsing==2.4.7          # via packaging
-pytest==5.4.0
+pytest >= 6.1.0
 pytest-flask==0.15.1
 pytest-timeout==1.4.2
 selenium==3.141.0


### PR DESCRIPTION
Workaround error during tests `TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'`