### PR TITLE
upgrade python-levenshtein as old version was yanked.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ pycryptodome==3.9.9       # via flask-user
 python-dateutil==2.9.0.post0
     # via celery
 python-editor==1.0.4      # via alembic
-python-levenshtein==0.27.1
+python-levenshtein==0.12.1
 python-memcached==1.59    # via flask-dogpile-cache
 python-statemachine==0.8.0	# via python-statemachine
 pytz==2020.5              # via babel

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,7 +67,7 @@ pycryptodome==3.9.9       # via flask-user
 python-dateutil==2.9.0.post0
     # via celery
 python-editor==1.0.4      # via alembic
-python-levenshtein==0.12.0
+python-levenshtein==0.27.1
 python-memcached==1.59    # via flask-dogpile-cache
 python-statemachine==0.8.0	# via python-statemachine
 pytz==2020.5              # via babel

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ scripts =
 zip_safe = False
 include_package_data = True
 setup_requires =
-    setuptools_scm
+    setuptools_scm==7.1.0
 
 # abstract requirements;
 # concrete requirements belong in requirements.txt


### PR DESCRIPTION
Build artifact errors depending on yanked version of `python-levenshtein`.  Attempt to upgrade to latest.

Error seen in CI build log:
```
#20 87.47 WARNING: The candidate selected for download or install is a yanked version: 'python-levenshtein' candidate (version 0.12.0 at https://files.pythonhosted.org/packages/42/a9/d1785c85ebf9b7dfacd08938dd028209c34a0ea3b1bcdb895208bd40a67d/python-Levenshtein-0.12.0.tar.gz#sha256=033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1 (from https://pypi.org/simple/python-levenshtein/))
#20 87.47 Reason for being yanked: Insecure, upgrade to 0.12.1
```