### PR TITLE
disable search on patient list

### DIFF
--- a/portal/templates/admin/patients_by_org.html
+++ b/portal/templates/admin/patients_by_org.html
@@ -29,7 +29,7 @@
              class="tnth-admin-table"
              data-classes="table table-hover table-condensed table-striped table-responsive"
              data-toggle="table"
-             data-search="true"
+             data-search="false"
              data-pagination="true"
              data-page-size="10"
              data-page-list="[10, 20, 30]"


### PR DESCRIPTION
Remove search box from patient list as it is currently not functional.
Per Slack [convo](https://cirg.slack.com/archives/C5TVC8KQE/p1746730199065269)

story: https://movember.atlassian.net/browse/TN-3345?focusedCommentId=334852

Verified in my own instance that search box is now gone:
![Screenshot 2025-05-08 at 1 18 21 PM](https://github.com/user-attachments/assets/d6b77df2-f655-4ef6-985d-2ef728309d5e)
