### PR TITLE
real timeout org tree lock

### DIFF
--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -838,7 +838,7 @@ class OrgTree(object):
     def __init__(self):
         # Maintain a singleton root object and lookup_table
         try:
-            with TimeoutLock(key=ORG_TREE_LOCK_KEY, expires=300):
+            with TimeoutLock(key=ORG_TREE_LOCK_KEY, expires=300, timeout=300):
                 if not OrgTree.root:
                     self.__reset_cache()
         except LockTimeout:


### PR DESCRIPTION
Hotfix:

Found a significant number of timeout exceptions raised looking to acquire the OrgTree-LOCK (used by any process needing to build the in-memory organization tree on first request).

The default timeout of 10 seconds is clearly inadequate.  Increasing to same value (300 or 5 mins) used for the expiration of this lock (to catch any hung processes holding on to the lock).