### PR TITLE
Feature/audit log resource library

### DIFF
--- a/portal/eproms_substudy_tailored_content/src/js/Base.js
+++ b/portal/eproms_substudy_tailored_content/src/js/Base.js
@@ -436,9 +436,6 @@ export default {
                     .then(() => {
                         // DOM updated
                         this.onDomainContentDidLoad();
-                        if (this.isAtMainPage(this.getSelectedDomain())) {
-                            return;
-                        }
                         //log accessed content domain url 
                         postData("/api/auditlog", {
                             "message": "GET " + window.location.pathname + window.location.hash,

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -140,6 +140,7 @@ def sort_query(query, sort_column, direction):
 
 @patients.route("/page", methods=["GET"])
 @roles_required([
+    ROLE.CLINICIAN.value,
     ROLE.INTERVENTION_STAFF.value,
     ROLE.STAFF.value,
     ROLE.STAFF_ADMIN.value])


### PR DESCRIPTION
see [Slack convo](https://cirg.slack.com/archives/C5MH9NVKQ/p1746488646164559?thread_ts=1746209750.440009&cid=C5MH9NVKQ)

**Issue**:
currently, any access to a specific EMPRO domain content page is logged to the audit log  but not when the main resource library page is accessed.

**Fix**:
remove code that exits before adding audit entry for resource library main page.

<img width="481" alt="Screenshot 2025-05-05 at 5 28 10 PM" src="https://github.com/user-attachments/assets/955dcfc3-3816-4a2b-b247-5e69ab133b56" />
