### PR TITLE
IRONN-242 update adherence cache on any patient demographics changes.

### DIFF
--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -34,6 +34,7 @@ from .role import ROLE, Role
 from .user import User, UserRoles, patients_query
 from .user_consent import consent_withdrawal_dates
 
+
 def update_patient_adherence_data(patient_id):
     """Cache invalidation and force rebuild for given patient's adherence data
 

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -43,7 +43,7 @@ def update_patient_adherence_data(patient_id):
     such as changing a user's study-id.
     """
     patient = User.query.get(patient_id)
-    AdherenceData.query.filter(AdherenceData.patient_id).delete()
+    AdherenceData.query.filter(AdherenceData.patient_id==patient_id).delete()
     for rs_id in ResearchStudy.assigned_to(patient):
         single_patient_adherence_data(patient_id=patient_id, research_study_id=rs_id)
 

--- a/portal/views/demographics.py
+++ b/portal/views/demographics.py
@@ -7,7 +7,9 @@ from ..audit import auditable_event
 from ..database import db
 from ..extensions import oauth
 from ..models.reference import MissingReference
+from ..models.reporting import update_patient_adherence_data
 from ..models.user import current_user, get_user
+from ..models.role import ROLE
 from .crossdomain import crossdomain
 
 demographics_api = Blueprint('demographics_api', __name__, url_prefix='/api')
@@ -176,7 +178,9 @@ def demographics_set(patient_id):
         patient_id, json.dumps(request.json)), user_id=current_user().id,
         subject_id=patient_id, context='user')
 
-    # update the patient_table cache with any change from above
-    patient_list_update_patient(patient_id)
+    # update the respective cache tables with any change from above
+    if patient.has_role(ROLE.PATIENT.value):
+        patient_list_update_patient(patient_id)
+        update_patient_adherence_data(patient_id)
 
     return jsonify(patient.as_fhir(include_empties=False))


### PR DESCRIPTION
Updates to a user's study-id via a PUT to /demographics would leave old adherence data rows with the old study-id.

We now force a recalculation of a user's adherence data when PUT /demographics is called.