### PR TITLE
TN-3331 prevent staff users from sending bogus reminder emails

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2082,7 +2082,8 @@ export default (function() {
                             resetBtn(true);
                         });
                     }).fail(function(xhr) { //report error
-                        self.messages.userInviteEmailErrorMessage = i18next.t("Error occurred retreving email content via API.");
+                        const message = `${i18next.t("Error occurred retreving email content via API.")} ${xhr && xhr.responseText ? xhr.responseText: ""}`;
+                        self.messages.userInviteEmailErrorMessage = message;
                         resetBtn();
                         self.modules.tnthAjax.reportError(self.subjectId, emailUrl, xhr.responseText);
                     });

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -267,6 +267,24 @@ body {
     min-height: 8px;
   }
 }
+.clamped-container {
+  font-size: 1em;
+  display: block; /* Fallback for non-webkit */
+  display: -webkit-box;
+  height: 8.4em;
+  line-height: 1.4em;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  h1,h2,h3,h4,h5,h6 {
+    display: none;
+  }
+  &:empty {
+    height: 0;
+    -webkit-line-clamp: 0;
+  }
+}
 #fillOrgs.org-tree {
   flex-direction: row;
 }

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -308,7 +308,7 @@
         <div id="profile{{prefix}}EmailBtnMsgWrapper" class="profilePatientEmail__btn-msg-wrapper tnth-hide">
             <div id="profile{{prefix}}EmailLoadingIndicator" v-show="patientEmailForm.loading"><i class="fa fa-spinner fa-spin fa-2x"></i></div>
             <div id="profile{{prefix}}EmailMessage" class="send-email-info text-info" v-html="messages.userInviteEmailInfoMessage"></div>
-            <div id="profile{{prefix}}EmailErrorMessage" class="send-email-info text-danger" v-html="messages.userInviteEmailErrorMessage"></div>
+            <div id="profile{{prefix}}EmailErrorMessage" class="send-email-info text-danger clamped-container" v-html="messages.userInviteEmailErrorMessage"></div>
         </div>
         {{emailReadyMessage()}}
     </div>

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -772,7 +772,7 @@ def patient_reminder_email(user_id):
             as_of_date=datetime.utcnow())
         if qstats.overall_status not in (
                 OverallStatus.due, OverallStatus.overdue, OverallStatus.in_progress):
-            raise BadRequest('No questionnaires available for patient to complete')
+            raise BadRequest(_('No questionnaire is due.'))
 
         qbd = qstats.current_qbd()
         if qbd:

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -32,6 +32,7 @@ from flask_user import roles_required
 from flask_wtf import FlaskForm
 from sqlalchemy import and_
 from sqlalchemy.orm.exc import NoResultFound
+from werkzeug.exceptions import BadRequest
 from wtforms import (
     BooleanField,
     HiddenField,
@@ -70,6 +71,7 @@ from ..models.organization import (
     OrgTree,
     UserOrganization,
 )
+from ..models.overall_status import OverallStatus
 from ..models.research_study import EMPRO_RS_ID, ResearchStudy
 from ..models.role import ALL_BUT_WRITE_ONLY, ROLE
 from ..models.table_preference import TablePreference
@@ -749,6 +751,7 @@ def patient_reminder_email(user_id):
     Query string
     :param research_study_id: set for targeted reminder emails, defaults to 0
 
+    :raises BadRequest: if the patient isn't currently eligible for reminder
     """
     from ..models.qb_status import QB_Status
     user = get_user(user_id, 'edit')
@@ -767,6 +770,10 @@ def patient_reminder_email(user_id):
             user,
             research_study_id=research_study_id,
             as_of_date=datetime.utcnow())
+        if qstats.overall_status not in (
+                OverallStatus.due, OverallStatus.overdue, OverallStatus.in_progress):
+            raise BadRequest('No questionnaires available for patient to complete')
+
         qbd = qstats.current_qbd()
         if qbd:
             qb_id, qb_iteration = qbd.qb_id, qbd.iteration

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -751,7 +751,7 @@ def patient_reminder_email(user_id):
     Query string
     :param research_study_id: set for targeted reminder emails, defaults to 0
 
-    :raises BadRequest: if the patient isn't currently eligible for reminder
+    :raises werkzeug.exceptions.BadRequest: if the patient isn't currently eligible for reminder
     """
     from ..models.qb_status import QB_Status
     user = get_user(user_id, 'edit')


### PR DESCRIPTION
TN-3331 describes symptoms as we didn't previously confirm a reminder email was appropriate to send, if requested by staff.

No longer generating email content, or sending email, unless the user has outstanding work, when the user (staff) requests to send a reminder email.