### PR TITLE
IRONN-285 add clinician role for accessing patients/page page

### DIFF
--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -140,6 +140,7 @@ def sort_query(query, sort_column, direction):
 
 @patients.route("/page", methods=["GET"])
 @roles_required([
+    ROLE.CLINICIAN.value,
     ROLE.INTERVENTION_STAFF.value,
     ROLE.STAFF.value,
     ROLE.STAFF_ADMIN.value])


### PR DESCRIPTION
address https://movember.atlassian.net/browse/IRONN-285?atlOrigin=eyJpIjoiMzI0NjQxMWI1ZmNmNDQ5Nzg5NjZlNTVjNGMxYTY3ZDciLCJwIjoiaiJ9&linkSource=email

- allow user with Clinician role only to access the `patients/page` page (this is the API endpoint that the frontend hits to retrieve records for each page of the patients list)