### PR TITLE
TN-3342 exclude deleted patients from patient lists.

### DIFF
--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -205,6 +205,7 @@ def page_of_patients():
 
     viewable_orgs = requested_orgs(user, research_study_id)
     query = PatientList.query.filter(PatientList.org_id.in_(viewable_orgs))
+    query = query.filter(PatientList.deleted==False)
     if research_study_id == EMPRO_RS_ID:
         # only include those in the study.  use empro_consentdate as a quick check
         query = query.filter(PatientList.empro_consentdate.isnot(None))


### PR DESCRIPTION
As a hotfix, do not include deleted patients in the patient lists, at both /patients and /patients/substudy

Fix for [TN-3342](https://movember.atlassian.net/browse/TN-3342)