### PR TITLE
fix request retry logic related to setting table preferences

### DIFF
--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -66,6 +66,8 @@ let requestTimerId = 0;
     },
     mixins: [CurrentUser],
     data: {
+      suppressColumnSwitch: false,
+      savePrefTimerId: 0,
       dataError: false,
       configured: false,
       initIntervalId: 0,
@@ -143,7 +145,7 @@ let requestTimerId = 0;
           errorElement.innerHTML = errorMessage;
         }
       },
-      clearError: function() {
+      clearError: function () {
         var errorElement = document.getElementById("admin-table-error-message");
         if (errorElement) {
           errorElement.innerHTML = "";
@@ -191,6 +193,7 @@ let requestTimerId = 0;
       getRemotePatientListData: function (params) {
         if (this.accessed) {
           var self = this;
+          this.accessed = true;
           this.setTablePreference(
             this.userId,
             this.tableIdentifier,
@@ -220,20 +223,20 @@ let requestTimerId = 0;
         console.log("param data ? ", params.data);
         var url = "/patients/page";
         var self = this;
-        $.get(url + "?" + $.param(params.data)).then(function (results) {
-          console.log("row results ", results);
-          if (!self.accessed && results && results.options) {
-            self.filterOptionsList = results.options;
-          }
-          self.accessed = true;
-          params.success(results);
-        }).fail(function(xhr, status) {
-          console.log("Error ", xhr);
-          console.log("status", status);
-          self.setError("Error occurred loading data.");
-          params.success([]);
-          self.accessed = true;
-        });
+        $.get(url + "?" + $.param(params.data))
+          .then(function (results) {
+            console.log("row results ", results);
+            if (!self.accessed && results && results.options) {
+              self.filterOptionsList = results.options;
+            }
+            params.success(results);
+          })
+          .fail(function (xhr, status) {
+            console.log("Error ", xhr);
+            console.log("status", status);
+            self.setError("Error occurred loading data.");
+            params.success([]);
+          });
       },
       handleCurrentUser: function () {
         var self = this;
@@ -744,7 +747,8 @@ let requestTimerId = 0;
         });
         if (this.sortFilterEnabled) {
           $("#adminTable").on("column-switch.bs.table", function () {
-            self.setTablePreference(self.userId);
+            if (this.suppressColumnSwitch) return; // ← guard
+            self.debouncedSaveTablePreference();
           });
         }
         $("#adminTableToolbar .orgs-filter-warning").popover();
@@ -1197,24 +1201,8 @@ let requestTimerId = 0;
         this.clearFilterButtons();
       },
       onOrgListSelectFilter: function () {
-        this.setTablePreference(
-          this.userId,
-          this.tableIdentifier,
-          null,
-          null,
-          null,
-          function () {
-            // callback from setting the filter preference
-            // this ensures that the table filter preference is saved before reloading the page
-            // so the backend can present patient list based on that saved preference
-            setTimeout(
-              function () {
-                $("#adminTable").bootstrapTable("refresh");
-              }.bind(this),
-              350
-            );
-          }.bind(this)
-        );
+        this.debouncedSaveTablePreference();
+        setTimeout(() => { $("#adminTable").bootstrapTable("refresh"); }, 350);
       },
       getDefaultTablePreference: function () {
         return {
@@ -1267,23 +1255,22 @@ let requestTimerId = 0;
         if (!this.sortFilterEnabled) {
           return false;
         }
-        var prefData = this.getTablePreference(
+        const prefData = this.getTablePreference(
           this.userId,
           this.tableIdentifier
         );
-        var hasColumnSelections =
+        const hasColumnSelections =
           prefData && prefData.filters && prefData.filters.column_selections;
         if (!hasColumnSelections) {
           return false;
         }
+        this.suppressColumnSwitch = true;
         var visibleColumns =
           $("#adminTable").bootstrapTable("getVisibleColumns");
         visibleColumns.forEach(function (c) {
-          //hide visible columns
-          if (String(c.class).toLowerCase() === "always-visible") {
-            return true;
+          if (String(c.class).toLowerCase() !== "always-visible") {
+            $("#adminTable").bootstrapTable("hideColumn", c.field);
           }
-          $("#adminTable").bootstrapTable("hideColumn", c.field);
         });
         prefData.filters.column_selections.forEach(function (column) {
           //show column(s) based on preference
@@ -1294,6 +1281,10 @@ let requestTimerId = 0;
           ).prop("checked", true);
           $("#adminTable").bootstrapTable("showColumn", column);
         });
+        // Give Bootstrap Table a tick to settle before re-enabling
+        setTimeout(() => {
+          this.suppressColumnSwitch = false;
+        }, 0);
       },
       setTableFilters: function (userId) {
         var prefData = this.currentTablePreference,
@@ -1329,6 +1320,19 @@ let requestTimerId = 0;
             }
           }
         }
+      },
+      preferencesEqual: (a, b) => {
+        try {
+          return JSON.stringify(a) === JSON.stringify(b);
+        } catch {
+          return false;
+        }
+      },
+      debouncedSaveTablePreference: function () {
+        clearTimeout(this.savePrefTimerId);
+        this.savePrefTimerId = setTimeout(() => {
+          this.setTablePreference(this.userId);
+        }, 300);
       },
       setTablePreference: function (
         userId,
@@ -1401,6 +1405,14 @@ let requestTimerId = 0;
           __filters["column_selections"].push($(this).attr("data-field"));
         });
         data["filters"] = __filters;
+
+        if (
+          this.currentTablePreference &&
+          this.preferencesEqual(this.currentTablePreference, data)
+        ) {
+          if (callback) callback(); // nothing changed, skip network call
+          return;
+        }
 
         if (Object.keys(data).length > 0) {
           var self = this;

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -151,10 +151,14 @@ export default { /*global $ */
             // avoid stacking multiple timers
             clearChainTimer();
             console.log(`[tnthAjax] ${methodUpper} ${url} try ${params.__state.sent+1}/${params.__state.max}`);
+            // https://www.pullrequest.com/blog/retrying-and-exponential-backoff-smart-strategies-for-robust-software/
+            const backoff = REQUEST_TIMEOUT_INTERVAL * Math.pow(2, Math.max(0, params.__state.sent - 1));
+            const jitter = Math.floor(Math.random() * 400);
+            const delay = Math.min(backoff + jitter, 30000);
             params.__state.chainTimerId = setTimeout(() => {
                 if (params.__state.terminated) return;    // stale timer guard
                 attempt();  
-            }, REQUEST_TIMEOUT_INTERVAL);
+            }, delay);
         }
 
         var methodLower = methodUpper.toLowerCase();
@@ -244,9 +248,9 @@ export default { /*global $ */
             if (!canSend() || params.__state.terminated) return;    // safety
             handleAuthThen(() => {
                 if (params.useWorker && window.Worker && !Utility.isTouchDevice()) {
-                sendWithWorker();
+                    sendWithWorker();
                 } else {
-                sendWithAjax();
+                    sendWithAjax();
                 }
             });
         };

--- a/portal/static/js/src/modules/TnthAjax.js
+++ b/portal/static/js/src/modules/TnthAjax.js
@@ -117,7 +117,7 @@ export default { /*global $ */
         };
 
         const canSend = () => {
-            return params.__state.sent < params.__state.max;
+            return params.__state.sent <= params.__state.max;
         }
         const markSent = () => {
             params.__state.sent += 1;

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -3153,8 +3153,6 @@ export default (function() {
                     if (errorMessage) {
                         $("#profileAuditLogTable").html("");
                         $("#profileAuditLogErrorMessage").text(errorMessage);
-                        //report error if loading audit log results in error
-                        self.modules.tnthAjax.reportError(self.subjectId, "/api/user/" + self.subjectId + "/audit", errorMessage);
                         return false;
                     }
                     var ww = $(window).width(), fData = [], len = ((ww < 650) ? 20 : (ww < 800 ? 40 : 80)), errorMessage="";


### PR DESCRIPTION
Fixes in response to several (hundreds) request errors seen in email:
`Received error {'actor': 'user 9179',_ 'message': 'Error generated in JS - [Error occurred processing request]  '_            'status - request timed out/network error, response text - no '_            'response text returned from server [data sent]: '_            '{type:PUT,url:/api/user/9179/table_preferences/patientList,attempts:1,max_attempts:1,contentType:application/json; '_            'charset=utf-8,dataType:json,sync:false,timeout:5000,data:{\\\\sort_field\\\\:\\\\lastname\\\\,\\\\sort_order\\\\:\\\\asc\\\\,\\\\filters\\\\:{\\\\questionnaire_status\\\\:\\\\Overdue\\\\,\\\\visit\\\\:\\\\Baseline\\\\,\\\\orgs_filter_control\\\\:[14644],\\\\column_selections\\\\:[\\\\userid\\\\,\\\\firstname\\\\,\\\\lastname\\\\,\\\\birthdate\\\\,\\\\email\\\\,\\\\questionnaire_status\\\\,\\\\visit\\\\,\\\\study_id\\\\,\\\\consentdate\\\\,\\\\org_name\\\\]}},useWorker:false,async:true,checkAuth:true,headers:{cache-control:no-cache, '_            'must-revalidate, private,expires:-1,p
 ragma:no-cache}}',_ 'page_url': '/api/user/9179/table_preferences/patientList',_ 'subject_id': '9179'}`

Possible cause:
The retry logic to cap re-try attempts may be failing

Fixes:
 - add tracking for each request to stop overlap - De-dupe & serialize attempts per request key
 - store attempts in internal state so they aren't lost on retry
 - always clear attempt state on request success or failure
 - add guard to prevent recursive saving of table preferences on column switching
 - only save table preferences when changed (and debounce it)
 
 Other changes:
- breaking up `sendRequest` code in `tnthAjax.js` into smaller helper functions for better management
- remove unnecessary sendErrorReport call in `profile.js` as it is already handled by `sendRequest`