### PR TITLE
Fixup/table preference

### DIFF
--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -1324,6 +1324,7 @@ let requestTimerId = 0;
         var tnthAjax = this.getDependency("tnthAjax");
         tableName = tableName || this.tableIdentifier;
         if (!tableName || !document.querySelector("#adminTable")) {
+          if (callback) callback();
           return false;
         }
         userId = userId || this.userId;

--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -1323,7 +1323,7 @@ let requestTimerId = 0;
       ) {
         var tnthAjax = this.getDependency("tnthAjax");
         tableName = tableName || this.tableIdentifier;
-        if (!tableName) {
+        if (!tableName || !document.querySelector("#adminTable")) {
           return false;
         }
         userId = userId || this.userId;

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -93,6 +93,16 @@ export default { /*global $ */
             $.ajax("/api/me").done(
                 function() {
                     console.log("user authorized");
+                    if ((typeof CsrfTokenChecker !== "undefined") && 
+                        !CsrfTokenChecker.checkTokenValidity()) {
+                        //if CSRF Token not valid, return error
+                        if (callback) {
+                            callback({"error": DEFAULT_SERVER_DATA_ERROR});
+                            fieldHelper.showError(targetField);
+                        }
+                        return;
+                    }
+                     
                     ajaxCall();
                 }
             ).fail(function() {

--- a/portal/templates/admin/admin_base.html
+++ b/portal/templates/admin/admin_base.html
@@ -93,6 +93,8 @@
     // custom ajax request here
     function patientDataAjaxRequest(params) {
 		loadIntervalId = setInterval(() => {
+			//document DOM not ready, don't make ajax call yet
+			if (!document.querySelector("#adminTable")) return;
 			if (typeof window.AdminObj === "undefined") return;
 			window.AdminObj.getRemotePatientListData(params);
 			clearInterval(loadIntervalId);


### PR DESCRIPTION
Address a stream of 400 errors (CSRF token is missing) related to saving patientlist table preferences.
Cause:
I think the error stemmed from when an ajax request was first made to retrieve patient data, which is precedes by a call to save table preferences, the document DOM was not ready (which includes the value of CSRF token in an hidden element) - hence the missing CSRF token error.
Fix:
To add check for DOM readiness before the request to save table preferences is made.