### PR TITLE
QuestionnaireBank IDs not consistent on test vs. prod.

### DIFF
--- a/portal/trigger_states/adherence_cache_validation.py
+++ b/portal/trigger_states/adherence_cache_validation.py
@@ -105,7 +105,7 @@ class CombinedData:
             if ad is None and ts is None:
                 continue
             if ad and not ts:
-                if ad in ('Due', 'Expired', 'Overdue'):
+                if ad in ('Due', 'Expired', 'Overdue', 'Not Yet Available'):
                     # trigger states often never started w/o user intervention
                     continue
                 if ad == 'Withdrawn':


### PR DESCRIPTION
Patch for PR #4443 - hardcoded ID for baseline_ss questionnaire bank didn't work on eproms.test.  Look up the value.