### PR TITLE
Add frontend handling of  auth/csrf token errors in request

### DIFF
--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -74,6 +74,20 @@ export default { /*global $ */
                                 callback({"error": DEFAULT_SERVER_DATA_ERROR, "data": false});
                             }
                         }).fail(function(xhr) {
+                            // catch auth error, e.g. unaunthorized or stale CSRF session token error before re-trying
+                            const doomedStatus = parseInt(xhr.status) === 400 || parseInt(xhr.status) === 401;
+                            const xhrResponseText = xhr.responseText ? String(xhr.responseText).toLowerCase() : "";
+                            if (
+                              doomedStatus &&
+                              (xhrResponseText.includes("csrf token") ||
+                                xhrResponseText.includes("unauthorize"))
+                            ) {
+                              if (callback) {
+                                callback({ error: DEFAULT_SERVER_DATA_ERROR });
+                                fieldHelper.showError(targetField);
+                              }
+                              return false;
+                            }
                             if (params.attempts < params.max_attempts) {
                                 (function(self, url, method, userId, params, callback) {
                                     setTimeout(function () {

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -82,6 +82,7 @@ export default { /*global $ */
                               (xhrResponseText.includes("csrf token") ||
                                 xhrResponseText.includes("unauthorize"))
                             ) {
+                              console.log("Request error ", xhrResponseText);
                               if (callback) {
                                 callback({ error: DEFAULT_SERVER_DATA_ERROR });
                                 fieldHelper.showError(targetField);


### PR DESCRIPTION
see [Slack convo](https://cirg.slack.com/archives/C5EU4L7PF/p1753460068004999)
- catch unauthorized or CSRF token related error before re-attempting an ajax request