### PR TITLE
TN-3319 extend wait time for adherence report export task

### DIFF
--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -342,6 +342,8 @@ import {EPROMS_MAIN_STUDY_ID, EPROMS_SUBSTUDY_ID} from "./data/common/consts.js"
                                     "error": true,
                                     "message": i18next.t("More than 5 minutes spent in pending status.")
                                 });
+                                //log error
+                                tnthAjax.reportError(self.userId, window.location.pathname, "Request to export report data failed. More than 5 minutes spent in pending status.");
                                 return;
                             }
                         }

--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -334,13 +334,13 @@ import {EPROMS_MAIN_STUDY_ID, EPROMS_SUBSTUDY_ID} from "./data/common/consts.js"
                         //check how long the status stays in pending
                         if (exportStatus === "PENDING") {
                             let passedTime = ((new Date()).getTime() - self.exportReportProgressTime.getTime()) / 1000;
-                            if (passedTime > 60) {
-                                //more than a minute passed and the task is still in PENDING status
+                            if (passedTime > 300) {
+                                //more than 5 minutes passed and the task is still in PENDING status
                                 //never advanced to PROGRESS to start the export process
                                 //abort
                                 self.onAfterExportReportData({
                                     "error": true,
-                                    "message": i18next.t("More than a minute spent in pending status.")
+                                    "message": i18next.t("More than 5 minutes spent in pending status.")
                                 });
                                 return;
                             }


### PR DESCRIPTION
https://movember.atlassian.net/browse/TN-3319?atlOrigin=eyJpIjoiOTYwODgxZDM5MTBhNGRkODhlNGViYTRhNDJiMjQwYzQiLCJwIjoiaiJ9

- increase wait time for celery task to start (progressing from PENDING status) from 1 minute to 5 minutes.
- log as error if waiting for more than 5 minutes.

screenshot for when 5 minutes have reached:
![Screenshot 2024-10-03 at 3 09 40 PM](https://github.com/user-attachments/assets/2e8b5f2d-6b0f-4d92-8ae8-6faa3c58dc17)
