### PR TITLE
TN-3318 remove patient-list-export button for researchers

### DIFF
--- a/portal/templates/admin/patients_by_org.html
+++ b/portal/templates/admin/patients_by_org.html
@@ -32,6 +32,8 @@
           {{deletedUsersFilter()}}
         {% endif %}
       </div>
+      {# variable for checking if user is a researcher #}
+      {% set isResearcher = user.has_role(ROLE.RESEARCHER.value) and not(user.has_role(ROLE.ADMIN.value)) %}
       <table id="adminTable"
              data-table-id="adminTable"
              class="tnth-admin-table"
@@ -48,7 +50,7 @@
              data-unique-id="id"
              data-id-field="id"
              data-filter-control="true"
-             data-show-export="true"
+             {%- if not isResearcher -%} data-show-export="true" {%- endif -%}
              data-export-data-type="all"
              >
             {{testUsersCheckbox(postUrl=url_for('patients.patients_root'))}}

--- a/portal/templates/admin/patients_substudy.html
+++ b/portal/templates/admin/patients_substudy.html
@@ -33,6 +33,8 @@
             </form>
           </div>
       </div>
+      {# variable for checking if user is a researcher #}
+      {% set isResearcher = user.has_role(ROLE.RESEARCHER.value) and not(user.has_role(ROLE.ADMIN.value)) %}
       <table id="adminTable"
              data-table-id="adminTable"
              class="tnth-admin-table"
@@ -49,7 +51,7 @@
              data-unique-id="id"
              data-id-field="id"
              data-filter-control="true"
-             data-show-export="true"
+             {%- if not isResearcher -%} data-show-export="true" {%- endif -%}
              data-export-data-type="all"
              >
             {{testUsersCheckbox(postUrl=url_for('patients.patients_substudy'))}}


### PR DESCRIPTION
Address https://movember.atlassian.net/browse/TN-3318
remove patient list export button on the patient list page for users with Researcher role (note: the button will still be present for users that have Admin role and have Researcher role as well)

Screenshot for a non-admin user with Researcher role:
![Screenshot 2024-09-25 at 9 13 58 AM](https://github.com/user-attachments/assets/e8d7736c-0f51-4d25-ad8e-91286300581b)

Screenshot for a user without Researcher role:
![Screenshot 2024-09-25 at 9 15 06 AM](https://github.com/user-attachments/assets/ef5c601b-857f-4402-9b8c-53620393acac)


The patient list export button, 
![Screenshot 2024-09-25 at 9 27 39 AM](https://github.com/user-attachments/assets/e6fb5752-5c49-409f-bfc8-44a75748d272)
is removed for non-admin users with Researcher role
